### PR TITLE
[eclass] Fix dev-util/extra-cmake-modules dependency for live ebuilds.

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -112,7 +112,11 @@ case ${KDE_AUTODEPS} in
 	false)	;;
 	*)
 		if [[ ${CATEGORY} = kde-frameworks ]]; then
-			ecm_version=1.$(get_version_component_range 2 ${PV}).0
+			if [[ ${PV} = 9999 ]]; then
+				ecm_version=9999
+			else
+				ecm_version=1.$(get_version_component_range 2 ${PV}).0
+			fi
 		else
 			ecm_version=1.2.0
 		fi


### PR DESCRIPTION
Due to 4e5d51866, the live KDE ebuilds had an invalid dependency on
dev-util/extra-cmake-modules.  Fix by ensuring they always depend on the live
version.
