### PR TITLE
[kde-apps/kdebase-data] Workaround for kde4-base vs kde5 conflict

### DIFF
--- a/kde-apps/kdebase-data/kdebase-data-15.08.49.9999.ebuild
+++ b/kde-apps/kdebase-data/kdebase-data-15.08.49.9999.ebuild
@@ -13,7 +13,7 @@ IUSE="+wallpapers"
 KEYWORDS=""
 
 RDEPEND="
-	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
+	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) >=kde-apps/kde-wallpapers-${PV}:5 ) )
 	x11-themes/hicolor-icon-theme
 "
 

--- a/kde-apps/kdebase-data/kdebase-data-9999.ebuild
+++ b/kde-apps/kdebase-data/kdebase-data-9999.ebuild
@@ -13,7 +13,7 @@ IUSE="+wallpapers"
 KEYWORDS=""
 
 RDEPEND="
-	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
+	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) >=kde-apps/kde-wallpapers-${PV}:5 ) )
 	x11-themes/hicolor-icon-theme
 "
 


### PR DESCRIPTION
Fixes a problem created by 5a5b4ed634c5d6161812fa60b8123c74bf20e069

Not sure what the dependency does here, though.

Package-Manager: portage-2.2.20