### PR TITLE
Qt5Test configure patches for konsole and dolphin, small fixes for kget and kile

### DIFF
--- a/app-editors/kile/kile-5.9999.ebuild
+++ b/app-editors/kile/kile-5.9999.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="http://kile.sourceforge.net/"
 
 LICENSE="FDL-1.2 GPL-2"
 KEYWORDS=""
-IUSE="debug +pdf +png"
+IUSE="+pdf +png"
 
 DEPEND="
 	$(add_frameworks_dep kconfig)

--- a/kde-apps/dolphin/dolphin-5.9999.ebuild
+++ b/kde-apps/dolphin/dolphin-5.9999.ebuild
@@ -6,7 +6,9 @@ EAPI=5
 
 EGIT_BRANCH="frameworks"
 KMNAME="kde-baseapps"
-KDE_HANDBOOK=true
+KDE_HANDBOOK="true"
+KDE_TEST="true"
+VIRTUALX_REQUIRED="test"
 inherit kde5
 
 DESCRIPTION="KDE filemanager focusing on usability"
@@ -52,6 +54,8 @@ DEPEND="
 RDEPEND="${DEPEND}
 	!kde-base/dolphin:4
 "
+
+PATCHES=( "${FILESDIR}/${PN}-5.9999-tests-optional.patch" )
 
 S=${S}/${PN}
 

--- a/kde-apps/dolphin/files/dolphin-5.9999-tests-optional.patch
+++ b/kde-apps/dolphin/files/dolphin-5.9999-tests-optional.patch
@@ -1,0 +1,11 @@
+--- a/src/CMakeLists.txt	2015-01-19 02:45:45.207037408 +0100
++++ b/src/CMakeLists.txt	2015-01-19 02:52:38.558025089 +0100
+@@ -334,4 +334,7 @@
+ install( PROGRAMS settings/services/servicemenuinstallation DESTINATION ${BIN_INSTALL_DIR} )
+ install( PROGRAMS settings/services/servicemenudeinstallation DESTINATION ${BIN_INSTALL_DIR} )
+ 
+-add_subdirectory(tests)
++if(BUILD_TESTING)
++    find_package(Qt5Test ${QT_MIN_VERSION} CONFIG REQUIRED)
++    add_subdirectory(tests)
++endif()

--- a/kde-apps/kget/kget-5.9999.ebuild
+++ b/kde-apps/kget/kget-5.9999.ebuild
@@ -4,14 +4,14 @@
 
 EAPI=5
 
-KDE_HANDBOOK=true
+KDE_HANDBOOK="true"
 EGIT_BRANCH="kf5_port"
 inherit kde5
 
 DESCRIPTION="An advanced download manager for KDE"
 HOMEPAGE="http://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
-IUSE="debug gpg mms sqlite"
+IUSE="gpg mms sqlite"
 
 # TODO: not yet ported
 # 	bittorrent? ( 

--- a/kde-apps/konsole/files/konsole-9999-tests-optional.patch
+++ b/kde-apps/konsole/files/konsole-9999-tests-optional.patch
@@ -1,0 +1,27 @@
+--- a/CMakeLists.txt	2015-01-19 01:06:41.388214548 +0100
++++ b/CMakeLists.txt	2015-01-19 01:13:14.851202822 +0100
+@@ -26,7 +26,7 @@
+ ecm_setup_version(${Konsole_VERSION} VARIABLE_PREFIX KONSOLEPRIVATE
+                   SOVERSION ${Konsole_VERSION_MAJOR}
+ )
+-find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED Core DBus Widgets Script Test)
++find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED Core DBus Widgets Script)
+ 
+ find_package(KF5 REQUIRED
+     Bookmarks Completion Config ConfigWidgets
+--- a/src/CMakeLists.txt	2015-01-19 01:06:41.386214548 +0100
++++ b/src/CMakeLists.txt	2015-01-19 01:15:51.963198139 +0100
+@@ -22,8 +22,11 @@
+               ${CMAKE_CURRENT_BINARY_DIR}/config-konsole.h)
+ 
+ ### Tests
+-add_subdirectory(autotests)
+-add_subdirectory(tests)
++if(BUILD_TESTING)
++  find_package(Qt5Test ${QT_MIN_VERSION} CONFIG REQUIRED)
++  add_subdirectory(autotests)
++  add_subdirectory(tests)
++endif()
+ 
+ ### Font Embedder and LineFont.h
+ option(KONSOLE_BUILD_FONTEMBEDDER "Konsole: build fontembedder executable" OFF)

--- a/kde-apps/konsole/konsole-9999.ebuild
+++ b/kde-apps/konsole/konsole-9999.ebuild
@@ -5,6 +5,8 @@
 EAPI=5
 
 KDE_HANDBOOK="true"
+KDE_TEST="true"
+VIRTUALX_REQUIRED="test"
 inherit kde5
 
 DESCRIPTION="KDE's terminal emulator"
@@ -45,6 +47,8 @@ DEPEND="
 RDEPEND="${DEPEND}
 	!kde-base/konsole:4
 "
+
+PATCHES=( "${FILESDIR}/${PN}-9999-tests-optional.patch" )
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
I noticed that the following packages would currently fail to configure without dev-qt/qttest installed:
* kde-apps/konsole:5
* kde-apps/dolphin:5

Both required a patch to CMakeLists.txt. I can try to upstream it in the next few days if the patches look good, unless someone else is quicker.

Minor ebuild fixes for kget and kile.