### PR TITLE
kde-apps/kdewebdev-meta: Drop kde-apps/klinkstatus from RDEPEND

### DIFF
--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-15.07.90.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-15.07.90.ebuild
@@ -10,9 +10,10 @@ DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep klinkstatus)
 RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
-	$(add_kdeapps_dep klinkstatus)
 	$(add_kdeapps_dep kommander)
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-15.08.0.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-15.08.0.ebuild
@@ -10,9 +10,10 @@ DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep klinkstatus)
 RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
-	$(add_kdeapps_dep klinkstatus)
 	$(add_kdeapps_dep kommander)
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-15.08.49.9999.ebuild
@@ -10,9 +10,10 @@ DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS=""
 IUSE=""
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep klinkstatus)
 RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
-	$(add_kdeapps_dep klinkstatus)
 	$(add_kdeapps_dep kommander)
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-9999.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-9999.ebuild
@@ -10,9 +10,10 @@ DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS=""
 IUSE=""
 
+# FIXME: Add back when ported
+# $(add_kdeapps_dep klinkstatus)
 RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
-	$(add_kdeapps_dep klinkstatus)
 	$(add_kdeapps_dep kommander)
 "

--- a/kde-apps/klinkstatus/klinkstatus-15.07.90.ebuild
+++ b/kde-apps/klinkstatus/klinkstatus-15.07.90.ebuild
@@ -22,7 +22,6 @@ RDEPEND="${DEPEND}"
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_KdepimLibs=ON
 		$(cmake-utils_use_with tidy LibTidy)
 	)
 

--- a/kde-apps/klinkstatus/klinkstatus-15.08.0.ebuild
+++ b/kde-apps/klinkstatus/klinkstatus-15.08.0.ebuild
@@ -22,7 +22,6 @@ RDEPEND="${DEPEND}"
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_KdepimLibs=ON
 		$(cmake-utils_use_with tidy LibTidy)
 	)
 

--- a/kde-apps/klinkstatus/klinkstatus-15.08.49.9999.ebuild
+++ b/kde-apps/klinkstatus/klinkstatus-15.08.49.9999.ebuild
@@ -22,7 +22,6 @@ RDEPEND="${DEPEND}"
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_KdepimLibs=ON
 		$(cmake-utils_use_with tidy LibTidy)
 	)
 

--- a/kde-apps/klinkstatus/klinkstatus-9999.ebuild
+++ b/kde-apps/klinkstatus/klinkstatus-9999.ebuild
@@ -22,7 +22,6 @@ RDEPEND="${DEPEND}"
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_KdepimLibs=ON
 		$(cmake-utils_use_with tidy LibTidy)
 	)
 


### PR DESCRIPTION
It depends on conflicting kde-base/kdepimlibs:4

Package-Manager: portage-2.2.20.1