### PR TITLE
kde-apps/pykde5, lokalize: add initial kf5 ebuilds

### DIFF
--- a/kde-apps/lokalize/lokalize-4.9999.ebuild
+++ b/kde-apps/lokalize/lokalize-4.9999.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="Applications/14.12"
+KDE_HANDBOOK="optional"
+PYTHON_COMPAT=( python2_7 )
+inherit python-single-r1 kde4-base
+
+DESCRIPTION="KDE4 translation tool"
+HOMEPAGE="http://www.kde.org/applications/development/lokalize
+http://l10n.kde.org/tools"
+KEYWORDS=""
+IUSE="debug nepomuk"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND="
+	${PYTHON_DEPS}
+	>=app-text/hunspell-1.2.8
+	>=dev-qt/qtsql-4.5.0:4[sqlite]
+	nepomuk? ( >=dev-libs/soprano-2.9.0 )
+"
+RDEPEND="${DEPEND}
+	$(add_kdeapps_dep kdesdk-strigi-analyzer)
+	$(add_kdebase_dep krosspython "${PYTHON_USEDEP}")
+	$(add_kdebase_dep pykde4 "${PYTHON_USEDEP}")
+"
+
+pkg_setup() {
+	python-single-r1_pkg_setup
+	kde4-base_pkg_setup
+}
+
+src_install() {
+	kde4-base_src_install
+	python_fix_shebang "${ED}/usr/share/apps/${PN}"
+}
+
+pkg_postinst() {
+	kde4-base_pkg_postinst
+
+	if ! has_version dev-vcs/subversion ; then
+		elog "To be able to autofetch KDE translations in new project wizard, install dev-vcs/subversion."
+	fi
+}

--- a/kde-apps/lokalize/lokalize-9999.ebuild
+++ b/kde-apps/lokalize/lokalize-9999.ebuild
@@ -4,42 +4,50 @@
 
 EAPI=5
 
-KDE_HANDBOOK="optional"
+KDE_HANDBOOK=true
 PYTHON_COMPAT=( python2_7 )
-inherit python-single-r1 kde4-base
+inherit python-single-r1 kde5
 
-DESCRIPTION="KDE4 translation tool"
+DESCRIPTION="KDE Applications 5 translation tool"
 HOMEPAGE="http://www.kde.org/applications/development/lokalize
 http://l10n.kde.org/tools"
 KEYWORDS=""
-IUSE="debug nepomuk"
+IUSE=""
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-DEPEND="
-	${PYTHON_DEPS}
+DEPEND="${PYTHON_DEPS}
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdoctools)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep kross)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep sonnet)
 	>=app-text/hunspell-1.2.8
-	>=dev-qt/qtsql-4.5.0:4[sqlite]
-	nepomuk? ( >=dev-libs/soprano-2.9.0 )
+	dev-qt/qtdbus:5
+	dev-qt/qtscript:5
+	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtwidgets:5
 "
 RDEPEND="${DEPEND}
-	$(add_kdeapps_dep kdesdk-strigi-analyzer)
-	$(add_kdebase_dep krosspython "${PYTHON_USEDEP}")
-	$(add_kdebase_dep pykde4 "${PYTHON_USEDEP}")
+	$(add_kdeapps_dep pykde5 "${PYTHON_USEDEP}")
 "
 
 pkg_setup() {
 	python-single-r1_pkg_setup
-	kde4-base_pkg_setup
+	kde5_pkg_setup
 }
 
 src_install() {
-	kde4-base_src_install
-	python_fix_shebang "${ED}/usr/share/apps/${PN}"
+	kde5_src_install
+	python_fix_shebang "${ED}/usr/share/${PN}"
 }
 
 pkg_postinst() {
-	kde4-base_pkg_postinst
+	kde5_pkg_postinst
 
 	if ! has_version dev-vcs/subversion ; then
 		elog "To be able to autofetch KDE translations in new project wizard, install dev-vcs/subversion."

--- a/kde-apps/pykde5/metadata.xml
+++ b/kde-apps/pykde5/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>

--- a/kde-apps/pykde5/pykde5-9999.ebuild
+++ b/kde-apps/pykde5/pykde5-9999.ebuild
@@ -1,0 +1,81 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_REQ_USE="threads"
+OPENGL_REQUIRED="always"
+
+inherit python-r1 portability kde5 multilib eutils
+
+DESCRIPTION="Python bindings for KDE Applications 5"
+KEYWORDS=""
+IUSE="doc"
+HOMEPAGE="http://techbase.kde.org/Development/Languages/Python"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	$(add_frameworks_dep karchive)
+	$(add_frameworks_dep kauth)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep kitemmodels)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kplotting)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep sonnet)
+	dev-python/PyQt5[${PYTHON_USEDEP},gui,widgets]
+	>=dev-python/sip-4.16.2:=[${PYTHON_USEDEP}]
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+
+DEPEND="${RDEPEND}
+	doc? ( $(add_frameworks_dep kapidox) )
+"
+
+src_prepare() {
+	kde5_src_prepare
+
+	python_copy_sources
+}
+
+src_configure() {
+	configuration() {
+		local mycmakeargs=(
+			-DPYTHON_EXECUTABLE=${PYTHON}
+		)
+		local CMAKE_BUILD_DIR=${S}_build-${PYTHON_ABI}
+		kde5_src_configure
+	}
+
+	python_foreach_impl run_in_build_dir configuration
+}
+
+src_compile() {
+	compilation() {
+		local CMAKE_BUILD_DIR=${S}_build-${PYTHON_ABI}
+		kde5_src_compile
+	}
+	python_foreach_impl run_in_build_dir compilation
+}
+
+src_test() {
+	python_foreach_impl run_in_build_dir kde5_src_test
+}
+
+src_install() {
+	installation() {
+		emake DESTDIR="${D}" install
+
+		python_optimize
+	}
+	python_foreach_impl run_in_build_dir installation
+
+	# As we don't call the eclass's src_install, we have to install the docs manually
+	use doc && HTML_DOCS=("${S}/docs/html/")
+	einstalldocs
+}


### PR DESCRIPTION
* [kde-apps/pykde5]
 * derived from pykde4 ebuild (and metadata), though I usually have no business with python
 * PyQt5[gui, widgets] flags are the minimum required to *build* successfully, however what about [dbus, declarative, script, sql, svg]?
 * is arm patch still required?
 * EDIT: dropped sys-devel/libtool from DEPEND
* [kde-apps/lokalize]
 * master switched to kf5