### PR TITLE
Patch inside src_prepare after eclass change

### DIFF
--- a/kde-apps/gwenview/gwenview-9999.ebuild
+++ b/kde-apps/gwenview/gwenview-9999.ebuild
@@ -52,7 +52,11 @@ DEPEND="
 
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}"-9999-tests-optional.patch )
+src_prepare() {
+	epatch "${FILESDIR}/${PN}"-9999-tests-optional.patch
+
+	kde5_src_prepare
+}
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -25,7 +25,11 @@ RDEPEND="${DEPEND}
 	$(add_plasma_dep plasma-workspace)
 "
 
-PATCHES=( "${FILESDIR}/${PN}-9999-tests-optional.patch" )
+src_prepare() {
+	epatch "${FILESDIR}/${PN}"-9999-tests-optional.patch
+
+	kde5_src_prepare
+}
 
 [[ ${KDE_BUILD_TYPE} != live ]] && S=${WORKDIR}/${MY_P}
 


### PR DESCRIPTION
`comment_add_subdirectory tests` otherwise happens before and thus breaks tests-optional patches. Two more to get upstream.