### PR TITLE
kde-base/*:4 updates to make kde-applications-14.12:4 installable

### DIFF
--- a/app-editors/kile/kile-9999.ebuild
+++ b/app-editors/kile/kile-9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	x11-misc/shared-mime-info
 "
 RDEPEND="${DEPEND}
-	$(add_kdebase_dep kdebase-data)
+	|| ( $(add_kdeapps_dep kdebase-data) $(add_kdebase_dep kdebase-data) )
 	$(add_kdebase_dep konsole)
 	|| (
-		$(add_kdebase_dep okular 'pdf?,postscript')
+		|| ( $(add_kdeapps_dep okular 'pdf?,postscript') $(add_kdebase_dep okular 'pdf?,postscript') )
 		app-text/acroread
 	)
 	virtual/latex-base

--- a/app-office/skrooge/skrooge-9999.ebuild
+++ b/app-office/skrooge/skrooge-9999.ebuild
@@ -27,7 +27,7 @@ DEPEND="
 	dev-qt/qtsql:4[sqlite]
 "
 RDEPEND="${DEPEND}
-	$(add_kdebase_dep kde-dev-scripts)
+	|| ( $(add_kdeapps_dep kde-dev-scripts) $(add_kdebase_dep kde-dev-scripts) )
 "
 
 # upstream does not ship tests in releases

--- a/kde-base/kdebase-startkde/kdebase-startkde-4.11.49.9999.ebuild
+++ b/kde-base/kdebase-startkde/kdebase-startkde-4.11.49.9999.ebuild
@@ -17,17 +17,16 @@ IUSE="+wallpapers"
 RDEPEND="
 	$(add_kdebase_dep kcminit)
 	$(add_kdebase_dep kdebase-runtime-meta)
-	wallpapers? ( $(add_kdebase_dep kde-wallpapers) )
-	$(add_kdebase_dep kfmclient)
-	$(add_kdebase_dep knotify)
-	$(add_kdebase_dep kreadconfig)
+	|| ( $(add_kdeapps_dep kfmclient) $(add_kdebase_dep kfmclient) )
+	|| ( $(add_kdeapps_dep knotify) $(add_kdebase_dep knotify) )
+	|| ( $(add_kdeapps_dep kreadconfig) $(add_kdebase_dep kreadconfig) )
 	$(add_kdebase_dep krunner)
 	$(add_kdebase_dep ksmserver)
 	$(add_kdebase_dep ksplash)
 	$(add_kdebase_dep kstartupconfig)
 	$(add_kdebase_dep kwin)
-	$(add_kdebase_dep phonon-kde)
-	$(add_kdebase_dep plasma-apps)
+	|| ( $(add_kdeapps_dep phonon-kde) $(add_kdebase_dep phonon-kde) )
+	|| ( $(add_kdeapps_dep plasma-apps) $(add_kdebase_dep plasma-apps) )
 	$(add_kdebase_dep plasma-workspace)
 	$(add_kdebase_dep systemsettings)
 	x11-apps/mkfontdir
@@ -37,6 +36,7 @@ RDEPEND="
 	x11-apps/xrdb
 	x11-apps/xsetroot
 	x11-apps/xset
+	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) $(add_kdebase_dep kde-wallpapers) ) )
 "
 
 KMEXTRACTONLY="

--- a/kde-base/kdelibs/kdelibs-4.9999.ebuild
+++ b/kde-base/kdelibs/kdelibs-4.9999.ebuild
@@ -97,7 +97,7 @@ RDEPEND="${COMMONDEPEND}
 	!<=kde-base/kcontrol-4.4.50:4
 	>=app-crypt/gnupg-2.0.11
 	app-misc/ca-certificates
-	$(add_kdebase_dep kde-env '' 4.14.3)
+	|| ( $(add_kdeapps_dep kde-env) $(add_kdebase_dep kde-env '' 4.14.3) )
 	sys-apps/dbus[X]
 	!aqua? (
 		udisks? ( sys-fs/udisks:2 )
@@ -111,7 +111,7 @@ RDEPEND="${COMMONDEPEND}
 PDEPEND="
 	$(add_kdebase_dep katepart '' 4.14.3)
 	|| (
-		$(add_kdebase_dep kfmclient '' 4.14.3)
+		|| ( $(add_kdeapps_dep kfmclient) $(add_kdebase_dep kfmclient '' 4.14.3) )
 		x11-misc/xdg-utils
 	)
 	handbook? (

--- a/kde-base/kdm/kdm-4.11.49.9999.ebuild
+++ b/kde-base/kdm/kdm-4.11.49.9999.ebuild
@@ -33,7 +33,7 @@ DEPEND="
 	systemd? ( sys-apps/systemd )
 "
 RDEPEND="${DEPEND}
-	$(add_kdebase_dep kdepasswd)
+	|| ( $(add_kdeapps_dep kdepasswd) $(add_kdebase_dep kdepasswd) )
 	$(add_kdebase_dep libkgreeter)
 	>=x11-apps/xinit-1.0.5-r2
 	x11-apps/xmessage

--- a/kde-base/plasma-workspace/plasma-workspace-4.11.49.9999.ebuild
+++ b/kde-base/plasma-workspace/plasma-workspace-4.11.49.9999.ebuild
@@ -59,7 +59,7 @@ DEPEND="${COMMONDEPEND}
 	x11-proto/renderproto
 "
 RDEPEND="${COMMONDEPEND}
-	$(add_kdebase_dep plasma-runtime)
+	|| ( $(add_kdeapps_dep plasma-runtime) $(add_kdebase_dep plasma-runtime) )
 "
 
 KMEXTRA="

--- a/kde-base/smokekde/smokekde-9999.ebuild
+++ b/kde-base/smokekde/smokekde-9999.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	akonadi? ( $(add_kdebase_dep kdepimlibs) )
 	attica? ( dev-libs/libattica )
 	kate? ( $(add_kdebase_dep kate) )
-	okular? ( $(add_kdebase_dep okular) )
+	okular? ( || ( $(add_kdeapps_dep okular) $(add_kdebase_dep okular) ) )
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-base/solid-actions-kcm/solid-actions-kcm-4.11.49.9999.ebuild
+++ b/kde-base/solid-actions-kcm/solid-actions-kcm-4.11.49.9999.ebuild
@@ -14,6 +14,6 @@ KEYWORDS=""
 IUSE="debug"
 
 RDEPEND="
-	$(add_kdebase_dep solid-runtime)
+	|| ( $(add_kdeapps_dep solid-runtime) $(add_kdebase_dep solid-runtime) )
 	!kde-base/solid:4
 "

--- a/kde-misc/homerun/homerun-9999.ebuild
+++ b/kde-misc/homerun/homerun-9999.ebuild
@@ -22,7 +22,7 @@ SLOT="4"
 IUSE="debug"
 
 DEPEND="
-	$(add_kdebase_dep libkonq)
+	|| ( $(add_kdeapps_dep libkonq) $(add_kdebase_dep libkonq) )
 	$(add_kdebase_dep libkworkspace)
 "
 RDEPEND="

--- a/kde-misc/kde-overlay-servicemenus/kde-overlay-servicemenus-0.1.ebuild
+++ b/kde-misc/kde-overlay-servicemenus/kde-overlay-servicemenus-0.1.ebuild
@@ -18,11 +18,11 @@ SLOT="4"
 IUSE="debug"
 
 RDEPEND="
-	$(add_kdebase_dep kdialog)
-	$(add_kdebase_dep kompare)
+	|| ( $(add_kdeapps_dep kdialog) $(add_kdebase_dep kdialog) )
+	|| ( $(add_kdeapps_dep kompare) $(add_kdebase_dep kompare) )
 	|| (
-		( $(add_kdebase_dep dolphin) )
-		( $(add_kdebase_dep konqueror) )
+		|| ( $(add_kdeapps_dep dolphin) $(add_kdebase_dep dolphin) )
+		|| ( $(add_kdeapps_dep konqueror) $(add_kdebase_dep konqueror) )
 	)
 "
 

--- a/kde-misc/publictransport/publictransport-0.11_beta.ebuild
+++ b/kde-misc/publictransport/publictransport-0.11_beta.ebuild
@@ -17,7 +17,7 @@ IUSE="debug gps protobuf marble test"
 
 DEPEND="
 	$(add_kdebase_dep plasma-workspace)
-	marble? ( $(add_kdebase_dep marble) )
+	marble? ( || ( $(add_kdeapps_dep marble) $(add_kdebase_dep marble) ) )
 	protobuf? ( dev-libs/protobuf )
 "
 RDEPEND="${DEPEND}

--- a/media-sound/amarok/amarok-9999.ebuild
+++ b/media-sound/amarok/amarok-9999.ebuild
@@ -38,7 +38,7 @@ fi
 COMMONDEPEND="
 	app-crypt/qca:2[qt4(+)]
 	$(add_kdebase_dep kdelibs 'nepomuk?,opengl?' 4.8.4)
-	$(add_kdebase_dep kdebase-kioslaves)
+	|| ( $(add_kdeapps_dep kdebase-kioslaves) $(add_kdebase_dep kdebase-kioslaves) )
 	>=media-libs/taglib-1.7[asf,mp4]
 	>=media-libs/taglib-extras-1.0.1
 	sys-libs/zlib
@@ -48,9 +48,9 @@ COMMONDEPEND="
 	>=dev-qt/qtscript-4.8:4
 	>=x11-libs/qtscriptgenerator-0.1.0
 	cdda? (
-		$(add_kdebase_dep libkcddb)
-		$(add_kdebase_dep libkcompactdisc)
-		$(add_kdebase_dep audiocd-kio)
+		|| ( $(add_kdeapps_dep libkcddb) $(add_kdebase_dep libkcddb) )
+		|| ( $(add_kdeapps_dep libkcompactdisc) $(add_kdebase_dep libkcompactdisc) )
+		|| ( $(add_kdeapps_dep audiocd-kio) $(add_kdebase_dep audiocd-kio) )
 	)
 	ipod? ( >=media-libs/libgpod-0.7.0[gtk] )
 	lastfm? ( >=media-libs/liblastfm-1.0.3 )
@@ -74,7 +74,7 @@ DEPEND="${COMMONDEPEND}
 "
 RDEPEND="${COMMONDEPEND}
 	!media-sound/amarok-utils
-	$(add_kdebase_dep phonon-kde)
+	|| ( $(add_kdeapps_dep phonon-kde) $(add_kdebase_dep phonon-kde) )
 "
 
 src_configure() {

--- a/media-sound/kaudiocreator/kaudiocreator-9999.ebuild
+++ b/media-sound/kaudiocreator/kaudiocreator-9999.ebuild
@@ -16,15 +16,15 @@ SLOT="4"
 IUSE="debug"
 
 COMMON_DEPEND="
-	$(add_kdebase_dep libkcddb)
-	$(add_kdebase_dep libkcompactdisc)
+	|| ( $(add_kdeapps_dep libkcddb) $(add_kdebase_dep libkcddb) )
+	|| ( $(add_kdeapps_dep libkcompactdisc) $(add_kdebase_dep libkcompactdisc) )
 	media-libs/libdiscid
 	>=media-libs/taglib-1.5
 "
 
 RDEPEND="${COMMON_DEPEND}
 	$(add_kdebase_dep kdelibs 'udev,udisks(+)')
-	$(add_kdebase_dep audiocd-kio)
+	|| ( $(add_kdeapps_dep audiocd-kio) $(add_kdebase_dep audiocd-kio) )
 "
 
 DEPEND="${COMMON_DEPEND}"

--- a/media-video/bangarang/bangarang-9999.ebuild
+++ b/media-video/bangarang/bangarang-9999.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-libs/soprano
 	$(add_kdebase_dep kdelibs 'nepomuk')
 	$(add_kdebase_dep nepomuk)
-	$(add_kdebase_dep audiocd-kio)
+	|| ( $(add_kdeapps_dep audiocd-kio) $(add_kdebase_dep audiocd-kio) )
 	media-libs/taglib
 	media-libs/phonon[qt4]
 	dev-qt/qtscript:4

--- a/media-video/kamoso/kamoso-9999.ebuild
+++ b/media-video/kamoso/kamoso-9999.ebuild
@@ -16,7 +16,7 @@ IUSE="debug nepomuk"
 
 DEPEND="
 	$(add_kdebase_dep kdelibs 'nepomuk?')
-	$(add_kdebase_dep libkipi)
+	|| ( $(add_kdeapps_dep libkipi) $(add_kdebase_dep libkipi) )
 	media-libs/phonon[qt4]
 	media-libs/qt-gstreamer
 "

--- a/media-video/kmplayer/kmplayer-9999.ebuild
+++ b/media-video/kmplayer/kmplayer-9999.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	)
 	npp? (
 		dev-libs/dbus-glib
-		$(add_kdebase_dep kreadconfig)
+		|| ( $(add_kdeapps_dep kreadconfig) $(add_kdebase_dep kreadconfig) )
 		>=x11-libs/gtk+-2.10.14:2
 		www-plugins/adobe-flash
 	)

--- a/net-p2p/ktorrent/ktorrent-9999.ebuild
+++ b/net-p2p/ktorrent/ktorrent-9999.ebuild
@@ -58,7 +58,7 @@ RDEPEND="${COMMONDEPEND}
 	ipfilter? (
 		app-arch/bzip2
 		app-arch/unzip
-		$(add_kdebase_dep kdebase-kioslaves)
+		|| ( $(add_kdeapps_dep kdebase-kioslaves) $(add_kdebase_dep kdebase-kioslaves) )
 	)
 	kross? ( $(add_kdebase_dep krosspython) )
 "

--- a/www-client/rekonq/rekonq-4.9999.ebuild
+++ b/www-client/rekonq/rekonq-4.9999.ebuild
@@ -32,10 +32,9 @@ DEPEND="
 		dev-libs/qoauth
 	)
 "
-RDEPEND="
-	${DEPEND}
-	$(add_kdebase_dep kdebase-kioslaves)
-	$(add_kdebase_dep keditbookmarks)
+RDEPEND="${DEPEND}
+	|| ( $(add_kdeapps_dep kdebase-kioslaves) $(add_kdebase_dep kdebase-kioslaves) )
+	|| ( $(add_kdeapps_dep keditbookmarks) $(add_kdebase_dep keditbookmarks) )
 "
 
 src_configure() {


### PR DESCRIPTION
The recently added 4.11.16 and 4.14.5 ebuilds were edited in place together with the respective live ebuilds.

I dropped kde-misc/krusader from my PR after noticing the overlay live ebuild had it already fixed, albeit not using eclass functions.

As far as overlay ebuilds are concerned, this PR should now be complete. An other example would be app-emulation/winetricks from tree which has an optional kde-base/kdialog dependency, I did not check all those.

Edit: Rearranged my PR so that this one covers only overlay changes.