### PR TITLE
[net-im/ktp-common-internals] Add requirement for kdepimlibs

### DIFF
--- a/net-im/ktp-common-internals/ktp-common-internals-9999.ebuild
+++ b/net-im/ktp-common-internals/ktp-common-internals-9999.ebuild
@@ -24,6 +24,7 @@ IUSE="debug"
 
 DEPEND="
 	net-libs/libkpeople
+	kde-base/kdepimlibs:4
 	>=net-libs/telepathy-qt-0.9.3
 	>=net-libs/telepathy-logger-qt-0.5.80
 "


### PR DESCRIPTION
Failing build without kdepimlibs: https://gist.github.com/xhochy/3601266e91736393eda0

Package-Manager: portage-2.2.7
