### PR TITLE
[kaccounts,ktp] fix some deps and build issues

### DIFF
--- a/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
@@ -13,6 +13,7 @@ LICENSE="LGPL-2.1"
 IUSE=""
 
 DEPEND="
+	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
@@ -28,3 +29,10 @@ DEPEND="
 	net-libs/signond
 "
 RDEPEND="${DEPEND}"
+
+src_configure() {
+	mycmakeargs=(
+		-DCMAKE_DISABLE_FIND_PACKAGE_KF5Akonadi=ON
+	)
+	kde5_src_configure
+}

--- a/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
@@ -11,7 +11,9 @@ HOMEPAGE="https://community.kde.org/KTp"
 LICENSE="LGPL-2.1"
 IUSE=""
 
-DEPEND=""
+DEPEND="
+	net-libs/libaccounts-glib
+"
 RDEPEND="
 	net-im/telepathy-connection-managers[xmpp]
 	net-libs/signon-ui

--- a/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
+++ b/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
@@ -13,12 +13,13 @@ LICENSE="LGPL-2.1"
 KEYWORDS=""
 IUSE="experimental"
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcodecs)
+	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kitemviews)
-	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
@@ -27,13 +28,20 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtwidgets:5
+	net-libs/accounts-qt
+	net-libs/signond
 	net-libs/telepathy-qt[qt5]
 "
-
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kio)
+	net-libs/libaccounts-glib
+"
+RDEPEND="${COMMON_DEPEND}
 	$(add_kdeapps_dep kaccounts-providers)
 	net-im/telepathy-connection-managers
-	experimental? ( net-im/telepathy-connection-managers[steam] )
 	!net-im/ktp-accounts-kcm
 "
 

--- a/kde-apps/ktp-auth-handler/ktp-auth-handler-9999.ebuild
+++ b/kde-apps/ktp-auth-handler/ktp-auth-handler-9999.ebuild
@@ -13,15 +13,16 @@ LICENSE="LGPL-2.1"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep kaccounts-integration)
 	$(add_kdeapps_dep ktp-common-internals)
-	app-crypt/qca[openssl,qt5]
+	app-crypt/qca[qt5]
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
@@ -30,7 +31,11 @@ DEPEND="
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]
 "
-
-RDEPEND="${DEPEND}
+DEPEND="
+	$(add_frameworks_dep kdewebkit)
+	${COMMON_DEPEND}
+"
+RDEPEND="${COMMON_DEPEND}
+	app-crypt/qca[openssl]
 	!net-im/ktp-auth-handler
 "

--- a/kde-apps/ktp-common-internals/ktp-common-internals-9999.ebuild
+++ b/kde-apps/ktp-common-internals/ktp-common-internals-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 KDE_DOXYGEN="true"
-KDE_TEST="true"
+KDE_TEST="false"
 inherit kde5
 
 DESCRIPTION="KDE Telepathy common library"
@@ -13,10 +13,10 @@ HOMEPAGE="http://community.kde.org/Real-Time_Communication_and_Collaboration"
 
 LICENSE="LGPL-2.1"
 KEYWORDS=""
-IUSE="otr"
+IUSE="otr sso"
 
 # todo: kdepimlibs
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
@@ -31,23 +31,32 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	$(add_kdeapps_dep kaccounts-integration)
 	dev-qt/qtdbus:5
 	dev-qt/qtdeclarative:5
 	dev-qt/qtgui:5
+	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
 	net-libs/accounts-qt
 	net-libs/telepathy-logger-qt:5
 	>=net-libs/telepathy-qt-0.9.5[qt5]
+	sso? (
+		$(add_kdeapps_dep kaccounts-integration)
+		net-libs/accounts-qt
+	)
 	otr? (
 		dev-libs/libgcrypt:0=
 		>=net-libs/libotr-4.0.0
 	)
 "
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kio)
+	dev-qt/qtnetwork:5
+"
+RDEPEND="
+	${COMMON_DEPEND}
 	!net-im/ktp-common-internals
 "
 
@@ -56,6 +65,8 @@ PATCHES=( "${FILESDIR}/${PN}-tests-optional.patch" )
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package doc Doxygen)
+		$(cmake-utils_use_find_package sso KAccounts)
+		$(cmake-utils_use_find_package sso AccountsQt5)
 		$(cmake-utils_use_find_package otr Libgcrypt)
 		$(cmake-utils_use_find_package otr LibOTR)
 	)

--- a/kde-apps/ktp-common-internals/metadata.xml
+++ b/kde-apps/ktp-common-internals/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<herd>kde</herd>
 	<use>
+		<flag name="sso">Enable support for Single sign-on through KAccounts</flag>
 		<flag name="otr">Enable support for encrypted conversations using Off-The-Records messaging</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/ktp-contact-list/ktp-contact-list-9999.ebuild
+++ b/kde-apps/ktp-contact-list/ktp-contact-list-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
@@ -33,7 +33,14 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	net-libs/telepathy-qt[qt5]
 "
-
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep knotifyconfig)
+	dev-qt/qtxml:5
+"
+RDEPEND="
+	${COMMON_DEPEND}
 	!net-im/ktp-contact-list
 "

--- a/kde-apps/ktp-contact-runner/ktp-contact-runner-9999.ebuild
+++ b/kde-apps/ktp-contact-runner/ktp-contact-runner-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="LGPL-2.1"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep krunner)
@@ -23,7 +23,10 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	net-libs/telepathy-qt[qt5]
 "
-
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kservice)
+"
+RDEPEND="${COMMON_DEPEND}
 	!net-im/ktp-contact-runner
 "

--- a/kde-apps/ktp-desktop-applets/ktp-desktop-applets-9999.ebuild
+++ b/kde-apps/ktp-desktop-applets/ktp-desktop-applets-9999.ebuild
@@ -13,13 +13,14 @@ LICENSE="GPL-2 LGPL-2.1"
 KEYWORDS=""
 IUSE=""
 
+COMMON_DEPEND="
+	$(add_frameworks_dep kwindowsystem)
+	dev-qt/qtdeclarative:5
+"
 DEPEND="
+	${COMMON_DEPEND}
 	$(add_frameworks_dep plasma)
 "
-RDEPEND="${DEPEND}
-	$(add_frameworks_dep kdeclarative)
-	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtquickcontrols:5
+RDEPEND="${COMMON_DEPEND}
 	!net-im/ktp-desktop-applets
 "

--- a/kde-apps/ktp-kded-module/ktp-kded-module-9999.ebuild
+++ b/kde-apps/ktp-kded-module/ktp-kded-module-9999.ebuild
@@ -4,7 +4,6 @@
 
 EAPI=5
 
-MY_P=${PN/kded/kded-integration}-${PV}
 inherit kde5
 
 DESCRIPTION="KDE Telepathy workspace integration"
@@ -14,7 +13,7 @@ LICENSE="LGPL-2.1"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
@@ -32,9 +31,13 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	net-libs/telepathy-qt[qt5]
 "
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kwidgetsaddons)
+"
+RDEPEND="
+	${COMMON_DEPEND}
 	$(add_kdeapps_dep signon-kwallet-extension)
 	!net-im/ktp-kded-module
 "
-
-[[ ${PV} == *9999* ]] || S=${WORKDIR}/${MY_P}

--- a/kde-apps/ktp-send-file/ktp-send-file-9999.ebuild
+++ b/kde-apps/ktp-send-file/ktp-send-file-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="LGPL-2.1"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
@@ -25,7 +25,12 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	net-libs/telepathy-qt[qt5]
 "
-RDEPEND="${DEPEND}
+DEPEND="
+	${COMMON_DEPEND}
+	$(add_frameworks_dep kcmutils)
+"
+RDEPEND="
+	${COMMON_DEPEND}
 	$(add_kdeapps_dep ktp-contact-list)
 	$(add_kdeapps_dep ktp-filetransfer-handler)
 	!net-im/ktp-send-file

--- a/kde-apps/ktp-text-ui/ktp-text-ui-9999.ebuild
+++ b/kde-apps/ktp-text-ui/ktp-text-ui-9999.ebuild
@@ -16,7 +16,6 @@ IUSE=""
 DEPEND="
 	$(add_frameworks_dep karchive)
 	$(add_frameworks_dep kcmutils)
-	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)


### PR DESCRIPTION
this basically handleds optional dependencies more explicitly and fixes the ktp-common-internals build issue.

Also it adds some runtime only and build time only deps for some packages.

TODO:
- [x] better USE flags names for kpeople, kaccounts support
- [x] clarify use test situation in eclass
- [x] semantic-desktop USE flag in kaccounts-integration