### PR TITLE
[dev-util/plasmate] Add required dependency on dev-util/kdevplatform:5

### DIFF
--- a/dev-util/plasmate/plasmate-9999.ebuild
+++ b/dev-util/plasmate/plasmate-9999.ebuild
@@ -36,6 +36,7 @@ DEPEND="
 	dev-qt/qtwebkit:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
+	dev-util/kdevplatform:5
 "
 RDEPEND="${DEPEND}
 	!kde-misc/plasmate:4


### PR DESCRIPTION
Package-Manager: portage-2.2.14_rc1

Otherwise CMake will fail building `dev-util/plasmate-9999`:

```
-- Found KF5: success (found version "5.3.0") found components:  Archive Completion Config ConfigWidgets CoreAddons I18n IconThemes KDE4Support KIO NewStuff Parts Plasma PlasmaQuick Service TextEditor WidgetsAddons XmlGui 
CMake Warning at /usr/lib64/cmake/KF5KDELibs4Support/FindKDevPlatform.cmake:40 (find_package):
  Could not find a package configuration file provided by "KDevPlatform"
  (requested version 1.90.60) with any of the following names:

    KDevPlatformConfig.cmake
    kdevplatform-config.cmake

  Add the installation prefix of "KDevPlatform" to CMAKE_PREFIX_PATH or set
  "KDevPlatform_DIR" to a directory containing one of the above files.  If
  "KDevPlatform" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  plasmate/CMakeLists.txt:21 (find_package)


CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find KDevPlatform (missing: KDevPlatform_CONFIG) (Required is at
  least version "1.90.60")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  /usr/lib64/cmake/KF5KDELibs4Support/FindKDevPlatform.cmake:44 (find_package_handle_standard_args)
  plasmate/CMakeLists.txt:21 (find_package)
```
