### PR TITLE
[eclass] Fix oldpim bug 555566

### DIFF
--- a/eclass/kde4-meta.eclass
+++ b/eclass/kde4-meta.eclass
@@ -182,7 +182,7 @@ kde4-meta_src_extract() {
 	else
 		local abort tarball tarfile f extractlist postfix
 
-		if [[ ${PV} =~ '4\.4\.[12].*' ]]; then
+		if [[ ${PV} =~ 4.4.11 ]]; then
 			postfix="bz2"
 			KMTARPARAMS+=" --bzip2"
 		else


### PR DESCRIPTION
kdepim-4.4.11.1 is served as tar.bz2