### PR TITLE
[kde-apps/knetwalk] VIRTUALX_REQUIRED="test"

### DIFF
--- a/kde-apps/knetwalk/knetwalk-9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-9999.ebuild
@@ -6,6 +6,7 @@ EAPI=5
 
 KDE_HANDBOOK="true"
 KDE_TEST="true"
+VIRTUALX_REQUIRED="test"
 inherit kde5
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"


### PR DESCRIPTION
Package-Manager: portage-2.2.14