### PR TITLE
[sys-block/partitionmanager] Add use flags to fetch some runtime dependecies

### DIFF
--- a/sys-block/partitionmanager/metadata.xml
+++ b/sys-block/partitionmanager/metadata.xml
@@ -2,4 +2,15 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
+	<use>
+		<flag name='btrfs'>Include Btrfs support (<pkg>sys-fs/btrfs-progs</pkg>)</flag>
+		<flag name='fat'>Include FAT16/FAT32 support (<pkg>sys-fs/dosfstools</pkg>)</flag>
+		<flag name='hfs'>Include HFS support (<pkg>sys-fs/hfsutils</pkg>)</flag>
+		<flag name='jfs'>Include JFS support (<pkg>sys-fs/jfsutils</pkg>)</flag>
+		<flag name='ntfs'>Include NTFS support (<pkg>sys-fs/ntfsprogs</pkg>)</flag>
+		<flag name='reiser4'>Include ReiserFS4 support (<pkg>sys-fs/reiser4progs</pkg>)</flag>
+		<flag name='reiserfs'>Include ReiserFS support (<pkg>sys-fs/reiserfsprogs</pkg>)</flag>
+		<flag name='xfs'>Include XFS support (<pkg>sys-fs/xfsprogs</pkg>)</flag>
+		<flag name='zfs'>Include ZFS support (<pkg>sys-fs/zfs</pkg>)</flag>
+	</use>
 </pkgmetadata>

--- a/sys-block/partitionmanager/partitionmanager-9999.ebuild
+++ b/sys-block/partitionmanager/partitionmanager-9999.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.kde.org/applications/system/kdepartitionmanager/"
 LICENSE="GPL-2 GPL-3"
 SLOT="5"
 KEYWORDS=""
-IUSE=""
+IUSE="btrfs fat hfs jfs ntfs reiserfs reiser4 xfs zfs"
 
 DEPEND="
 	$(add_frameworks_dep kconfig)
@@ -33,4 +33,16 @@ RDEPEND="${DEPEND}
 	>=sys-block/parted-3
 	sys-apps/util-linux
 	!sys-block/partitionmanager:0
+	btrfs? ( sys-fs/btrfs-progs )
+	fat? ( sys-fs/dosfstools )
+	hfs? (
+		sys-fs/diskdev_cmds
+		virtual/udev
+		sys-fs/hfsutils )
+	jfs? ( sys-fs/jfsutils )
+	ntfs? ( sys-fs/ntfs3g[ntfsprogs] )
+	reiserfs? ( sys-fs/reiserfsprogs )
+	reiser4? ( sys-fs/reiser4progs )
+	xfs? ( sys-fs/xfsprogs )
+	zfs? ( sys-fs/zfs )
 "


### PR DESCRIPTION
Add use flags to fetch some runtime dependecies. (gparted ebuild does the same thing.)
