### PR TITLE
[kde-frameworks/kauth] Re-enable PDEPEND on kde-plasma/polkit-kde-agent.

### DIFF
--- a/kde-frameworks/kauth/kauth-9999.ebuild
+++ b/kde-frameworks/kauth/kauth-9999.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	nls? ( dev-qt/linguist-tools:5 )
 "
-#PDEPEND="policykit? ( sys-auth/polkit-kde-agent )"
+PDEPEND="policykit? ( kde-plasma/polkit-kde-agent )"
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
See also: 97ee921

Package-Manager: portage-2.2.15