### PR TITLE
New packages: kdb, kproperty, kreport

### DIFF
--- a/kde-apps/kdb/kdb-9999.ebuild
+++ b/kde-apps/kdb/kdb-9999.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit kde5 python-single-r1
+
+DESCRIPTION="Database connectivity and creation framework for various vendors"
+LICENSE="LGPL-2+"
+KEYWORDS=""
+IUSE="mysql postgres sqlite"
+
+RDEPEND="
+	$(add_frameworks_dep kcoreaddons)
+	dev-libs/icu:=
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	mysql? ( virtual/mysql )
+	postgres? ( dev-db/postgresql:* )
+	sqlite? ( dev-db/sqlite:3 )
+"
+
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package mysql)
+		$(cmake-utils_use_find_package postgres)
+		$(cmake-utils_use_find_package sqlite)
+	)
+
+	kde5_src_configure
+}

--- a/kde-apps/kdb/metadata.xml
+++ b/kde-apps/kdb/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>

--- a/kde-apps/kproperty/kproperty-9999.ebuild
+++ b/kde-apps/kproperty/kproperty-9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="Property editing framework with editor widget similar to Qt Designer"
+LICENSE="LGPL-2+"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep kwidgetsaddons)
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+
+RDEPEND="${DEPEND}"

--- a/kde-apps/kproperty/metadata.xml
+++ b/kde-apps/kproperty/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>

--- a/kde-apps/kreport/kreport-9999.ebuild
+++ b/kde-apps/kreport/kreport-9999.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+KDE_TEST="true"
+inherit kde5
+
+DESCRIPTION="Framework for creation and generation of reports in multiple formats"
+LICENSE="LGPL-2+"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kross)
+	$(add_kdeapps_dep kproperty)
+	dev-qt/qtgui:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
+
+RDEPEND="${DEPEND}"

--- a/kde-apps/kreport/metadata.xml
+++ b/kde-apps/kreport/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>


### PR DESCRIPTION
In kdb, so far only sqlite is actually built, but mysql and postgres should be enabled soon.

kde-apps/kdb[sqlite] looks like a dependency of kexi
kde-apps/kreport is going to be a dependency of plan