### PR TITLE
[net-wireless/bluedevil] Add dependency on kcmutils

### DIFF
--- a/net-wireless/bluedevil/bluedevil-9999.ebuild
+++ b/net-wireless/bluedevil/bluedevil-9999.ebuild
@@ -13,6 +13,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
+	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)


### PR DESCRIPTION
Fixes:

```
>>> Working in BUILD_DIR: "/var/tmp/portage/net-wireless/bluedevil-9999/work/bluedevil-9999_build"
cmake --no-warn-unused-cli -C /var/tmp/portage/net-wireless/bluedevil-9999/work/bluedevil-9999_build/gentoo_common_config.cmake -G Unix Makefiles -DCMAKE_INSTA
LL_PREFIX=/usr -DBUILD_TESTING=OFF -DSYSCONF_INSTALL_DIR=/etc -DCMAKE_BUILD_TYPE=Gentoo -DCMAKE_INSTALL_DO_STRIP=OFF -DCMAKE_USER_MAKE_RULES_OVERRIDE=/var/tmp/
portage/net-wireless/bluedevil-9999/work/bluedevil-9999_build/gentoo_rules.cmake  /var/tmp/portage/net-wireless/bluedevil-9999/work/bluedevil-9999
Not searching for unused variables given on the command line.
loading initial cache file /var/tmp/portage/net-wireless/bluedevil-9999/work/bluedevil-9999_build/gentoo_common_config.cmake
-- The C compiler identification is GNU 4.9.0
-- The CXX compiler identification is GNU 4.9.0
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found KF5CoreAddons: /usr/lib64/cmake/KF5CoreAddons/KF5CoreAddonsConfig.cmake (found version "4.99.0") 
-- Found KF5WidgetsAddons: /usr/lib64/cmake/KF5WidgetsAddons/KF5WidgetsAddonsConfig.cmake (found version "4.99.0") 
-- Found KF5DBusAddons: /usr/lib64/cmake/KF5DBusAddons/KF5DBusAddonsConfig.cmake (found version "4.99.0") 
-- Found KF5Notifications: /usr/lib64/cmake/KF5Notifications/KF5NotificationsConfig.cmake (found version "4.99.0") 
-- Found Gettext: /usr/bin/msgmerge (found version "0.18.3") 
-- Found KF5IconThemes: /usr/lib64/cmake/KF5IconThemes/KF5IconThemesConfig.cmake (found version "4.99.0") 
-- Found KF5I18n: /usr/lib64/cmake/KF5I18n/KF5I18nConfig.cmake (found version "4.99.0") 
-- Found KF5KIO: /usr/lib64/cmake/KF5KIO/KF5KIOConfig.cmake (found version "4.99.0") 
CMake Warning at /usr/share/ECM/find-modules/FindKF5.cmake:75 (find_package):
  Could not find a package configuration file provided by "KF5KCMUtils" with
  any of the following names:

    KF5KCMUtilsConfig.cmake
    kf5kcmutils-config.cmake

  Add the installation prefix of "KF5KCMUtils" to CMAKE_PREFIX_PATH or set
  "KF5KCMUtils_DIR" to a directory containing one of the above files.  If
  "KF5KCMUtils" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:20 (find_package)


-- Could NOT find KF5KCMUtils: found neither KF5KCMUtilsConfig.cmake nor kf5kcmutils-config.cmake 
-- Found KF5KDELibs4Support: /usr/lib64/cmake/KF5KDELibs4Support/KF5KDELibs4SupportConfig.cmake (found version "4.99.0") 
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find KF5 (missing: KCMUtils) (found version "4.99.0")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/ECM/find-modules/FindKF5.cmake:111 (find_package_handle_standard_args)
  CMakeLists.txt:20 (find_package)
```
