### PR TITLE
[kde-frameworks/kactivities] Add dependency on kdeclarative

### DIFF
--- a/kde-frameworks/kactivities/kactivities-9999.ebuild
+++ b/kde-frameworks/kactivities/kactivities-9999.ebuild
@@ -15,6 +15,7 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kservice)


### PR DESCRIPTION
Package-Manager: portage-2.2.11-r1
