### PR TITLE
[kde-base/kwin] Add dev-qt/qtgraphicaleffects as runtime dependency

### DIFF
--- a/kde-base/breeze/breeze-4.96.0.ebuild
+++ b/kde-base/breeze/breeze-4.96.0.ebuild
@@ -11,3 +11,7 @@ DESCRIPTION="Breeze visual style for the Plasma desktop"
 HOMEPAGE="https://projects.kde.org/projects/kde/workspace/breeze"
 KEYWORDS=" ~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
+
+RDEPEND="
+	dev-qt/qtgraphicaleffects:5
+"

--- a/kde-base/breeze/breeze-9999.ebuild
+++ b/kde-base/breeze/breeze-9999.ebuild
@@ -16,4 +16,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	dev-qt/qtwidgets:5
 "
-RDEPEND="${DEPEND}"
+RDEPEND="
+	${DEPEND}
+	dev-qt/qtgraphicaleffects:5
+"


### PR DESCRIPTION
Without dev-qt/qtgraphicaleffects installed, Aurorae based kwin
decorations can't be rendered.

Package-Manager: portage-2.2.10
