### PR TITLE
kde-apps/libkdegames, konquest: add kf5 ebuilds 

### DIFF
--- a/kde-apps/konquest/konquest-5.9999.ebuild
+++ b/kde-apps/konquest/konquest-5.9999.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+KDE_HANDBOOK="true"
+KDE_SELINUX_MODULE="games"
+inherit kde5
+
+DESCRIPTION="Galactic Strategy KDE Game"
+HOMEPAGE="
+	http://www.kde.org/applications/games/konquest/
+	http://games.kde.org/game.php?game=konquest
+"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemmodels)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_kdeapps_dep libkdegames)
+	dev-qt/qtdeclarative:5[widgets]
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwidgets:5
+	media-libs/phonon[qt5]
+"
+
+RDEPEND="${DEPEND}
+	!kde-apps/konquest:4
+	!kde-base/konquest
+"
+
+src_prepare() {
+	# fix copy-paste (?) error, there are no tests
+	sed -i "/find_package(Qt5/ s/ Test//" CMakeLists.txt || die
+
+	kde5_src_prepare
+}

--- a/kde-apps/libkdegames/files/libkdegames-5.9999-buildsystem.patch
+++ b/kde-apps/libkdegames/files/libkdegames-5.9999-buildsystem.patch
@@ -1,0 +1,58 @@
+--- a/CMakeLists.txt	2015-01-18 21:48:57.436568121 +0100
++++ b/CMakeLists.txt	2015-01-18 21:49:04.667567906 +0100
+@@ -1,5 +1,3 @@
+-enable_testing()
+-
+ project(libkdegames)
+ 
+ cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+@@ -9,7 +7,7 @@
+ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+ 
+ 
+-find_package(Qt5 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS Widgets Qml Quick QuickWidgets Svg Test)
++find_package(Qt5 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS Widgets Qml Quick QuickWidgets Svg)
+ find_package(KF5 REQUIRED COMPONENTS CoreAddons Config WidgetsAddons Codecs Archive
+     DBusAddons DNSSD Declarative
+     I18n GuiAddons Service ConfigWidgets ItemViews IconThemes Completion JobWidgets TextWidgets GlobalAccel XmlGui Crash
+@@ -51,7 +49,10 @@
+ add_subdirectory( highscore )
+ add_subdirectory( includes )
+ add_subdirectory( libkdegamesprivate )
+-add_subdirectory( tests )
++
++if(BUILD_TESTING)
++    add_subdirectory( tests )
++endif()
+ 
+ include_directories(
+     ${CMAKE_CURRENT_SOURCE_DIR}/highscore
+--- a/tests/CMakeLists.txt	2015-01-18 21:34:42.477593601 +0100
++++ b/tests/CMakeLists.txt	2015-01-18 21:39:09.461585644 +0100
+@@ -1,3 +1,5 @@
++find_package(Qt5Test ${QT_MIN_VERSION} REQUIRED NO_MODULE)
++
+ set( EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR} )
+ include_directories(  ${CMAKE_SOURCE_DIR}/libkdegames )
+ 
+--- a/libkdegamesprivate/CMakeLists.txt	2015-01-18 21:49:50.737566533 +0100
++++ b/libkdegamesprivate/CMakeLists.txt	2015-01-18 21:51:18.496563917 +0100
+@@ -1,7 +1,8 @@
+-enable_testing()
+ project(libkdegamesprivate)
+ 
+-add_subdirectory(tests)
++if(BUILD_TESTING)
++    add_subdirectory( tests )
++endif()
+ 
+ # NOTE: The libkdegamesprivate target is compiled in the parent directory,
+ # because CMake can't cope with exported libraries in two different
+--- a/libkdegamesprivate/tests/CMakeLists.txt	2015-01-18 21:49:50.737566533 +0100
++++ b/libkdegamesprivate/tests/CMakeLists.txt	2015-01-18 21:54:04.201558979 +0100
+@@ -1,3 +1,5 @@
++find_package(Qt5Test ${QT_MIN_VERSION} REQUIRED NO_MODULE)
++
+ set( EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR} )
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+ 

--- a/kde-apps/libkdegames/libkdegames-5.9999.ebuild
+++ b/kde-apps/libkdegames/libkdegames-5.9999.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+KDE_TEST="true"
+VIRTUALX_REQUIRED="test"
+inherit kde5
+
+DESCRIPTION="Base library common to many KDE games"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep karchive)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kcodecs)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kcrash)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdnssd)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kjobwidgets)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kxmlgui)
+	dev-qt/qtdeclarative:5[widgets]
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtsvg:5
+	media-libs/libsndfile
+	media-libs/openal
+"
+
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${PN}-5.9999-buildsystem.patch" )


### PR DESCRIPTION
Many games have frameworks branches already, one problem seems to be broken desktop files (Exec), however konquest run from terminal works fine.