### PR TITLE
[net-im/ktp-text-ui] fix 4.9999 branch

### DIFF
--- a/net-im/ktp-text-ui/ktp-text-ui-4.9999.ebuild
+++ b/net-im/ktp-text-ui/ktp-text-ui-4.9999.ebuild
@@ -7,6 +7,7 @@ EAPI=5
 KDE_LINGUAS="bs ca ca@valencia cs da de el es et fi fr ga gl hu ia it ja kk km
 ko lt mr nb nds nl pl pt pt_BR ro ru sk sl sr sr@ijekavian sr@ijekavianlatin
 sr@latin sv tr ug uk vi wa zh_CN zh_TW"
+EGIT_BRANCH="kde-telepathy-0.9"
 inherit kde4-base
 
 DESCRIPTION="KDE Telepathy text chat window"


### PR DESCRIPTION
Since http://quickgit.kde.org/?p=ktp-text-ui.git&a=commit&h=4b2e10f2202ca8ecb91bcb93fb7f5ffe57b44675 master branch is frameworks-oriented and is not compatible with KDE SC 4.