### PR TITLE
[kde-plasma/kcm-touchpad] 'frameworks' branch is now obsolete.

### DIFF
--- a/kde-plasma/kcm-touchpad/kcm-touchpad-9999.ebuild
+++ b/kde-plasma/kcm-touchpad/kcm-touchpad-9999.ebuild
@@ -4,7 +4,6 @@
 
 EAPI=5
 
-EGIT_BRANCH="frameworks"
 inherit kde5
 
 DESCRIPTION="KControl module for xf86-input-synaptics"


### PR DESCRIPTION
Package-Manager: portage-2.2.15