### PR TITLE
[kde-apps/lokalize] Add missing RDEP dev-python/translate-toolkit

### DIFF
--- a/kde-apps/lokalize/lokalize-9999.ebuild
+++ b/kde-apps/lokalize/lokalize-9999.ebuild
@@ -34,6 +34,7 @@ DEPEND="${PYTHON_DEPS}
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep pykde5 "${PYTHON_USEDEP}")
+	dev-python/translate-toolkit[${PYTHON_USEDEP}]
 	!kde-apps/lokalize:4
 	!kde-base/lokalize
 "


### PR DESCRIPTION
The `Translate OpenDocument` button in Lokalize shows the error message `Install translate-toolkit package and retry`.
This PR fixes this.