### PR TITLE
[kde-apps/kdebase-runtime-meta] Fix conflict with kf5-based apps

### DIFF
--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.04.3.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.04.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE="+crash-reporter +handbook minimal nepomuk"
+IUSE="crash-reporter +handbook minimal nepomuk"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell)
@@ -47,6 +47,7 @@ RDEPEND="
 		$(add_plasma_dep khelpcenter)
 		kde-base/khelpcenter:4
 	) )
+	minimal? ( $(add_kdeapps_dep solid-runtime '-bluetooth') )
 	nepomuk? ( $(add_kdeapps_dep nepomuk) )
 	!minimal? (
 		$(add_kdeapps_dep attica)
@@ -55,3 +56,4 @@ RDEPEND="
 		$(add_kdeapps_dep knetattach)
 	)
 "
+REQUIRED_USE="minimal? ( !crash-reporter )"

--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.49.9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS=""
-IUSE="+crash-reporter +handbook minimal nepomuk"
+IUSE="crash-reporter +handbook minimal nepomuk"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell)
@@ -47,6 +47,7 @@ RDEPEND="
 		$(add_plasma_dep khelpcenter)
 		kde-base/khelpcenter:4
 	) )
+	minimal? ( $(add_kdeapps_dep solid-runtime '-bluetooth') )
 	nepomuk? ( $(add_kdeapps_dep nepomuk) )
 	!minimal? (
 		$(add_kdeapps_dep attica)
@@ -55,3 +56,4 @@ RDEPEND="
 		$(add_kdeapps_dep knetattach)
 	)
 "
+REQUIRED_USE="minimal? ( !crash-reporter )"

--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-9999.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS=""
-IUSE="+crash-reporter +handbook minimal nepomuk"
+IUSE="crash-reporter +handbook minimal nepomuk"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell)
@@ -47,6 +47,7 @@ RDEPEND="
 		$(add_plasma_dep khelpcenter)
 		kde-base/khelpcenter:4
 	) )
+	minimal? ( $(add_kdeapps_dep solid-runtime '-bluetooth') )
 	nepomuk? ( $(add_kdeapps_dep nepomuk) )
 	!minimal? (
 		$(add_kdeapps_dep attica)
@@ -55,3 +56,4 @@ RDEPEND="
 		$(add_kdeapps_dep knetattach)
 	)
 "
+REQUIRED_USE="minimal? ( !crash-reporter )"


### PR DESCRIPTION
See also https://github.com/gentoo/gentoo-portage-rsync-mirror/pull/183

Package-Manager: portage-2.2.20