### PR TITLE
[media-libs/phonon*] Add qt5 support to 9999 ebuilds

### DIFF
--- a/media-libs/phonon-gstreamer/metadata.xml
+++ b/media-libs/phonon-gstreamer/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>kde</herd>
+<use>
+	<flag name="network">Support http clients</flag>
+</use>
+</pkgmetadata>

--- a/media-libs/phonon-gstreamer/phonon-gstreamer-9999.ebuild
+++ b/media-libs/phonon-gstreamer/phonon-gstreamer-9999.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+[[ ${PV} == *9999 ]] && git_eclass="git-2"
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+
+MY_PN="phonon-backend-gstreamer"
+MY_P=${MY_PN}-${PV}
+
+inherit cmake-utils multibuild ${git_eclass}
+
+DESCRIPTION="Phonon GStreamer backend"
+HOMEPAGE="https://projects.kde.org/projects/kdesupport/phonon/phonon-gstreamer"
+[[ ${PV} == *9999 ]] || SRC_URI="mirror://kde/stable/phonon/${MY_PN}/${PV}/src/${MY_P}.tar.xz"
+
+LICENSE="LGPL-2.1"
+if [[ ${PV} == *9999 ]]; then
+	KEYWORDS=""
+else
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-fbsd ~x86-fbsd ~x64-macos"
+fi
+SLOT="0"
+IUSE="alsa debug +network +qt4 qt5"
+REQUIRED_USE="|| ( qt4 qt5 )"
+
+RDEPEND="
+	media-libs/gstreamer:0.10
+	media-plugins/gst-plugins-meta:0.10[alsa?,ogg,vorbis]
+	>=media-libs/phonon-4.6.0
+	qt4? (
+		>=dev-qt/qtcore-4.6.0:4[glib]
+		>=dev-qt/qtgui-4.6.0:4[glib]
+		>=dev-qt/qtopengl-4.6.0:4
+	)
+	qt5? (
+		>=dev-qt/qtcore-5.0.0:5[glib]
+		>=dev-qt/qtgui-5.0.0:5[glib]
+		>=dev-qt/qtopengl-5.0.0:5
+	)
+	virtual/opengl
+	network? ( media-plugins/gst-plugins-soup:0.10 )
+"
+DEPEND="${RDEPEND}
+	qt4? ( >=dev-util/automoc-0.9.87 )
+	virtual/pkgconfig
+"
+
+S="${WORKDIR}/${MY_P}"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=()
+	if use qt4; then
+		MULTIBUILD_VARIANTS+=(qt4)
+	fi
+	if use qt5; then
+		MULTIBUILD_VARIANTS+=(qt5)
+	fi
+}
+
+src_configure() {
+	myconfigure() {
+		local mycmakeargs=()
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=OFF)
+		fi
+		if [[ ${MULTIBUILD_VARIANT} = qt5 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=ON)
+		fi
+		cmake-utils_src_configure
+	}
+
+	multibuild_foreach_variant myconfigure
+}
+
+src_compile() {
+	multibuild_foreach_variant cmake-utils_src_compile
+}
+
+src_install() {
+	multibuild_foreach_variant cmake-utils_src_install
+}
+
+src_test() {
+	multibuild_foreach_variant cmake-utils_src_test
+}

--- a/media-libs/phonon-vlc/metadata.xml
+++ b/media-libs/phonon-vlc/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>kde</herd>
+</pkgmetadata>

--- a/media-libs/phonon-vlc/phonon-vlc-9999.ebuild
+++ b/media-libs/phonon-vlc/phonon-vlc-9999.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+MY_PN="phonon-backend-vlc"
+MY_P="${MY_PN}-${PV}"
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+[[ ${PV} == 9999 ]] && git_eclass=git-2
+inherit cmake-utils multibuild ${git_eclass}
+unset git_eclass
+
+DESCRIPTION="Phonon VLC backend"
+HOMEPAGE="https://projects.kde.org/projects/kdesupport/phonon/phonon-vlc"
+[[ ${PV} == 9999 ]] || SRC_URI="mirror://kde/stable/phonon/${MY_PN}/${PV}/${MY_P}.tar.xz"
+
+LICENSE="LGPL-2.1"
+
+# Don't move KEYWORDS on the previous line or ekeyword won't work # 399061
+[[ ${PV} == 9999 ]] || \
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-fbsd"
+
+SLOT="0"
+IUSE="debug +qt4 qt5"
+REQUIRED_USE="|| ( qt4 qt5 )"
+
+RDEPEND="
+	=media-libs/phonon-9999[qt4=,qt5=]
+	>=media-video/vlc-2.0.1[dbus,ogg,vorbis]
+	qt4? (
+		>=dev-qt/qtcore-4.6.0:4
+		>=dev-qt/qtdbus-4.6.0:4
+		>=dev-qt/qtgui-4.6.0:4
+	)
+	qt5? (
+		>=dev-qt/qtcore-5.0.0:5
+		>=dev-qt/qtdbus-5.0.0:5
+		>=dev-qt/qtgui-5.0.0:5
+	)
+"
+DEPEND="${RDEPEND}
+	app-arch/xz-utils
+	qt4? ( >=dev-util/automoc-0.9.87 )
+	virtual/pkgconfig
+"
+
+S=${WORKDIR}/${MY_P}
+
+DOCS=( AUTHORS )
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=()
+	if use qt4; then
+		MULTIBUILD_VARIANTS+=(qt4)
+	fi
+	if use qt5; then
+		MULTIBUILD_VARIANTS+=(qt5)
+	fi
+}
+
+src_configure() {
+	myconfigure() {
+		local mycmakeargs=()
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=OFF)
+		fi
+		if [[ ${MULTIBUILD_VARIANT} = qt5 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=ON)
+		fi
+		cmake-utils_src_configure
+	}
+
+	multibuild_foreach_variant myconfigure
+}
+
+src_compile() {
+	multibuild_foreach_variant cmake-utils_src_compile
+}
+
+src_install() {
+	multibuild_foreach_variant cmake-utils_src_install
+}
+
+src_test() {
+	multibuild_foreach_variant cmake-utils_src_test
+}
+
+pkg_postinst() {
+	elog "For more verbose debug information, export the following variables:"
+	elog "PHONON_DEBUG=1"
+	elog ""
+	elog "To make KDE detect the new backend without reboot, run:"
+	elog "kbuildsycoca4 --noincremental"
+}

--- a/media-libs/phonon/phonon-9999.ebuild
+++ b/media-libs/phonon/phonon-9999.ebuild
@@ -1,6 +1,6 @@
 # Copyright 1999-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
+# $Header: /var/cvsroot/gentoo-x86/media-libs/phonon/phonon-9999.ebuild,v 1.19 2013/05/10 17:39:09 kensington Exp $
 
 EAPI=5
 
@@ -13,21 +13,31 @@ else
 	KEYWORDS=""
 fi
 
-inherit cmake-utils ${SCM_ECLASS}
+inherit cmake-utils multibuild ${SCM_ECLASS}
 
 DESCRIPTION="KDE multimedia API"
 HOMEPAGE="https://projects.kde.org/projects/kdesupport/phonon"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="aqua debug +gstreamer pulseaudio vlc zeitgeist"
+IUSE="aqua debug +gstreamer pulseaudio +qt4 qt5 vlc zeitgeist"
 
 COMMON_DEPEND="
 	!!dev-qt/qtphonon:4
-	>=dev-qt/qtcore-4.6.0:4
-	>=dev-qt/qtdbus-4.6.0:4
-	>=dev-qt/qtgui-4.6.0:4
-	>=dev-qt/qttest-4.6.0:4
+	qt4? (
+		>=dev-qt/qtcore-4.6.0:4
+		>=dev-qt/qtdbus-4.6.0:4
+		>=dev-qt/qtgui-4.6.0:4
+		>=dev-qt/qttest-4.6.0:4
+	)
+	qt5? (
+		>=dev-qt/qtcore-5.0.0:5
+		>=dev-qt/qtdbus-5.0.0:5
+		>=dev-qt/qtdeclarative-5.0.0:5
+		>=dev-qt/qtgui-5.0.0:5
+		>=dev-qt/qtopengl-5.0.0:5
+		>=dev-qt/qttest-5.0.0:5
+	)
 	pulseaudio? (
 		dev-libs/glib:2
 		>=media-sound/pulseaudio-0.9.21[glib]
@@ -40,21 +50,63 @@ COMMON_DEPEND="
 # waveout? ( media-sound/phonon-waveout )
 PDEPEND="
 	aqua? ( media-libs/phonon-qt7 )
-	gstreamer? ( media-libs/phonon-gstreamer )
-	vlc? ( >=media-libs/phonon-vlc-0.3.2 )
+	gstreamer? (
+		|| ( <media-libs/phonon-gstreamer-9999 =media-libs/phonon-gstreamer-9999[qt4=,qt5=] )
+		qt5? ( =media-libs/phonon-gstreamer-9999[qt5] )
+	)
+	vlc? (
+		|| ( ( >=media-libs/phonon-vlc-0.3.2 <media-libs/phonon-vlc-9999 ) =media-libs/phonon-vlc-9999[qt4=,qt5=] )
+		qt5? ( =media-libs/phonon-vlc-9999[qt5] )
+	)
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
-	>=dev-util/automoc-0.9.87
+	qt4? ( >=dev-util/automoc-0.9.87 )
 	virtual/pkgconfig
 "
 
-REQUIRED_USE="|| ( aqua gstreamer vlc )"
+REQUIRED_USE="
+	|| ( aqua gstreamer vlc )
+	|| ( qt4 qt5 )
+	zeitgeist? ( qt4 )
+"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=()
+	if use qt4; then
+		MULTIBUILD_VARIANTS+=(qt4)
+	fi
+	if use qt5; then
+		MULTIBUILD_VARIANTS+=(qt5)
+	fi
+}
 
 src_configure() {
-	local mycmakeargs=(
-		$(cmake-utils_use_with pulseaudio GLIB2)
-		$(cmake-utils_use_with pulseaudio PulseAudio)
-	)
-	cmake-utils_src_configure
+	myconfigure() {
+		local mycmakeargs=(
+			$(cmake-utils_use_with pulseaudio GLIB2)
+			$(cmake-utils_use_with pulseaudio PulseAudio)
+		)
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=OFF)
+		fi
+		if [[ ${MULTIBUILD_VARIANT} = qt5 ]]; then
+			mycmakeargs+=(-DPHONON_BUILD_PHONON4QT5=ON)
+		fi
+		cmake-utils_src_configure
+	}
+
+	multibuild_foreach_variant myconfigure
+}
+
+src_compile() {
+	multibuild_foreach_variant cmake-utils_src_compile
+}
+
+src_install() {
+	multibuild_foreach_variant cmake-utils_src_install
+}
+
+src_test() {
+	multibuild_foreach_variant cmake-utils_src_test
 }


### PR DESCRIPTION
Add support to simultaneously install phonon 4 for Qt4 and Qt5. In contrast to other projects Phonon supports to be installed with both Qt versions on the same system.
