### PR TITLE
Set min. required CMake version

### DIFF
--- a/kde-misc/kcmsystemd/kcmsystemd-1.1.0.ebuild
+++ b/kde-misc/kcmsystemd/kcmsystemd-1.1.0.ebuild
@@ -3,6 +3,7 @@
 # $Header: $
 
 EAPI=5
+CMAKE_MIN_VERSION="3.0.0"
 
 inherit kde5
 


### PR DESCRIPTION
Should prevent:
```
[…]
-- Detecting CXX compiler ABI info - done
CMake Error at CMakeLists.txt:10 (cmake_policy):
  Policy "CMP0037" is not known to this version of CMake.
[…]
```

See also [CMake docs](http://www.cmake.org/cmake/help/v3.0/policy/CMP0037.html).