### PR TITLE
[kde-apps] Add kf5 snapshots

### DIFF
--- a/kde-apps/dolphin/dolphin-15.04.50_pre20150515.ebuild
+++ b/kde-apps/dolphin/dolphin-15.04.50_pre20150515.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+KDE_HANDBOOK="true"
+KDE_TEST="true"
+VIRTUALX_REQUIRED="test"
+inherit kde5 git-r3
+
+DESCRIPTION="Plasma filemanager focusing on usability"
+HOMEPAGE="http://dolphin.kde.org http://www.kde.org/applications/system/dolphin"
+KEYWORDS=" ~amd64 ~x86"
+IUSE="semantic-desktop"
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="8b12612bbf8ae4500a84634087a074d94a495eec"
+SRC_URI=""
+
+DEPEND="
+	$(add_frameworks_dep kactivities)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcodecs)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kjobwidgets)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep kparts)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep solid)
+	dev-qt/qtconcurrent:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	media-libs/phonon[qt5]
+	semantic-desktop? (
+		$(add_plasma_dep baloo)
+		$(add_plasma_dep baloo-widgets)
+		$(add_plasma_dep kfilemetadata)
+	)
+"
+RDEPEND="${DEPEND}
+	$(add_plasma_dep kio-extras)
+"
+
+RESTRICT="test"
+
+src_unpack() {
+	git-r3_src_unpack
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_with semantic-desktop KF5Baloo)
+		$(cmake-utils_use_with semantic-desktop KF5BalooWidgets)
+		$(cmake-utils_use_with semantic-desktop KF5FileMetaData)
+	)
+
+	kde5_src_configure
+}

--- a/kde-apps/dolphin/dolphin-15.04.50_pre20150515.ebuild
+++ b/kde-apps/dolphin/dolphin-15.04.50_pre20150515.ebuild
@@ -12,7 +12,7 @@ inherit kde5 git-r3
 DESCRIPTION="Plasma filemanager focusing on usability"
 HOMEPAGE="http://dolphin.kde.org http://www.kde.org/applications/system/dolphin"
 KEYWORDS=" ~amd64 ~x86"
-IUSE="semantic-desktop"
+IUSE="semantic-desktop thumbnail"
 
 EGIT_REPO_URI="git://anongit.kde.org/${PN}"
 EGIT_COMMIT="8b12612bbf8ae4500a84634087a074d94a495eec"
@@ -56,6 +56,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kio-extras)
+	thumbnail? (
+		>=kde-apps/ffmpegthumbs-15.04.50_pre20150515
+		>=kde-apps/thumbnailers-15.04.50_pre20150515
+	)
 "
 
 RESTRICT="test"

--- a/kde-apps/dolphin/dolphin-9999.ebuild
+++ b/kde-apps/dolphin/dolphin-9999.ebuild
@@ -12,7 +12,7 @@ inherit kde5
 DESCRIPTION="Plasma filemanager focusing on usability"
 HOMEPAGE="http://dolphin.kde.org http://www.kde.org/applications/system/dolphin"
 KEYWORDS=""
-IUSE="semantic-desktop"
+IUSE="semantic-desktop thumbnail"
 
 DEPEND="
 	$(add_frameworks_dep kactivities)
@@ -53,6 +53,10 @@ DEPEND="
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kio-extras)
 	$(add_kdeapps_dep libkonq '' 5.9999)
+	thumbnail? (
+		$(add_kdeapps_dep ffmpegthumbs '' 5.9999)
+		$(add_kdeapps_dep thumbnailers '' 5.9999)
+	)
 "
 
 RESTRICT="test"

--- a/kde-apps/ffmpegthumbs/ffmpegthumbs-15.04.50_pre20150515.ebuild
+++ b/kde-apps/ffmpegthumbs/ffmpegthumbs-15.04.50_pre20150515.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+inherit kde5 git-r3
+
+DESCRIPTION="A FFmpeg based thumbnail Generator for Video Files"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="c06602ff79ac5e3eb94cef2c680135caa1a3c53c"
+SRC_URI=""
+
+RDEPEND="
+	$(add_frameworks_dep kio)
+	dev-qt/qtgui:5
+	virtual/ffmpeg"
+
+DEPEND="
+	${RDEPEND}
+	virtual/pkgconfig
+"

--- a/kde-apps/gwenview/gwenview-15.04.1.ebuild
+++ b/kde-apps/gwenview/gwenview-15.04.1.ebuild
@@ -14,11 +14,8 @@ HOMEPAGE="
 	http://gwenview.sourceforge.net/
 "
 KEYWORDS=" ~amd64 ~x86"
-IUSE="semantic-desktop"
+IUSE="kipi raw semantic-desktop"
 
-# Not released: USE="kipi raw"
-# kipi? ( $(add_kdeapps_dep libkipi '' 5.9999) )
-# raw? ( $(add_kdeapps_dep libkdcraw '' 5.9999) )
 DEPEND="
 	$(add_frameworks_dep kactivities)
 	$(add_frameworks_dep kcompletion)
@@ -48,17 +45,18 @@ DEPEND="
 	media-libs/phonon[qt5]
 	virtual/jpeg:0
 	x11-libs/libX11
+	kipi? ( $(add_kdeapps_dep libkipi '' 5.9999) )
+	raw? ( $(add_kdeapps_dep libkdcraw '' 5.9999) )
 	semantic-desktop? ( $(add_plasma_dep baloo) )
 "
 
 RDEPEND="${DEPEND}"
 
 src_configure() {
-#	Not released:
-#	local mycmakeargs=(
-#		$(cmake-utils_use_find_package kipi KF5Kipi)
-#		$(cmake-utils_use_find_package raw KF5KDcraw)
-#	)
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package kipi KF5Kipi)
+		$(cmake-utils_use_find_package raw KF5KDcraw)
+	)
 
 	# Workaround for bug #479510
 	if [[ -e ${EPREFIX}/usr/include/${CHOST}/jconfig.h ]]; then

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-15.04.1.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-15.04.1.ebuild
@@ -19,7 +19,10 @@ RDEPEND="
 	$(add_kdeapps_dep kgamma)
 	$(add_kdeapps_dep kolourpaint)
 	$(add_kdeapps_dep kruler)
-	$(add_kdeapps_dep ksnapshot)
+	|| (
+		$(add_kdeapps_dep ksnapshot)
+		$(add_kdeapps_dep kscreengenie)
+	)
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_kdeapps_dep libkipi)

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-15.04.49.9999.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-15.04.49.9999.ebuild
@@ -19,7 +19,10 @@ RDEPEND="
 	$(add_kdeapps_dep kgamma)
 	$(add_kdeapps_dep kolourpaint)
 	$(add_kdeapps_dep kruler)
-	$(add_kdeapps_dep ksnapshot)
+	|| (
+		$(add_kdeapps_dep ksnapshot)
+		$(add_kdeapps_dep kscreengenie)
+	)
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_kdeapps_dep libkipi)

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
@@ -19,7 +19,10 @@ RDEPEND="
 	$(add_kdeapps_dep kgamma)
 	$(add_kdeapps_dep kolourpaint)
 	$(add_kdeapps_dep kruler)
-	$(add_kdeapps_dep ksnapshot)
+	|| (
+		$(add_kdeapps_dep ksnapshot)
+		$(add_kdeapps_dep kscreengenie)
+	)
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_kdeapps_dep libkipi)

--- a/kde-apps/libkdcraw/libkdcraw-15.04.50_pre20150515.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-15.04.50_pre20150515.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+inherit kde5 git-r3
+
+DESCRIPTION="KDE digital camera raw image library wrapper"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="9850efbb21df2f10e66267876574ff8918a642b3"
+SRC_URI=""
+
+DEPEND="
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep threadweaver)
+	>=media-libs/libraw-0.16:=
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+RDEPEND="${DEPEND}"
+
+src_unpack() {
+	git-r3_src_unpack
+}

--- a/kde-apps/libkexiv2/libkexiv2-15.04.50_pre20150515.ebuild
+++ b/kde-apps/libkexiv2/libkexiv2-15.04.50_pre20150515.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+inherit kde5 git-r3
+
+DESCRIPTION="KDE Image Plugin Interface: an exiv2 library wrapper"
+KEYWORDS=" ~amd64 ~x86"
+IUSE="+xmp"
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="bba8e5f2ccaa0047a81c376e0d2efd0f57b3e8de"
+SRC_URI=""
+
+DEPEND="
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep khtml)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep ktextwidgets)
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	>=media-gfx/exiv2-0.24:=[xmp=]
+"
+RDEPEND="${DEPEND}"
+
+src_unpack() {
+	git-r3_src_unpack
+}

--- a/kde-apps/libkipi/libkipi-15.04.50_pre20150515.ebuild
+++ b/kde-apps/libkipi/libkipi-15.04.50_pre20150515.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+KDE_TEST="true"
+inherit kde5 git-r3
+
+DESCRIPTION="A library for image plugins accross KDE applications"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="1a656885dd94a1d2db4e99efe066f5296f8c114c"
+SRC_URI=""
+
+DEPEND="
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kxmlgui)
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+
+RDEPEND="${DEPEND}"
+
+src_unpack() {
+	git-r3_src_unpack
+}

--- a/kde-apps/okular/okular-15.04.50_pre20150515.ebuild
+++ b/kde-apps/okular/okular-15.04.50_pre20150515.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+KDE_HANDBOOK="true"
+KDE_PUNT_BOGUS_DEPS="true"
+EGIT_BRANCH="frameworks"
+inherit kde5 git-r3
+
+DESCRIPTION="Universal document viewer based on KPDF"
+HOMEPAGE="http://okular.kde.org http://www.kde.org/applications/graphics/okular"
+KEYWORDS=" ~amd64 ~x86"
+IUSE="chm crypt dpi djvu ebook +jpeg +pdf +postscript +tiff"
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="8452e86b657f05d92f5e2a8dae6e179b5dd2ceb3"
+SRC_URI=""
+
+# TODO:
+# * Deactivated dependency media-libs/qimageblitz as there is no Qt5 version
+#   yet
+DEPEND="
+	$(add_frameworks_dep kactivities)
+	$(add_frameworks_dep karchive)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep khtml)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kjs)
+	$(add_frameworks_dep kparts)
+	$(add_frameworks_dep kwallet)
+	$(add_frameworks_dep threadweaver)
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwidgets:5
+	media-libs/freetype
+	media-libs/phonon[qt5]
+	sys-devel/gettext
+	sys-libs/zlib
+	chm? ( dev-libs/chmlib )
+	crypt? ( app-crypt/qca:2[qt5] )
+	djvu? ( app-text/djvu )
+	dpi? ( $(add_plasma_dep libkscreen) )
+	ebook? ( app-text/ebook-tools )
+	jpeg? (
+		>=kde-apps/libkexiv2-15.04.50_pre20150515:5
+		virtual/jpeg:0
+	)
+	pdf? ( app-text/poppler[qt5,-exceptions(-)] )
+	postscript? ( app-text/libspectre )
+	tiff? ( media-libs/tiff:0 )
+"
+RDEPEND="${DEPEND}"
+
+RESTRICT=test
+# test 2: parttest hangs
+
+src_unpack() {
+	git-r3_src_unpack
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package chm CHM)
+		$(cmake-utils_use_find_package crypt Qca-qt5)
+		$(cmake-utils_use_find_package djvu DjVuLibre)
+		$(cmake-utils_use_find_package dpi KF5Screen)
+		$(cmake-utils_use_find_package ebook EPub)
+		$(cmake-utils_use_find_package jpeg KF5KExiv2)
+		$(cmake-utils_use_find_package pdf Poppler)
+		$(cmake-utils_use_find_package postscript LibSpectre)
+		$(cmake-utils_use_find_package tiff)
+	)
+
+	kde5_src_configure
+}

--- a/kde-apps/thumbnailers/thumbnailers-15.04.50_pre20150515.ebuild
+++ b/kde-apps/thumbnailers/thumbnailers-15.04.50_pre20150515.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+KMNAME="kdegraphics-thumbnailers"
+EGIT_BRANCH="frameworks"
+inherit kde5 git-r3
+
+DESCRIPTION="Thumbnail generators for PDF/PS and RAW files"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+EGIT_REPO_URI="git://anongit.kde.org/${KMNAME}"
+EGIT_COMMIT="fa9e70cd5950e36608211507f53f8bd1d12e074f"
+SRC_URI=""
+
+DEPEND="
+	>=kde-apps/libkdcraw-15.04.50_pre20150515:5
+	>=kde-apps/libkexiv2-15.04.50_pre20150515:5
+	$(add_frameworks_dep kio)
+	dev-qt/qtgui:5
+"
+
+RDEPEND="${DEPEND}"
+
+if [[ ${KDE_BUILD_TYPE} != live ]]; then
+	S="${WORKDIR}/${P}"
+fi
+
+src_unpack() {
+	git-r3_src_unpack
+}

--- a/kde-plasma/baloo-widgets/baloo-widgets-5.3.50_pre20150515.ebuild
+++ b/kde-plasma/baloo-widgets/baloo-widgets-5.3.50_pre20150515.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit kde5 git-r3
+
+DESCRIPTION="Widget library for baloo"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="331c8595ecadf85f5626123c2e5fc3facae01798"
+SRC_URI=""
+
+DEPEND="
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_plasma_dep baloo)
+	$(add_plasma_dep kfilemetadata)
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+RDEPEND="${DEPEND}
+	!kde-base/baloo-widgets:4
+"
+
+src_unpack() {
+	git-r3_src_unpack
+}

--- a/profiles/package.mask/kde-apps-15.04.50
+++ b/profiles/package.mask/kde-apps-15.04.50
@@ -1,0 +1,8 @@
+# Mask snapshots
+=kde-apps/dolphin-15.04.50*
+=kde-apps/ffmpegthumbs-15.04.50*
+=kde-apps/libkdcraw-15.04.50*
+=kde-apps/libkexiv2-15.04.50*
+=kde-apps/libkipi-15.04.50*
+=kde-apps/okular-15.04.50*
+=kde-apps/thumbnailers-15.04.50*

--- a/profiles/package.mask/kde-plasma-5.3.50
+++ b/profiles/package.mask/kde-plasma-5.3.50
@@ -1,0 +1,2 @@
+# Mask snapshots
+=kde-plasma/baloo-widgets-5.3.50*


### PR DESCRIPTION
This is a suggestion on how adding a few snapshots could improve the kf5 side of things (dolphin:5 with konsolepart:5; raw and kipi support in gwenview etc.; also thumbnails for dolphin:5). It is compatible with meta ebuilds and only needs a small change in kdegraphics-meta.