### PR TITLE
[kde-plasma/plasma-desktop] Split up USE=usb into evdev,logitech

### DIFF
--- a/kde-plasma/plasma-desktop/metadata.xml
+++ b/kde-plasma/plasma-desktop/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<herd>kde</herd>
 	<use>
+		<flag name="evdev">Enable configuration module for desktop input devices.</flag>
 		<flag name="gtk2">Add support for gtk+2-based applications using legacy xembed systray icons via libappindicator.</flag>
 		<flag name="gtk3">Add support for gtk+3-based applications using legacy xembed systray icons via libappindicator.</flag>
 		<flag name="legacy-systray">Add support for applications using legacy xembed systray icons.</flag>

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="KDE Plasma desktop"
 KEYWORDS=""
-IUSE="+fontconfig gtk2 gtk3 legacy-systray pulseaudio +qt4 touchpad usb"
+IUSE="+evdev +fontconfig gtk2 gtk3 legacy-systray pulseaudio +qt4 touchpad"
 
 COMMON_DEPEND="
 	$(add_plasma_dep baloo)
@@ -66,10 +66,10 @@ COMMON_DEPEND="
 	dev-qt/qtxml:5
 	media-libs/phonon[qt5]
 	x11-libs/libX11
-	x11-libs/libxcb
 	x11-libs/libXcursor
 	x11-libs/libXfixes
 	x11-libs/libXi
+	x11-libs/libxcb
 	x11-libs/libxkbfile
 	fontconfig? (
 		media-libs/fontconfig
@@ -83,11 +83,6 @@ COMMON_DEPEND="
 		media-sound/pulseaudio
 	)
 	touchpad? ( x11-drivers/xf86-input-synaptics )
-	usb? (
-		x11-libs/libXcursor
-		x11-libs/libXfixes
-		virtual/libusb:0
-	)
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep breeze)
@@ -117,6 +112,7 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 	dev-libs/boost
 	x11-proto/xproto
+	evdev? ( x11-drivers/xf86-input-evdev )
 	fontconfig? ( x11-libs/libXrender )
 "
 
@@ -132,9 +128,9 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
+		$(cmake-utils_use_find_package evdev)
 		$(cmake-utils_use_find_package fontconfig Fontconfig)
 		$(cmake-utils_use_find_package pulseaudio PulseAudio)
-		$(cmake-utils_use_find_package usb USB)
 		$(cmake-utils_use_find_package touchpad Synaptics)
 	)
 


### PR DESCRIPTION
Makes virtual/libusb:0 optional through USE=logitech
Keeps kcm_input optional through USE=evdev (and re-adjusts DEPENDs)

Package-Manager: portage-2.2.20