### PR TITLE
[kde-misc/milou] Add missing dep on kde-base/baloo:5

### DIFF
--- a/kde-misc/milou/milou-9999.ebuild
+++ b/kde-misc/milou/milou-9999.ebuild
@@ -19,5 +19,6 @@ DEPEND="
 	$(add_frameworks_dep krunner)
 	dev-qt/qtdeclarative:5
 	dev-qt/qtgui:5
+	kde-base/baloo:5
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Package-Manager: portage-2.2.10
