### PR TITLE
[kde-plasma/breeze] USE kde4 -> qt4

### DIFF
--- a/kde-plasma/breeze/breeze-5.3.2.ebuild
+++ b/kde-plasma/breeze/breeze-5.3.2.ebuild
@@ -9,7 +9,7 @@ inherit kde5 multibuild
 DESCRIPTION="Breeze visual style for the Plasma desktop"
 HOMEPAGE="https://projects.kde.org/projects/kde/workspace/breeze"
 KEYWORDS="~amd64"
-IUSE="kde4"
+IUSE="qt4"
 
 DEPEND="
 	$(add_frameworks_dep frameworkintegration)
@@ -26,7 +26,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	x11-libs/libxcb
-	kde4? (
+	qt4? (
 		kde-base/kdelibs:4
 		x11-libs/libX11
 	)
@@ -38,14 +38,14 @@ RDEPEND="${DEPEND}
 
 pkg_setup() {
 	kde5_pkg_setup
-	MULTIBUILD_VARIANTS=( kf5 $(usev kde4) )
+	MULTIBUILD_VARIANTS=( kf5 $(usev qt4) )
 }
 
 src_configure() {
 	myconfigure() {
 		local mycmakeargs=()
 
-		if [[ ${MULTIBUILD_VARIANT} = kde4 ]] ; then
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]] ; then
 			mycmakeargs+=( -DUSE_KDE4=true )
 		fi
 

--- a/kde-plasma/breeze/breeze-5.3.49.9999.ebuild
+++ b/kde-plasma/breeze/breeze-5.3.49.9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5 multibuild
 DESCRIPTION="Breeze visual style for the Plasma desktop"
 HOMEPAGE="https://projects.kde.org/projects/kde/workspace/breeze"
 KEYWORDS=""
-IUSE="kde4"
+IUSE="qt4"
 
 DEPEND="
 	$(add_frameworks_dep frameworkintegration)
@@ -26,7 +26,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	x11-libs/libxcb
-	kde4? (
+	qt4? (
 		kde-base/kdelibs:4
 		x11-libs/libX11
 	)
@@ -38,14 +38,14 @@ RDEPEND="${DEPEND}
 
 pkg_setup() {
 	kde5_pkg_setup
-	MULTIBUILD_VARIANTS=( kf5 $(usev kde4) )
+	MULTIBUILD_VARIANTS=( kf5 $(usev qt4) )
 }
 
 src_configure() {
 	myconfigure() {
 		local mycmakeargs=()
 
-		if [[ ${MULTIBUILD_VARIANT} = kde4 ]] ; then
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]] ; then
 			mycmakeargs+=( -DUSE_KDE4=true )
 		fi
 

--- a/kde-plasma/breeze/breeze-9999.ebuild
+++ b/kde-plasma/breeze/breeze-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5 multibuild
 DESCRIPTION="Breeze visual style for the Plasma desktop"
 HOMEPAGE="https://projects.kde.org/projects/kde/workspace/breeze"
 KEYWORDS=""
-IUSE="kde4"
+IUSE="qt4"
 
 DEPEND="
 	$(add_frameworks_dep frameworkintegration)
@@ -26,7 +26,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	x11-libs/libxcb
-	kde4? (
+	qt4? (
 		kde-base/kdelibs:4
 		x11-libs/libX11
 	)
@@ -38,14 +38,14 @@ RDEPEND="${DEPEND}
 
 pkg_setup() {
 	kde5_pkg_setup
-	MULTIBUILD_VARIANTS=( kf5 $(usev kde4) )
+	MULTIBUILD_VARIANTS=( kf5 $(usev qt4) )
 }
 
 src_configure() {
 	myconfigure() {
 		local mycmakeargs=()
 
-		if [[ ${MULTIBUILD_VARIANT} = kde4 ]] ; then
+		if [[ ${MULTIBUILD_VARIANT} = qt4 ]] ; then
 			mycmakeargs+=( -DUSE_KDE4=true )
 		fi
 

--- a/kde-plasma/breeze/metadata.xml
+++ b/kde-plasma/breeze/metadata.xml
@@ -2,7 +2,4 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
-	<use>
-		<flag name="kde4">Build the Breeze style for KDE 4</flag>
-	</use>
 </pkgmetadata>


### PR DESCRIPTION
Setting affects the look of all Qt4 applications in a plasma session, so use of more common qt4 flag seems appropriate.

Package-Manager: portage-2.2.18