### PR TITLE
[kde-base/powerdevil] Add ebuild for KF5 based powerdevil

### DIFF
--- a/kde-misc/powerdevil/metadata.xml
+++ b/kde-misc/powerdevil/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>kde</herd>
+<use>
+  <flag name="upower">Adds support for the <pkg>sys-power/upower</pkg> backend</flag>
+</use>
+</pkgmetadata>

--- a/kde-misc/powerdevil/powerdevil-9999.ebuild
+++ b/kde-misc/powerdevil/powerdevil-9999.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="Power management for the KDE Plasma Shell."
+HOMEPAGE="https://projects.kde.org/projects/extragear/base/powerdevil"
+KEYWORDS=""
+IUSE="+upower X"
+
+COMMON_DEPEND="
+	$(add_frameworks_dep kauth)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep plasma)
+	$(add_frameworks_dep solid)
+	X? (
+		x11-libs/libX11
+		x11-libs/libxcb
+		x11-libs/libXrandr
+	)
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	kde-base/plasma-workspace
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	upower? ( sys-power/upower )
+	!kde-base/powerdevil:4
+"
+
+DEPEND="${COMMON_DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package upower UDev)
+		$(cmake-utils_use_find_package X X11)
+	)
+
+	kde5_src_configure
+}


### PR DESCRIPTION
Please review.

@johu The circular dep issue (plasma-workspace <-> powerdevil) is resolved. It's just a case where a non-installed powerdevil isn't properly handled in plasma-workspace. [Reported upstream](https://bugs.kde.org/show_bug.cgi?id=334329).
