### PR TITLE
[kde-base/kdelibs] Explicitly depend on qt4 USE for libattica

### DIFF
--- a/kde-base/kdelibs/kdelibs-4.13.90.ebuild
+++ b/kde-base/kdelibs/kdelibs-4.13.90.ebuild
@@ -33,7 +33,7 @@ COMMONDEPEND="
 	>=app-misc/strigi-0.7.7
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xsl-stylesheets
-	>=dev-libs/libattica-0.4.2
+	>=dev-libs/libattica-0.4.2[qt4]
 	>=dev-libs/libdbusmenu-qt-0.3.2
 	dev-libs/libpcre[unicode]
 	dev-libs/libxml2

--- a/kde-base/kdelibs/kdelibs-4.14.49.9999.ebuild
+++ b/kde-base/kdelibs/kdelibs-4.14.49.9999.ebuild
@@ -33,7 +33,7 @@ COMMONDEPEND="
 	>=app-misc/strigi-0.7.7
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xsl-stylesheets
-	>=dev-libs/libattica-0.4.2
+	>=dev-libs/libattica-0.4.2[qt4]
 	>=dev-libs/libdbusmenu-qt-0.3.2
 	dev-libs/libpcre[unicode]
 	dev-libs/libxml2

--- a/kde-base/kdelibs/kdelibs-4.9999.ebuild
+++ b/kde-base/kdelibs/kdelibs-4.9999.ebuild
@@ -33,7 +33,7 @@ COMMONDEPEND="
 	>=app-misc/strigi-0.7.7
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xsl-stylesheets
-	>=dev-libs/libattica-0.4.2
+	>=dev-libs/libattica-0.4.2[qt4]
 	>=dev-libs/libdbusmenu-qt-0.3.2
 	dev-libs/libpcre[unicode]
 	dev-libs/libxml2


### PR DESCRIPTION
Package-Manager: portage-2.2.10
