### PR TITLE
Remove KDELibs4support dependencies in kdepim ebuilds

### DIFF
--- a/kde-apps/kimap/files/kimap-15.08.0-remove-kdelibs4support.patch
+++ b/kde-apps/kimap/files/kimap-15.08.0-remove-kdelibs4support.patch
@@ -1,0 +1,78 @@
+commit bf73c02636b55197e7c7ff870739c98cb200ef1a
+Author: Volker Krause <vkrause@kde.org>
+Date:   Fri Sep 4 15:45:29 2015 +0200
+
+    Remove KDELibs4Support dependency.
+
+commit ce575030415015c38d3e035b9bc507b9d4ae5a72
+Author: Volker Krause <vkrause@kde.org>
+Date:   Fri Sep 4 15:44:41 2015 +0200
+
+    Port away from deprecated Qt methods.
+    
+    Those are not available once we remove the KDELibs4Support dependency.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2beff4..c4af8c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,8 @@ ecm_setup_version(${KIMAP_LIB_VERSION} VARIABLE_PREFIX KIMAP
+ 
+ ########### Find packages ###########
+ find_package(KF5CoreAddons ${KF5_VERSION} CONFIG REQUIRED)
+-find_package(KF5KDELibs4Support ${KF5_VERSION} CONFIG REQUIRED)
++find_package(KF5I18n ${KF5_VERSION} CONFIG REQUIRED)
++find_package(KF5KIO ${KF5_VERSION} CONFIG REQUIRED)
+ 
+ find_package(KF5Mime ${KMIME_LIBS_VERSION} CONFIG REQUIRED)
+ 
+diff --git a/autotests/kimaptest/sslserver.cpp b/autotests/kimaptest/sslserver.cpp
+index b4bd7d0..98e83d5 100644
+--- a/autotests/kimaptest/sslserver.cpp
++++ b/autotests/kimaptest/sslserver.cpp
+@@ -77,7 +77,9 @@ void SslServer::incomingConnection(qintptr handle)
+ 
+     QSslKey ssl_key(staticKey(), QSsl::Rsa);
+     QSslCertificate ssl_cert(staticCert());
+-    Q_ASSERT(ssl_cert.isValid());
++    Q_ASSERT(QDateTime::currentDateTime() >= ssl_cert.effectiveDate());
++    Q_ASSERT(QDateTime::currentDateTime() <= ssl_cert.expiryDate());
++    Q_ASSERT(!ssl_cert.isBlacklisted());
+ 
+     socket->setPrivateKey(ssl_key);
+     socket->setLocalCertificate(ssl_cert);
+@@ -86,7 +88,7 @@ void SslServer::incomingConnection(qintptr handle)
+     socket->ignoreSslErrors();
+     connect(socket, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(sslErrors(QList<QSslError>)));
+     connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(error(QAbstractSocket::SocketError)));
+-    if (mProtocol != QSsl::TlsV1) {
++    if (mProtocol != QSsl::TlsV1_0) {
+         socket->startServerEncryption();
+     }
+     addPendingConnection(socket);
+diff --git a/autotests/kimaptest/sslserver.h b/autotests/kimaptest/sslserver.h
+index 0ecd9fd..e714f38 100644
+--- a/autotests/kimaptest/sslserver.h
++++ b/autotests/kimaptest/sslserver.h
+@@ -29,7 +29,7 @@ public:
+     SslServer(QSsl::SslProtocol);
+     virtual void incomingConnection(qintptr handle) Q_DECL_OVERRIDE;
+ 
+-private slots:
++private Q_SLOTS:
+     void sslErrors(const QList<QSslError> &errors);
+     void error(QAbstractSocket::SocketError);
+ 
+diff --git a/src/appendjob.cpp b/src/appendjob.cpp
+index 4d72903..8584c0e 100644
+--- a/src/appendjob.cpp
++++ b/src/appendjob.cpp
+@@ -124,7 +124,7 @@ void AppendJob::doStart()
+ 
+     if (!d->internalDate.isNull()) {
+         const QDateTime utcDateTime = d->internalDate.toUTC();
+-        parameters += " \"" + utcDateTime.toString(QString::fromAscii("dd-MMM-yyyy hh:mm:ss")).toLatin1() + " +0000" + '\"';
++        parameters += " \"" + utcDateTime.toString(QStringLiteral("dd-MMM-yyyy hh:mm:ss")).toLatin1() + " +0000" + '\"';
+     }
+ 
+     parameters += " {" + QByteArray::number(d->content.size()) + '}';

--- a/kde-apps/kimap/kimap-15.08.0.ebuild
+++ b/kde-apps/kimap/kimap-15.08.0.ebuild
@@ -13,6 +13,10 @@ LICENSE="LGPL-2+"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+PATCHES=(
+	"${FILESDIR}"/kimap-15.08.0-remove-kdelibs4support.patch
+)
+
 RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcoreaddons)

--- a/kde-apps/kimap/kimap-15.08.49.9999.ebuild
+++ b/kde-apps/kimap/kimap-15.08.49.9999.ebuild
@@ -13,6 +13,10 @@ LICENSE="LGPL-2+"
 KEYWORDS=""
 IUSE=""
 
+PATCHES=(
+	"${FILESDIR}"/kimap-15.08.0-remove-kdelibs4support.patch
+)
+
 RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcoreaddons)

--- a/kde-apps/kpimtextedit/files/kpimtextedit-15.08.0-remove-kdelibs4support.patch
+++ b/kde-apps/kpimtextedit/files/kpimtextedit-15.08.0-remove-kdelibs4support.patch
@@ -1,0 +1,20 @@
+commit 1d0d86f017ab4b53442c1c6eb04d3d50b483a741
+Author: Montel Laurent <montel@kde.org>
+Date:   Tue Jul 28 07:01:16 2015 +0200
+
+    Remove KF5KDELibs4Support
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2655c6a..bb55630 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,8 +34,7 @@ find_package(KF5TextWidgets ${KF5_VERSION} CONFIG REQUIRED)
+ find_package(KF5WidgetsAddons ${KF5_VERSION} CONFIG REQUIRED)
+ find_package(KF5KIO ${KF5_VERSION} CONFIG REQUIRED)
+ find_package(KF5Codecs ${KF5_VERSION} CONFIG REQUIRED)
+-#REMOVE IT WHEN all kdelib4support removed
+-find_package(KF5KDELibs4Support ${KF5_VERSION} CONFIG REQUIRED)
++find_package(KF5IconThemes ${KF5_VERSION} CONFIG REQUIRED)
+ 
+ add_definitions(-DTRANSLATION_DOMAIN=\"libkpimtextedit\")
+ add_definitions("-DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII")

--- a/kde-apps/kpimtextedit/kpimtextedit-15.08.0.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-15.08.0.ebuild
@@ -13,6 +13,10 @@ LICENSE="LGPL-2+"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+PATCHES=(
+	"${FILESDIR}"/kpimtextedit-15.08.0-remove-kdelibs4support.patch
+)
+
 RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcompletion)

--- a/kde-apps/kpimtextedit/kpimtextedit-15.08.49.9999.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-15.08.49.9999.ebuild
@@ -13,6 +13,10 @@ LICENSE="LGPL-2+"
 KEYWORDS=""
 IUSE=""
 
+PATCHES=(
+	"${FILESDIR}"/kpimtextedit-15.08.0-remove-kdelibs4support.patch
+)
+
 RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcompletion)


### PR DESCRIPTION
As I was upgrading my system, I got some build errors regarding these packages due to missing dependencies.  These two are the ones found so far.