### PR TITLE
[kde-base/plasma-workspace] Depends on qtquickcontrols[widgets]

### DIFF
--- a/kde-base/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-base/plasma-workspace/plasma-workspace-9999.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_kdemisc_dep milou)
-	dev-qt/qtquickcontrols:5
+	dev-qt/qtquickcontrols:5[widgets]
 	!kde-base/freespacenotifier:4
 	!kde-base/libkworkspace:4
 	!kde-base/libtaskmanager:4


### PR DESCRIPTION
The plasmashell configuration dialog requires at least WidgetMessageDialog.qml
which is provided by dev-qt/qtquickcontrols once it is built with the 'widgets'
USE flag enabled.

Package-Manager: portage-2.2.10
