### PR TITLE
[eclass] Depend on ECM git master to fix QM loader build errors

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -88,7 +88,11 @@ SLOT=5
 case ${KDE_AUTODEPS} in
 	false)	;;
 	*)
-		DEPEND+=" >=dev-libs/extra-cmake-modules-0.0.12"
+		if [[ ${KDE_BUILD_TYPE} = live ]]; then
+			DEPEND+=" >=dev-libs/extra-cmake-modules-9999"
+		else
+			DEPEND+=" >=dev-libs/extra-cmake-modules-0.0.12"
+		fi
 		RDEPEND+=" kde-frameworks/kf-env"
 		COMMONDEPEND+="	>=dev-qt/qtcore-${QT_MINIMAL}:5"
 		;;


### PR DESCRIPTION
Current ECM 0.0.12 doesn't provide `ecm_create_qm_loader` which results in:

```
CMake Error at src/solid/CMakeLists.txt:49 (ecm_create_qm_loader):
  Unknown CMake command "ecm_create_qm_loader".
```

for those KF5 components making use of `ecm_create_qm_loader`.
