### PR TITLE
[net-libs/jreen] Update dependencies

### DIFF
--- a/net-libs/jreen/jreen-9999.ebuild
+++ b/net-libs/jreen/jreen-9999.ebuild
@@ -26,13 +26,12 @@ DEPEND="
 	media-libs/speex
 	>=net-dns/libidn-1.20
 	net-libs/libgsasl
+	sys-libs/zlib
 	qt4? (
-		>=app-crypt/qca-2.0.3[qt4(+)]
 		>=dev-qt/qtcore-4.6.0:4
 		>=dev-qt/qtgui-4.6.0:4
 	)
 	qt5? (
-		=app-crypt/qca-9999[qt5]
 		dev-qt/qtcore:5
 		dev-qt/qtnetwork:5
 	)


### PR DESCRIPTION
- QCA is no longer used (fully replaced by gsasl)
- zlib is a direct dependency

Package-Manager: portage-2.2.10
