### PR TITLE
[kde-apps/dolphin] Switch branch to master

### DIFF
--- a/kde-apps/dolphin/dolphin-5.9999.ebuild
+++ b/kde-apps/dolphin/dolphin-5.9999.ebuild
@@ -4,7 +4,6 @@
 
 EAPI=5
 
-EGIT_BRANCH="frameworks"
 KDE_HANDBOOK="true"
 KDE_TEST="true"
 VIRTUALX_REQUIRED="test"


### PR DESCRIPTION
Now that Dolphin was split-off into its own repo, `master` is where the action happens.