### PR TITLE
[kde-plasma/plasma-sdk] Patch out bogus upstream dep

### DIFF
--- a/kde-plasma/plasma-sdk/files/plasma-sdk-5.3.2-remove-qtwebkit.patch
+++ b/kde-plasma/plasma-sdk/files/plasma-sdk-5.3.2-remove-qtwebkit.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2015-07-18 18:21:24.686994466 +0200
++++ b/CMakeLists.txt	2015-07-18 18:21:51.772993658 +0200
+@@ -24,7 +24,7 @@
+ # where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+ 
+-find_package(Qt5 REQUIRED NO_MODULE COMPONENTS Core DBus Gui Qml Quick Svg WebKit WebKitWidgets Widgets Xml)
++find_package(Qt5 REQUIRED NO_MODULE COMPONENTS Core DBus Gui Qml Quick Svg Widgets Xml)
+ 
+ find_package(Qt5Test ${QT_MIN_VERSION} CONFIG QUIET)
+ set_package_properties(Qt5Test PROPERTIES

--- a/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
@@ -35,3 +35,5 @@ DEPEND="
 RDEPEND="${DEPEND}
 	!dev-util/plasmate
 "
+
+PATCHES=( "${FILESDIR}/${PN}-5.3.2-remove-qtwebkit.patch" )


### PR DESCRIPTION
Patch works the same for 5.3.2.

Package-Manager: portage-2.2.20