### PR TITLE
[kde-base/libkscreen] add EGIT_BRANCH

### DIFF
--- a/kde-base/libkscreen/libkscreen-9999.ebuild
+++ b/kde-base/libkscreen/libkscreen-9999.ebuild
@@ -5,6 +5,7 @@
 EAPI=5
 
 VIRTUALX_REQUIRED="test"
+EGIT_BRANCH="frameworks"
 inherit kde5
 
 DESCRIPTION="KDE screen management library"


### PR DESCRIPTION
currently the KDE4 version is built, which shouldn't be done by this ebuild
