### PR TITLE
[kde-base/kwayland] Remove kwayland-wayland-1.5.patch from 9999.

### DIFF
--- a/kde-base/kwayland/kwayland-9999.ebuild
+++ b/kde-base/kwayland/kwayland-9999.ebuild
@@ -22,5 +22,3 @@ RDEPEND="${DEPEND}"
 
 # All failing, i guess we need a virtual wayland server
 RESTRICT="test"
-
-PATCHES=( "${FILESDIR}/${PN}-wayland-1.5.patch" )


### PR DESCRIPTION
The latest KWayland no longer requires the kwayland-wayland-1.5.patch, as the latest changes in git no longer require egl.
