### PR TITLE
[dev-libs/grantlee] git repo has moved

### DIFF
--- a/dev-libs/grantlee/grantlee-9999.ebuild
+++ b/dev-libs/grantlee/grantlee-9999.ebuild
@@ -8,8 +8,8 @@ VIRTUALX_REQUIRED="test"
 inherit cmake-utils virtualx git-r3
 
 DESCRIPTION="C++ string template engine based on the Django template system"
-HOMEPAGE="http://www.gitorious.org/grantlee/pages/Home"
-EGIT_REPO_URI=( "git://gitorious.org/grantlee/${PN}" )
+HOMEPAGE="https://github.com/steveire/grantlee"
+EGIT_REPO_URI=( "https://github.com/steveire/${PN}.git" )
 
 LICENSE="LGPL-2.1"
 SLOT="5"


### PR DESCRIPTION
Today, the doomed [gitorious repo] (https://www.gitorious.org/grantlee/pages/Home) for grantlee stopped responding for me, terminating an emerge. Some quick searching [revealed] (https://github.com/steveire/grantlee) that the repo had, in fact, relocated. Comparing the author of the two repos and some moved review requests seems to attest to the veracity of the new repo.