### PR TITLE
[kde-frameworks/kapidox] add jinja dep

### DIFF
--- a/kde-frameworks/kapidox/kapidox-9999.ebuild
+++ b/kde-frameworks/kapidox/kapidox-9999.ebuild
@@ -17,6 +17,7 @@ IUSE=""
 
 RDEPEND="
 	app-doc/doxygen
+	dev-python/jinja[${PYTHON_USEDEP}]
 	dev-python/pystache[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	media-gfx/graphviz[python]


### PR DESCRIPTION
I get this error with only jinja[python_targets_python2_7]:

Traceback (most recent call last):
  File /usr/lib/python-exec/python3.4/kgenapidox, line 40, in <module>
    from kapidox.generator import *
  File /usr/lib64/python3.4/site-packages/kapidox/generator.py, line 52, in <module>
    import jinja2
ImportError: No module named 'jinja2'
