### PR TITLE
[kde-plasma/milou] [kde-apps/dolphin] Add missing KF5/Qt5 dependencies

### DIFF
--- a/kde-apps/dolphin/dolphin-9999.ebuild
+++ b/kde-apps/dolphin/dolphin-9999.ebuild
@@ -38,6 +38,7 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
+	dev-qt/qtconcurrent:5
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5

--- a/kde-plasma/milou/milou-9999.ebuild
+++ b/kde-plasma/milou/milou-9999.ebuild
@@ -16,10 +16,14 @@ IUSE=""
 DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep krunner)
 	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep plasma)
 	dev-qt/qtdeclarative:5
 	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
 "
 RDEPEND="${DEPEND}
 	!kde-base/milou


### PR DESCRIPTION
According to upstream commits

milou: a53085390be6a1f6405abd93694cd612841a60fc
dolphin: adeaab9745c681e99b6bf7b3144a6fc0878a387f

Package-Manager: portage-2.2.18