### PR TITLE
[kde-plasma/kwin] Add missing dev-qt/qtwayland dep.

### DIFF
--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -54,6 +54,7 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-keysyms
 	wayland? (
 		$(add_plasma_dep kwayland)
+		dev-qt/qtwayland:5
 		>=dev-libs/libinput-0.10
 		>=dev-libs/wayland-1.2
 		virtual/libudev:=


### PR DESCRIPTION
Package-Manager: portage-2.2.20

Otherwise, `kwin_wayland` will report on startup:
```
default unknown: This application failed to start because it could not find or load the Qt platform plugin "wayland".

Available platform plugins are: minimal, offscreen, xcb.

Reinstalling the application may fix this problem.
zsh: abort (core dumped)  kwin_wayland
```