### PR TITLE
[net-irc/konversation] should depend on qca[openssl]

### DIFF
--- a/net-irc/konversation/konversation-9999.ebuild
+++ b/net-irc/konversation/konversation-9999.ebuild
@@ -49,6 +49,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	!net-irc/konversation:4
+	crypt? ( app-crypt/qca:2[openssl] )
 "
 
 src_configure() {


### PR DESCRIPTION
DH and CBC (ECB too, but ECB doesn't matter) support are only provided through the qca-ossl plugin, which are the only ones supported by konversation. It makes no sense to enable crypt support without having the qca-ossl plugin enabled at all.