### PR TITLE
[dev-util/kdevplatform] Fix 4.9999 ebuild.

### DIFF
--- a/dev-util/kdevplatform/kdevplatform-4.9999.ebuild
+++ b/dev-util/kdevplatform/kdevplatform-4.9999.ebuild
@@ -11,6 +11,7 @@ pt_BR ru sk sl sv th uk zh_CN zh_TW"
 VIRTUALDBUS_TEST="true"
 VIRTUALX_REQUIRED="test"
 EGIT_REPONAME="${PN}"
+EGIT_BRANCH="1.7"
 inherit kde4-base
 
 DESCRIPTION="KDE development support libraries and apps"


### PR DESCRIPTION
It seems that the commit 2625e3d888dd91cca2343ea8b0824c74627bce0b accidentally removed EGIT_BRANCH from the ebuild. I am not an ebuild expert but I have successfully emerged the kdevplatform package with this patch.
