### PR TITLE
[kde-frameworks/baloo] Drop kdelibs4support from DEPEND

### DIFF
--- a/kde-frameworks/baloo/baloo-9999.ebuild
+++ b/kde-frameworks/baloo/baloo-9999.ebuild
@@ -17,7 +17,6 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kcrash)
 	$(add_frameworks_dep kdbusaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kfilemetadata)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kidletime)


### PR DESCRIPTION
...just in time

Package-Manager: portage-2.2.20