### PR TITLE
[kde-frameworks/kauth] Remove polkit-kde-agent dependency.

### DIFF
--- a/kde-frameworks/kauth/kauth-9999.ebuild
+++ b/kde-frameworks/kauth/kauth-9999.ebuild
@@ -22,7 +22,6 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	nls? ( dev-qt/linguist-tools:5 )
 "
-PDEPEND="policykit? ( sys-auth/polkit-kde-agent )"
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
KAuth does not in fact depend on polkit-kde-agent for policykit support, and furthermore, having such a dependency doesn't make any sense, as polkit-kde-agent is a KDE4 package, so its dependencies block KF5.

I have tested merging this package with this commit and USE="policykit", and it seems to work as expected.
