### PR TITLE
[dev-util] Drop kdelibs4support from DEPEND as did upstream

### DIFF
--- a/dev-util/kdevelop-qmake/kdevelop-qmake-9999.ebuild
+++ b/dev-util/kdevelop-qmake/kdevelop-qmake-9999.ebuild
@@ -17,7 +17,6 @@ DEPEND="
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep ktexteditor)

--- a/dev-util/kdevelop/kdevelop-9999.ebuild
+++ b/dev-util/kdevelop/kdevelop-9999.ebuild
@@ -19,7 +19,6 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)

--- a/dev-util/kdevplatform/kdevplatform-9999.ebuild
+++ b/dev-util/kdevplatform/kdevplatform-9999.ebuild
@@ -29,7 +29,6 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdeclarative)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)


### PR DESCRIPTION
Package-Manager: portage-2.2.20