### PR TITLE
[app-editors/kile:5] Re-organise dependencies using CDEPEND

### DIFF
--- a/app-editors/kile/kile-5.9999.ebuild
+++ b/app-editors/kile/kile-5.9999.ebuild
@@ -4,6 +4,8 @@
 
 EAPI=5
 
+CMAKE_MIN_VERSION="3.0.2"
+
 KDE_HANDBOOK=true
 EGIT_BRANCH="frameworks"
 MY_P=${P/_beta/b}
@@ -18,10 +20,6 @@ KEYWORDS=""
 IUSE="debug +pdf +png"
 
 DEPEND="
-	>=dev-util/cmake-3.0.2
-"
-
-RDEPEND="${DEPEND}
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kdoctools)
@@ -35,16 +33,20 @@ RDEPEND="${DEPEND}
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	|| (
-		$(add_kdeapps_dep konsole)
-		$(add_kdeapps_dep okular 'pdf?,postscript')
-		app-text/acroread
-	)
-	dev-qt/qtcore:5
+	$(add_kdeapps_dep okular)
 	dev-qt/qtdbus:5
 	dev-qt/qtscript:5
 	dev-qt/qttest:5
 	dev-qt/qtwidgets:5
+"
+
+RDEPEND="${DEPEND}
+	!app-editors/kile:4
+	$(add_kdeapps_dep konsole)
+	|| (
+		$(add_kdeapps_dep okular 'pdf?')
+		app-text/acroread
+	)
 	virtual/latex-base
 	virtual/tex-base
 	pdf? (


### PR DESCRIPTION
 - move packages to CDEPEND where DEPEND is due
 - avoid cmake in RDEPEND
 - drop non-existing okular[postscript] use-dep
 - fix konsole RDEPEND
 - block app-editors/kile:4