### PR TITLE
[kde-frameworks/kconfig] Upstream re-wrote the kiosk documentation (bc157c1b)

### DIFF
--- a/kde-frameworks/kconfig/kconfig-9999.ebuild
+++ b/kde-frameworks/kconfig/kconfig-9999.ebuild
@@ -20,4 +20,4 @@ DEPEND="${RDEPEND}
 	test? ( dev-qt/qtconcurrent:5 )
 "
 
-DOCS=( DESIGN docs/DESIGN.kconfig docs/README.kiosk )
+DOCS=( DESIGN docs/DESIGN.kconfig docs/options.md )


### PR DESCRIPTION
Package-Manager: portage-2.2.10
