### PR TITLE
Fix kde-apps/kdesdk-meta dependencies

### DIFF
--- a/kde-apps/kdesdk-meta/kdesdk-meta-15.04.3.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-15.04.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE SDK - merge this to pull in all kdesdk-derived packages"
 HOMEPAGE="http://www.kde.org/applications/development"
 KEYWORDS="~amd64 ~x86"
-IUSE="cvs relaxed_deps"
+IUSE="cvs hard_deps"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin-plugins)
@@ -23,9 +23,6 @@ RDEPEND="
 	$(add_kdeapps_dep okteta)
 	$(add_kdeapps_dep poxml)
 	$(add_kdeapps_dep umbrello)
-	relaxed_deps? ( $(add_kdeapps_dep kompare '' '14.12.3')
-		$(add_kdeapps_dep libkomparediff2 '' '14.12.3') )
-	!relaxed_deps? ( $(add_kdeapps_dep kompare)
-		$(add_kdeapps_dep libkomparediff2) )
 	cvs? ( $(add_kdeapps_dep cervisia) )
+	hard_deps? ( $(add_kdeapps_dep kompare) )
 "

--- a/kde-apps/kdesdk-meta/metadata.xml
+++ b/kde-apps/kdesdk-meta/metadata.xml
@@ -3,6 +3,6 @@
 <pkgmetadata>
 	<herd>kde</herd>
 	<use>
-		<flag name='relaxed_deps'> Allow relaxed dependency on lower version to enable coninstabillity with other meta packages.</flag>
+		<flag name='hard_deps'> Force KF5 dependencies. It may cause incompatibilities with other packages.</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
* I removed kompare and libkomparediff2 because they are already pulled in as dependencies for dolphin-plugins, which selects the correct slot and version for both packages, so there's no need to have them here. This also fix this conflict (both on world update and kdesdk-meta installation):

> \* Error: The above package list contains packages which cannot be
> \* installed at the same time on the same system.
>
>  (kde-apps/kompare-14.12.3:4/14.12::kde, installed) pulled in by
>    \>=kde-apps/kompare-14.12.3:4[aqua=] (>=kde-apps/kompare-14.12.3:4[-aqua]) required by (kde-apps/dolphin-plugins-15.04.3:4/15.04::kde, installed)
>
>  (kde-apps/kompare-15.04.3:5/5::kde, ebuild scheduled for merge) pulled in by
    \>=kde-apps/kompare-14.12.3 required by (kde-apps/kdesdk-meta-15.04.3:5/5::kde, installed)
>
>  (kde-apps/libkomparediff2-15.04.3:5/5::kde, ebuild scheduled for merge) pulled in by
>   \>=kde-apps/libkomparediff2-14.12.3 required by (kde-apps/kdesdk-meta-15.04.3:5/5::kde, installed)
>    \>=kde-apps/libkomparediff2-15.04.3:5 required by (kde-apps/kompare-15.04.3:5/5::kde, ebuild scheduled for merge)

* Thanks to the first modification, there are no conflicts at all, so there's no need for the "relaxed_deps" useflag, which also was almost useless because it was impossible to have it disabled, again because of the above-mentioned conflict.