### PR TITLE
net-libs/telepathy-logger-qt: use right versions, also fix :5 ebuild

### DIFF
--- a/net-libs/telepathy-logger-qt/telepathy-logger-qt-9999.ebuild
+++ b/net-libs/telepathy-logger-qt/telepathy-logger-qt-9999.ebuild
@@ -28,12 +28,3 @@ DEPEND="${RDEPEND}
 	sys-devel/bison
 	sys-devel/flex
 "
-
-src_prepare() {
-	sed -i -e 's/INCLUDE(Qt5Macros)//g' cmake/modules/FindQt5.cmake || die "couldn't remove Qt5Macros include"
-}
-
-src_configure() {
-	export QT_SELECT=5
-	cmake-utils_src_configure
-}


### PR DESCRIPTION
sadly there is currently a compile error on the qt5 branch, but it should be safe nethertheless.