### PR TITLE
[eclass] Correct the destination path for various config files

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -269,6 +269,9 @@ kde5_src_configure() {
 		cmakeargs+=( -DBUILD_TESTING=OFF )
 	fi
 
+	# make sure config files go to /etc instead of /usr/etc
+	cmakeargs+=(-DSYSCONF_INSTALL_DIR="${EPREFIX}"/etc)
+
 	# allow the ebuild to override what we set here
 	mycmakeargs=("${cmakeargs[@]}" "${mycmakeargs[@]}")
 


### PR DESCRIPTION
Currently, at least the following packages install files to `/usr/etc` instead of `/etc`:

```
kde-base/kinfocenter
kde-base/kio-extras
kde-base/ksysguard
kde-base/kwin
kde-base/kwrited
kde-base/plasma-desktop
kde-base/plasma-workspace
kde-frameworks/khtml
kde-frameworks/kio
kde-frameworks/ktexteditor
kde-frameworks/kxmlgui
```

This PR fixes that. Needs a manual rebuild of affected packages:

```
emerge -1 /usr/etc
```
