### PR TITLE
kde-apps/kdeedu-meta: Relax RDEPEND on kde-apps/marble

### DIFF
--- a/kde-apps/kdeedu-meta/kdeedu-meta-15.07.90.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-15.07.90.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkdeedu)
 	$(add_kdeapps_dep libkeduvocdocument)
-	$(add_kdeapps_dep marble)
+	$(add_kdeapps_dep marble '' '4.14.3')
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)

--- a/kde-apps/kdeedu-meta/kdeedu-meta-15.08.0.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-15.08.0.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkdeedu)
 	$(add_kdeapps_dep libkeduvocdocument)
-	$(add_kdeapps_dep marble)
+	$(add_kdeapps_dep marble '' '4.14.3')
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)

--- a/kde-apps/kdeedu-meta/kdeedu-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-15.08.49.9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkdeedu)
 	$(add_kdeapps_dep libkeduvocdocument)
-	$(add_kdeapps_dep marble)
+	$(add_kdeapps_dep marble '' '4.14.3')
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)


### PR DESCRIPTION
While marble was ported to kf5 in 15.08, libkgeomap:4 and packages depending on it continue to pull in kde-apps/marble:4. Let the meta ebuild go out of their way.

Package-Manager: portage-2.2.20.1