### PR TITLE
[sets] Add missing version for kde-apps/kgeography

### DIFF
--- a/sets/kdeedu-live
+++ b/sets/kdeedu-live
@@ -2,7 +2,7 @@
 ~kde-apps/blinken-9999
 ~kde-apps/kalgebra-9999
 ~kde-apps/kanagram-9999
-~kde-apps/kgeography
+~kde-apps/kgeography-9999
 ~kde-apps/khangman-9999
 ~kde-apps/kiten-9999
 ~kde-apps/klettres-9999


### PR DESCRIPTION
Fixes
> /var/lib/layman/kde/sets/kdeedu-live: Validation failed at line: 5, data ~kde-apps/kgeography