### PR TITLE
[kde-plasma/plasma-desktop] Add missing RDEPEND

### DIFF
--- a/kde-plasma/plasma-desktop/plasma-desktop-5.3.49.9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-5.3.49.9999.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="KDE Plasma desktop"
 KEYWORDS=""
-IUSE="+fontconfig pulseaudio touchpad usb"
+IUSE="+fontconfig pulseaudio +qt4 touchpad usb"
 
 COMMON_DEPEND="
 	$(add_plasma_dep baloo)
@@ -96,6 +96,7 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep oxygen)
 	sys-apps/accountsservice
 	x11-apps/setxkbmap
+	qt4? ( kde-base/qguiplatformplugin_kde )
 	!kde-apps/kcontrol
 	!kde-base/attica
 	!kde-base/kcontrol

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="KDE Plasma desktop"
 KEYWORDS=""
-IUSE="+fontconfig pulseaudio touchpad usb"
+IUSE="+fontconfig pulseaudio +qt4 touchpad usb"
 
 COMMON_DEPEND="
 	$(add_plasma_dep baloo)
@@ -96,6 +96,7 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep oxygen)
 	sys-apps/accountsservice
 	x11-apps/setxkbmap
+	qt4? ( kde-base/qguiplatformplugin_kde )
 	!kde-apps/kcontrol
 	!kde-base/attica
 	!kde-base/kcontrol


### PR DESCRIPTION
Pull in kde-base/qguiplatformplugin_kde if USE=qt4
Gentoo Bug 549824

I'm wondering if this is it - that would fit cause (plasma-desktop session) and scope (qt4 apps)

Package-Manager: portage-2.2.18