### PR TITLE
[kde-plasma/kwin] kwin depends on <libinput-0.8.0

### DIFF
--- a/kde-plasma/kwin/kwin-5.2.0.1.ebuild
+++ b/kde-plasma/kwin/kwin-5.2.0.1.ebuild
@@ -58,7 +58,7 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-keysyms
 	wayland? (
 		$(add_plasma_dep kwayland)
-		dev-libs/libinput
+		<dev-libs/libinput-0.8.0
 		>=dev-libs/wayland-1.2
 		virtual/libudev
 		>=x11-libs/libxkbcommon-0.4.1

--- a/kde-plasma/kwin/kwin-5.2.9999.ebuild
+++ b/kde-plasma/kwin/kwin-5.2.9999.ebuild
@@ -56,7 +56,7 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-keysyms
 	wayland? (
 		$(add_plasma_dep kwayland)
-		dev-libs/libinput
+		<dev-libs/libinput-0.8.0
 		>=dev-libs/wayland-1.2
 		virtual/libudev
 		>=x11-libs/libxkbcommon-0.4.1


### PR DESCRIPTION
upstream discussion: https://bugs.kde.org/show_bug.cgi?id=342893

currently kwin-5.2.0.1 fails to build with >=libinput-0.8.0, also the 5.2 branch disables libinput support completly if >=0.8.0 is found, hence we should depen on <0.8.0. The 5.3 will most likely support >=0.8.0.

Package-Manager: portage-2.2.15