### PR TITLE
[kde-base/kwin] Drop blocker on kde-base/kwin:4

### DIFF
--- a/kde-base/kwin/kwin-9999.ebuild
+++ b/kde-base/kwin/kwin-9999.ebuild
@@ -60,7 +60,6 @@ COMMON_DEPEND="
 	)
 "
 RDEPEND="${COMMON_DEPEND}
-	!kde-base/kwin:4
 	!kde-base/systemsettings:4
 "
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
kwin:5 is now co-installable with kwin:4. See also:
http://quickgit.kde.org/?p=kwin.git&a=commit&h=52653aaede30d5e2b6cbefa58be53c1742f7a315

Package-Manager: portage-2.2.10
