### PR TITLE
[kde-misc/kdeconnect] Update dependencies

### DIFF
--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -19,7 +19,7 @@ LICENSE="GPL-2+"
 
 DEPEND="
 	app-crypt/qca:2[qt5,openssl]
-	dev-libs/qjson[qt5]
+	x11-libs/libfakekey
 "
 RDEPEND="${DEPEND}
 	$(add_kdebase_dep plasma-workspace)


### PR DESCRIPTION
Package-Manager: portage-2.2.14

`dev-libs/qjson` is obsolete - Qt builtin JSON support is used now
`x11-libs/libfakekey` is now used for the touchpad functionality
