### PR TITLE
[kde-base/kwin] Add media-libs/libepoxy dependency (upstream: 01e1aef3)

### DIFF
--- a/kde-base/kwin/kwin-9999.ebuild
+++ b/kde-base/kwin/kwin-9999.ebuild
@@ -43,6 +43,7 @@ COMMON_DEPEND="
 	dev-qt/qtscript:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras
+	media-libs/libepoxy
 	x11-libs/libICE
 	x11-libs/libSM
 	x11-libs/libX11


### PR DESCRIPTION
Package-Manager: portage-2.2.10
