### PR TITLE
kde-apps/kdebase-meta: Add USE=minimal to hide kde-apps/plasma-apps

### DIFF
--- a/kde-apps/kdebase-meta/kdebase-meta-15.08.0.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-15.08.0.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE="+wallpapers"
+IUSE="minimal +wallpapers"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
@@ -23,6 +23,6 @@ RDEPEND="
 	$(add_kdeapps_dep kwrite)
 	$(add_kdeapps_dep libkonq)
 	$(add_kdeapps_dep nsplugins)
-	$(add_kdeapps_dep plasma-apps)
+	!minimal? ( $(add_kdeapps_dep plasma-apps) )
 	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
 "

--- a/kde-apps/kdebase-meta/kdebase-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-15.08.49.9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-derived packages"
 KEYWORDS=""
-IUSE="+wallpapers"
+IUSE="minimal +wallpapers"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
@@ -23,6 +23,6 @@ RDEPEND="
 	$(add_kdeapps_dep kwrite)
 	$(add_kdeapps_dep libkonq)
 	$(add_kdeapps_dep nsplugins)
-	$(add_kdeapps_dep plasma-apps)
+	!minimal? ( $(add_kdeapps_dep plasma-apps) )
 	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
 "

--- a/kde-apps/kdebase-meta/kdebase-meta-9999.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-derived packages"
 KEYWORDS=""
-IUSE="+wallpapers"
+IUSE="minimal +wallpapers"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
@@ -23,6 +23,6 @@ RDEPEND="
 	$(add_kdeapps_dep kwrite)
 	$(add_kdeapps_dep libkonq)
 	$(add_kdeapps_dep nsplugins)
-	$(add_kdeapps_dep plasma-apps)
+	!minimal? ( $(add_kdeapps_dep plasma-apps) )
 	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
 "


### PR DESCRIPTION
Though no blocker, it has no use on a plasma 5 system and needlessly pulls in kde-apps/libkonq:4. In plasma 5 it is part of plasma-desktop.

However, kde-apps/libkonq:4 still has too many other dependants to be dropped, so plasma-5 users who want better integration by libkonq:5 better simply not use kdebase-meta and kdenetwork-meta.

Package-Manager: portage-2.2.20.1