### PR TITLE
[kde-base/kinfocenter] Add kde-frameworks/kdbusaddons to dependencies.

### DIFF
--- a/kde-base/kinfocenter/kinfocenter-9999.ebuild
+++ b/kde-base/kinfocenter/kinfocenter-9999.ebuild
@@ -20,6 +20,7 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)


### PR DESCRIPTION
See also:
http://quickgit.kde.org/?p=kinfocenter.git&a=commitdiff&h=04efe132&hp=84854e5b

Package-Manager: portage-2.2.10
