### PR TITLE
[kde-apps/kdialog] fix RDEPEND for 5.9999 ebuild

### DIFF
--- a/kde-apps/kdialog/kdialog-5.9999.ebuild
+++ b/kde-apps/kdialog/kdialog-5.9999.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 
 S=${WORKDIR}/${P}/${PN}
 
-RDEPEND="$(add_frameworks_dep kde4libs)
+RDEPEND="$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-qt/qtdbus:5"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Package-Manager: portage-2.2.15