### PR TITLE
[kde-base/kinfocenter] Add live ebuild for KF5 based kinfocenter

### DIFF
--- a/kde-base/kinfocenter/kinfocenter-9999.ebuild
+++ b/kde-base/kinfocenter/kinfocenter-9999.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+KDE_HANDBOOK="true"
+inherit kde5
+
+DESCRIPTION="A utility that provides information about a computer system"
+HOMEPAGE="http://www.kde.org/applications/system/kinfocenter/"
+KEYWORDS=""
+IUSE="egl gles ieee1394 +opengl +pci samba nfs server wayland X"
+
+REQUIRED_USE="egl? ( || ( gles opengl ) )"
+
+RDEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep solid)
+	dev-qt/qtgui:5[opengl?]
+	dev-qt/qtwidgets:5
+	gles? (
+		dev-qt/qtgui:5[gles2]
+		|| (
+		media-libs/mesa[egl,gles1]
+		media-libs/mesa[egl,gles2]
+	) )
+	ieee1394? ( sys-libs/libraw1394 )
+	nfs? ( net-fs/nfs-utils )
+	opengl? (
+		virtual/glu
+		virtual/opengl
+	)
+	pci? ( sys-apps/pciutils )
+	samba? ( net-fs/samba[server=] )
+	wayland? ( >=dev-libs/wayland-1.2 )
+	X? ( x11-libs/libX11 )
+	!kde-base/kcontrol:4
+	!kde-base/kinfocenter:4
+"
+DEPEND="${RDEPEND}
+	$(add_frameworks_dep plasma)
+"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package egl EGL)
+		$(cmake-utils_use_find_package gles OpenGLES)
+		$(cmake-utils_use_find_package ieee1394 RAW1394)
+		$(cmake-utils_use_find_package opengl OpenGL)
+		$(cmake-utils_use_find_package pci PCIUTILS)
+		$(cmake-utils_use_find_package wayland Wayland)
+		$(cmake-utils_use_find_package X X11)
+	)
+
+	kde5_src_configure
+}

--- a/kde-base/kinfocenter/metadata.xml
+++ b/kde-base/kinfocenter/metadata.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<herd>kde</herd>
+	<herd>kde</herd>
+	<use>
+		<flag name="egl">Retrieve information about OpenGL via EGL</flag>
+		<flag name="gles">Show OpenGL ES information in kinfocenter</flag>
+		<flag name="nfs">Show information about NFS mounts, shares and log entries</flag>
+		<flag name="pci">Show advanced PCI information</flag>
+		<flag name="samba">Show information about Samba mounts, shares and log entries</flag>
+		<flag name="server">Show server specific information in the Samba/NFS module</flag>
+	</use>
 </pkgmetadata>

--- a/sets/kde-workspaces-live
+++ b/sets/kde-workspaces-live
@@ -1,5 +1,6 @@
 ~kde-base/kde-cli-tools-9999
 ~kde-base/khotkeys-9999
+~kde-base/kinfocenter-9999
 ~kde-base/kio-extras-9999
 ~kde-base/ksysguard-9999
 ~kde-base/kwin-9999


### PR DESCRIPTION
Known issues:
- CMakeLists.txt provided by upstream doesn't allow to explicitely disable
  the optional RAW1394 and PCIUTILS modules, so they might cause automagic
  dependencies
- kinfocenter starts, but doesn't list any modules at all

Package-Manager: portage-2.2.10
