### PR TITLE
[kde-base/khelpcenter] Copy the khelpcenter.desktop file from the install image instead of an already installed instance.

### DIFF
--- a/kde-base/khelpcenter/khelpcenter-5.0.0.ebuild
+++ b/kde-base/khelpcenter/khelpcenter-5.0.0.ebuild
@@ -44,6 +44,6 @@ src_install() {
 
 	if use compat ; then
 		insinto /usr/share/kde4/services
-		doins /usr/share/kservices5/khelpcenter.desktop
+		doins "${D}"/usr/share/kservices5/khelpcenter.desktop
 	fi
 }

--- a/kde-base/khelpcenter/khelpcenter-5.0.9999.ebuild
+++ b/kde-base/khelpcenter/khelpcenter-5.0.9999.ebuild
@@ -44,6 +44,6 @@ src_install() {
 
 	if use compat ; then
 		insinto /usr/share/kde4/services
-		doins /usr/share/kservices5/khelpcenter.desktop
+		doins "${D}"/usr/share/kservices5/khelpcenter.desktop
 	fi
 }

--- a/kde-base/khelpcenter/khelpcenter-9999.ebuild
+++ b/kde-base/khelpcenter/khelpcenter-9999.ebuild
@@ -44,6 +44,6 @@ src_install() {
 
 	if use compat ; then
 		insinto /usr/share/kde4/services
-		doins /usr/share/kservices5/khelpcenter.desktop
+		doins "${D}"/usr/share/kservices5/khelpcenter.desktop
 	fi
 }


### PR DESCRIPTION
This fixes a small mistake I made in khelpcenter.  I didn't realize it until I tried installing khelpcenter:5 on a machine that it was never installed on previously.
