### PR TITLE
[kde-apps/kde-apps-meta] Fall back to released kde-l10n versions

### DIFF
--- a/kde-apps/kde-apps-meta/kde-apps-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-15.08.49.9999.ebuild
@@ -10,6 +10,8 @@ DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS=""
 IUSE="accessibility nls sdk"
 
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+
 RDEPEND="
 	$(add_kdeapps_dep kate)
 	$(add_kdeapps_dep kdeadmin-meta)
@@ -24,8 +26,8 @@ RDEPEND="
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
 	nls? (
-		$(add_kdeapps_dep kde-l10n)
-		$(add_kdeapps_dep kde4-l10n)
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
 	)
 	sdk? (
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
@@ -10,6 +10,8 @@ DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS=""
 IUSE="accessibility nls sdk"
 
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+
 RDEPEND="
 	$(add_kdeapps_dep kate)
 	$(add_kdeapps_dep kdeadmin-meta)
@@ -24,8 +26,8 @@ RDEPEND="
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
 	nls? (
-		$(add_kdeapps_dep kde-l10n)
-		$(add_kdeapps_dep kde4-l10n)
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
 	)
 	sdk? (
 		$(add_kdeapps_dep kdesdk-meta)


### PR DESCRIPTION
Fixes repoman complaint and USE=nls in live ebuilds

Package-Manager: portage-2.2.20