### PR TITLE
[eclass] Avoid confusion over system configuration

### DIFF
--- a/eclass/kde4-base.eclass
+++ b/eclass/kde4-base.eclass
@@ -894,12 +894,10 @@ kde4-base_pkg_postinst() {
 		fi
 		# for all 3rd party soft tell user that he SHOULD install kdebase-startkde or kdebase-runtime-meta
 		if [[ ${KDEBASE} != kde-base ]] && \
-				! has_version 'kde-apps/kdebase-runtime-meta' && \
-				! has_version 'kde-base/kdebase-startkde'; then
+				! has_version 'kde-apps/kdebase-runtime-meta'; then
 			if [[ ${KDE_REQUIRED} == always ]] || ( [[ ${KDE_REQUIRED} == optional ]] && use kde ); then
 				echo
-				ewarn "WARNING! Your system configuration contains neither \"kde-base/kdebase-runtime-meta\""
-				ewarn "nor \"kde-base/kdebase-startkde\". You need one of above."
+				ewarn "WARNING! Your system configuration does not contain \"kde-apps/kdebase-runtime-meta\"."
 				ewarn "With this setting you are unsupported by KDE team."
 				ewarn "All missing features you report for misc packages will be probably ignored or closed as INVALID."
 			fi


### PR DESCRIPTION
E.g. https://forums.gentoo.org/viewtopic-p-7786236.html#7786236

Since kde-apps/kdebase-runtime-meta is a dependency of kdebase-startkde, I figured the latter is redundant here anyway.