### PR TITLE
make s-c-p optional according to upstream comments

### DIFF
--- a/kde-base/print-manager/print-manager-4.14.2.ebuild
+++ b/kde-base/print-manager/print-manager-4.14.2.ebuild
@@ -8,7 +8,7 @@ inherit kde4-base
 
 DESCRIPTION="Manage print jobs and printers in KDE"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="debug"
+IUSE="debug +gtk"
 
 DEPEND="
 	>=net-print/cups-1.5.0[dbus]
@@ -17,7 +17,24 @@ RDEPEND="${DEPEND}
 	!kde-base/printer-applet:4
 	!kde-base/system-config-printer-kde:4
 	!kde-misc/print-manager
-	app-admin/system-config-printer-gnome
+	gtk? ( app-admin/system-config-printer-gnome )
 "
 
 PATCHES=( "${FILESDIR}/${PN}-4.14.1-cups20.patch" )
+
+pkg_postinst(){
+	if ! use gtk ; then
+		ewarn
+		ewarn "By switching off \"gtk\" USE flag, you have chosen to do without"
+		ewarn "an important, though optional, runtime dependency:"
+		ewarn
+		ewarn "app-admin/system-config-printer-gnome"
+		ewarn
+		ewarn "${PN} will work nevertheless, but is going to be less comfortable"
+		ewarn "and will show the following error status during runtime:"
+		ewarn
+		ewarn "\"Failed to group devices: 'The name org.fedoraproject.Config.Printing"
+		ewarn "was not provided by any .service files'\""
+		ewarn
+	fi
+}


### PR DESCRIPTION
...from https://bugs.kde.org/show_bug.cgi?id=320326

I chose to keep the dependency behind the 'gtk' flag for lack of inspiration, enabled by default:
- desktop profile users will get it as upstream intended, after all it's 'important'
- if the user has consciously disabled 'gtk', there is a fat ewarn message explaining state of affairs
