### PR TITLE
Block kde4-l10n-4.14.3 for kde-plasma/ packages

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -136,8 +136,8 @@ case ${KDE_AUTODEPS} in
 
 		if [[ ${CATEGORY} = kde-plasma ]]; then
 			RDEPEND+="
+				!<kde-apps/kde4-l10n-15.04
 				!kde-apps/kde4-l10n[-minimal]
-				!kde-base/kde-l10n:4[-minimal(-)]
 			"
 		fi
 

--- a/profiles/package.mask/kde-apps-15.04.3
+++ b/profiles/package.mask/kde-apps-15.04.3
@@ -74,8 +74,6 @@
 ~kde-apps/kdegames-meta-15.04.3
 ~kde-apps/kdegraphics-meta-15.04.3
 ~kde-apps/kdegraphics-mobipocket-15.04.3
-~kde-apps/kde4-l10n-15.04.3
-~kde-apps/kde-l10n-15.04.3
 ~kde-apps/kdemultimedia-meta-15.04.3
 ~kde-apps/kdenetwork-filesharing-15.04.3
 ~kde-apps/kdenetwork-meta-15.04.3


### PR DESCRIPTION
Block kde4-l10n-4.14.3 for kde-plasma/ packages, at the same time lift the mask on *l10n-15.04.3 to satisfy deps, this should resolve bugs like '#553572

To be merged after 15.04.3 release - unless I overlooked something?

Much better than constantly hacking at stable kde4-l10n-4.14.3 ebuild, might as well revert the [minimal] flag afterwards.