### PR TITLE
Add kf5-based colour management stuff

### DIFF
--- a/kde-misc/colord-kde/colord-kde-9999.ebuild
+++ b/kde-misc/colord-kde/colord-kde-9999.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="Provides interfaces and session daemon to colord"
+HOMEPAGE="http://projects.kde.org/projects/playground/graphics/colord-kde"
+#SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep plasma)
+	media-libs/lcms:2
+	dev-qt/qtdbus:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	x11-libs/libxcb
+	x11-libs/libX11
+"
+RDEPEND="${DEPEND}
+	x11-misc/colord
+"
+
+pkg_postinst() {
+	kde5_pkg_postinst
+	if ! has_version "gnome-extra/gnome-color-manager"; then
+		elog "You may want to install gnome-extra/gnome-color-manager to add support for"
+		elog "colorhug calibration devices."
+	fi
+}

--- a/kde-misc/colord-kde/metadata.xml
+++ b/kde-misc/colord-kde/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>

--- a/kde-misc/kolor-manager/kolor-manager-5.9999.ebuild
+++ b/kde-misc/kolor-manager/kolor-manager-5.9999.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+inherit kde5
+
+DESCRIPTION="KControl module for Oyranos CMS cross desktop settings"
+HOMEPAGE="http://www.oyranos.org/wiki/index.php?title=Kolor-manager"
+
+LICENSE="BSD-2"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep ki18n)
+	dev-qt/qtwidgets:5
+	media-gfx/synnefo[qt5]
+	=media-libs/oyranos-9999
+	media-libs/libXcm
+	x11-libs/libXrandr
+"
+RDEPEND="${DEPEND}"

--- a/kde-misc/kolor-manager/kolor-manager-9999.ebuild
+++ b/kde-misc/kolor-manager/kolor-manager-9999.ebuild
@@ -15,7 +15,8 @@ SLOT="4"
 IUSE="debug"
 
 DEPEND="
-	>=media-libs/oyranos-0.9.5
+	media-gfx/synnefo[-qt5]
+	=media-libs/oyranos-9999
 	media-libs/libXcm
 	x11-libs/libXrandr
 "

--- a/media-gfx/synnefo/metadata.xml
+++ b/media-gfx/synnefo/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+	<use>
+		<flag name="qt5">Build Qt5 frontend instead of Qt4</flag>
+	</use>
+</pkgmetadata>

--- a/media-gfx/synnefo/synnefo-9999.ebuild
+++ b/media-gfx/synnefo/synnefo-9999.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit cmake-utils
+
+DESCRIPTION="Qt front end for the Oyranos Color Management System"
+HOMEPAGE="https://github.com/oyranos-cms/Synnefo"
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/oyranos-cms/Synnefo.git"
+	inherit git-r3
+	KEYWORDS=""
+#else
+#	SRC_URI="https://github.com/oyranos-cms/Synnefo/archive/${PV}.tar.gz -> ${P}.tar.gz"
+#	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="BSD-2"
+SLOT="0"
+IUSE="qt5"
+
+DEPEND="
+	=media-libs/oyranos-9999
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+	)
+	!qt5? (
+		dev-qt/qtcore:4
+		dev-qt/qtgui:4
+	)
+"
+RDEPEND="${DEPEND}
+	x11-misc/xcalib
+"
+
+DOCS=( "AUTHORS.md" "README.md" )
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_use !qt5 qt4)
+	)
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
- media-gfx/synnefo
 - Any objection to how qt4 flag is used there? From upstream README: USE_Qt4 - use Qt4 even if Qt5 is installed, default is to detect Qt5
