### PR TITLE
[eclass] Fix breakage by KDE_APPS_MINIMAL

### DIFF
--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -187,7 +187,8 @@ add_kdeapps_dep() {
 	elif [[ ${CATEGORY} = kde-apps ]]; then
 		version=${PV}
 	elif [[ -z "${version}" ]] ; then
-		version=${KDE_APPS_MINIMAL}
+		# In KDE applications world, 5.9999 > yy.mm.x
+		[[ ${PV} = 5.9999 ]] && version=5.9999 || version=${KDE_APPS_MINIMAL}
 	fi
 
 	_add_kdecategory_dep kde-apps "${1}" "${2}" "${version}"


### PR DESCRIPTION
commit 6c68003fda689d2240ea45df4614166655f6b8ae made live packages depend on
e.g. >=14.12 instead of 5.9999. This change helps out as long as there exist
packages with separate frameworks branch. Alternative would be to add 5.9999
version to add_kdeapps_dep calls in every affected ebuild.

Package-Manager: portage-2.2.15