### PR TITLE
[media-gfx/kgraphviewer] Add kf5 version

### DIFF
--- a/media-gfx/kgraphviewer/kgraphviewer-9999.ebuild
+++ b/media-gfx/kgraphviewer/kgraphviewer-9999.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+EGIT_BRANCH="frameworks"
+KDE_HANDBOOK="true"
+inherit kde5
+
+DESCRIPTION="Graphviz dot graph file viewer"
+HOMEPAGE="http://www.kde.org/applications/graphics/kgraphviewer/
+http://extragear.kde.org/apps/kgraphviewer/"
+
+LICENSE="GPL-2 FDL-1.2"
+KEYWORDS=""
+IUSE=""
+
+RDEPEND="
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep khtml)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kparts)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kxmlgui)
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwidgets:5
+	>=media-gfx/graphviz-2.30
+"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+"

--- a/media-gfx/kgraphviewer/metadata.xml
+++ b/media-gfx/kgraphviewer/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+</pkgmetadata>


### PR DESCRIPTION
Package-Manager: portage-2.2.20

Currently doesn't seem to build with Qt 5.5, but upstream is informed already (it's an easy fix).