### PR TITLE
[kde-apps] Remove conflicting KDE4-based RDEPENDs from meta

### DIFF
--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-15.07.80.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-15.07.80.ebuild
@@ -10,8 +10,9 @@ DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-deriv
 KEYWORDS="~amd64 ~x86"
 IUSE="+cron"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kuser)
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
-	$(add_kdeapps_dep kuser)
 	cron? ( $(add_kdeapps_dep kcron) )
 "

--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-15.08.49.9999.ebuild
@@ -10,8 +10,9 @@ DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-deriv
 KEYWORDS=""
 IUSE="+cron"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kuser)
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
-	$(add_kdeapps_dep kuser)
 	cron? ( $(add_kdeapps_dep kcron) )
 "

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-15.07.80.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-15.07.80.ebuild
@@ -10,10 +10,11 @@ DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS="~amd64 ~x86"
 IUSE="ppp"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kopete)
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
 	$(add_kdeapps_dep kget)
-	$(add_kdeapps_dep kopete)
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
 	$(add_kdeapps_dep plasma-telepathy-meta)

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-15.08.49.9999.ebuild
@@ -10,10 +10,11 @@ DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS=""
 IUSE="ppp"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kopete)
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
 	$(add_kdeapps_dep kget)
-	$(add_kdeapps_dep kopete)
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
 	$(add_kdeapps_dep plasma-telepathy-meta)

--- a/kde-apps/kdeutils-meta/kdeutils-meta-15.07.80.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-15.07.80.ebuild
@@ -11,13 +11,14 @@ HOMEPAGE="http://www.kde.org/applications/utilities http://utils.kde.org"
 KEYWORDS="~amd64 ~x86"
 IUSE="cups floppy lirc"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kgpg)
 RDEPEND="
 	$(add_kdeapps_dep ark)
 	$(add_kdeapps_dep filelight)
 	$(add_kdeapps_dep kcalc)
 	$(add_kdeapps_dep kcharselect)
 	$(add_kdeapps_dep kdf)
-	$(add_kdeapps_dep kgpg)
 	$(add_kdeapps_dep ktimer)
 	$(add_kdeapps_dep kwalletmanager)
 	$(add_kdeapps_dep superkaramba)

--- a/kde-apps/kdeutils-meta/kdeutils-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-15.08.49.9999.ebuild
@@ -11,13 +11,14 @@ HOMEPAGE="http://www.kde.org/applications/utilities http://utils.kde.org"
 KEYWORDS=""
 IUSE="cups floppy lirc"
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep kgpg)
 RDEPEND="
 	$(add_kdeapps_dep ark)
 	$(add_kdeapps_dep filelight)
 	$(add_kdeapps_dep kcalc)
 	$(add_kdeapps_dep kcharselect)
 	$(add_kdeapps_dep kdf)
-	$(add_kdeapps_dep kgpg)
 	$(add_kdeapps_dep ktimer)
 	$(add_kdeapps_dep kwalletmanager)
 	$(add_kdeapps_dep superkaramba)


### PR DESCRIPTION
kgpg - depends on kde-base/kdepimlibs:4
kopete - depends on kde-base/kdepimlibs:4
kuser - depends on kde-base/kdepimlibs:4

Package-Manager: portage-2.2.20