### PR TITLE
[RFC] kde-accounts-kcm: add RDEPEND for various services

### DIFF
--- a/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
+++ b/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://community.kde.org/Real-Time_Communication_and_Collaboration"
 
 LICENSE="LGPL-2.1"
 KEYWORDS=""
-IUSE=""
+IUSE="experimental gadu haze icq meanwhile steam yahoo xmpp"
 
 DEPEND="
 	$(add_frameworks_dep kcodecs)
@@ -30,7 +30,33 @@ DEPEND="
 	net-libs/telepathy-qt[qt5]
 "
 
+# for now we depend on all services we want to use, later we could remove some depending on USE flags.
+#  haze is used for multiple services like steam, sametime, yahoo and not just only for icq, so we list it explicitly
+#  we also have to enable some services inside pidgin directly
+#    gadu:      used for gadugadu
+#    meanwhile: used for IBM sametime
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kaccounts-providers)
+	net-im/telepathy-connection-managers[icq?,xmpp?,yahoo?]
+	gadu? ( net-im/pidgin[gadu] )
+	haze? ( net-voip/telepathy-haze )
+	meanwhile? ( net-im/pidgin[meanwhile] )
+	steam? ( x11-plugins/pidgin-opensteamworks )
 	!net-im/ktp-accounts-kcm
 "
+
+REQUIRED_USE="
+	gadu? ( haze )
+	meanwhile? ( haze )
+	steam? ( experimental haze )
+"
+
+src_prepare() {
+	if use experimental ; then
+		mv "${S}"/data/kaccounts/disabled/*.in "${S}"/data/kaccounts/ || die "couldn't enable experimental services"
+
+		ewarn "Experimental providers are enabled. Most of them aren't integrated nicely and may require additional steps for account creation." \
+			"Use at your own risk!"
+	fi
+	kde5_src_prepare
+}

--- a/kde-apps/ktp-accounts-kcm/metadata.xml
+++ b/kde-apps/ktp-accounts-kcm/metadata.xml
@@ -2,4 +2,11 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
+	<use>
+		<flag name="experimental">Enables disabled services</flag>
+		<flag name="gadu">Enable Gadu Gadu protocol support</flag>
+		<flag name="haze">Enable support for <pkg>net-im/pidgin</pkg> provided protocols</flag>
+		<flag name="meanwhile">Enable the Sametime protocol handler.</flag>
+		<flag name="steam">Enable the Opensteamworks protocol support</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
I am not sure if this is the best way to handle this. Ideally these flags should be handled inside net-im/telepathy-connection-managers or net-voip/telepathy-haze so that we can simply use? depend o them.

Package-Manager: portage-2.2.17