### PR TITLE
[kde-base/kdepim-runtime] doesn't need strigi any more

### DIFF
--- a/kde-base/kdepim-runtime/kdepim-runtime-9999.ebuild
+++ b/kde-base/kdepim-runtime/kdepim-runtime-9999.ebuild
@@ -15,7 +15,6 @@ RESTRICT="test"
 # Would need test programs _testrunner and akonaditest from kdepimlibs, see bug 313233
 
 DEPEND="
-	app-misc/strigi
 	>=app-office/akonadi-server-1.10.43
 	dev-libs/boost:=
 	dev-libs/libxml2:2


### PR DESCRIPTION
AFAICS, kdepim-runtime doesn't need strigi any more.  At least not in building time.
