### PR TITLE
[kde-base/dolphin] block dolphin:4

### DIFF
--- a/kde-base/dolphin/dolphin-9999.ebuild
+++ b/kde-base/dolphin/dolphin-9999.ebuild
@@ -49,7 +49,9 @@ DEPEND="
 		$(add_kdebase_dep kfilemetadata)
 	)
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!kde-base/dolphin:4
+"
 
 S=${S}/${PN}
 


### PR DESCRIPTION
on merging dolphin:5 there are file collisions, so block dolphin:4
