### PR TITLE
[kde-apps/kde-l10n] Always block older kde4-l10n

### DIFF
--- a/kde-apps/kde-l10n/kde-l10n-15.07.90.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-15.07.90.ebuild
@@ -14,7 +14,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde4-l10n-15.07.80
+	!<kde-apps/kde4-l10n-${PV}
 "
 
 KEYWORDS=" ~amd64 ~x86"

--- a/kde-apps/kde4-l10n/kde4-l10n-15.07.90.ebuild
+++ b/kde-apps/kde4-l10n/kde4-l10n-15.07.90.ebuild
@@ -15,7 +15,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde-l10n-15.04.0-r1
+	!<kde-apps/kde-l10n-${PV}
 	!kde-base/kdepim-l10n
 "
 


### PR DESCRIPTION
Package-Manager: portage-2.2.20