### PR TITLE
[kde-frameworks/kwallet] Add USE=gpg and missing DEPENDs

### DIFF
--- a/kde-apps/gpgmepp/gpgmepp-9999.ebuild
+++ b/kde-apps/gpgmepp/gpgmepp-9999.ebuild
@@ -11,7 +11,9 @@ LICENSE="LGPL-2+"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+RDEPEND="
 	app-crypt/gpgme:=
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+"

--- a/kde-frameworks/kwallet/kwallet-9999.ebuild
+++ b/kde-frameworks/kwallet/kwallet-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 DESCRIPTION="Framework providing desktop-wide storage for passwords"
 LICENSE="LGPL-2+"
 KEYWORDS=""
-IUSE=""
+IUSE="gpg"
 
 RDEPEND="
 	$(add_frameworks_dep kconfig)
@@ -25,5 +25,17 @@ RDEPEND="
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
+	gpg? (
+		$(add_kdeapps_dep gpgmepp)
+		app-crypt/gpgme
+	)
 "
 DEPEND="${RDEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package gpg Gpgme)
+		$(cmake-utils_use_find_package gpg Gpgmepp)
+	)
+	kde5_src_configure
+}

--- a/kde-frameworks/kwallet/metadata.xml
+++ b/kde-frameworks/kwallet/metadata.xml
@@ -2,4 +2,5 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
+	<use><flag name="gpg">Support wallets with GnuPG encryption additionally to default blowfish-encrypted file</flag></use>
 </pkgmetadata>


### PR DESCRIPTION
kde-frameworks/kwallet-5.10.0 needs a similar backport because it does the same find_package calls and links to it even though there is no gpgmepp-5.10.0 yet.

Package-Manager: portage-2.2.19