### PR TITLE
kde-plasma/plasma-meta: add mediacenter and sdk useflags

### DIFF
--- a/kde-plasma/plasma-meta/metadata.xml
+++ b/kde-plasma/plasma-meta/metadata.xml
@@ -4,7 +4,9 @@
 	<herd>kde</herd>
 	<use>
 		<flag name="display-manager">Pull in a graphical display manager</flag>
+		<flag name="mediacenter">Pull in <pkg>kde-plasma/plasma-mediacenter</pkg></flag>
 		<flag name="sddm">Pull in the <pkg>x11-misc/sddm</pkg> display manager and KCM</flag>
+		<flag name="sdk">Pull in <pkg>kde-plasma/plasma-sdk</pkg></flag>
 		<flag name="wallpapers">Install the KDE wallpapers</flag>
 	</use>
 </pkgmetadata>

--- a/kde-plasma/plasma-meta/plasma-meta-5.4.1.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-5.4.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.kde.org/workspaces/plasmadesktop/"
 LICENSE="metapackage"
 SLOT="5"
 KEYWORDS="~amd64"
-IUSE="bluetooth +display-manager gtk +sddm networkmanager pulseaudio +wallpapers"
+IUSE="bluetooth +display-manager gtk mediacenter networkmanager pulseaudio +sddm sdk +wallpapers"
 
 RDEPEND="
 	$(add_plasma_dep breeze)
@@ -38,8 +38,6 @@ RDEPEND="
 	$(add_plasma_dep oxygen)
 	$(add_plasma_dep oxygen-fonts)
 	$(add_plasma_dep plasma-desktop)
-	$(add_plasma_dep plasma-mediacenter)
-	$(add_plasma_dep plasma-sdk)
 	$(add_plasma_dep plasma-workspace)
 	$(add_plasma_dep polkit-kde-agent)
 	$(add_plasma_dep powerdevil)
@@ -53,8 +51,10 @@ RDEPEND="
 		!sddm? ( x11-misc/lightdm )
 	)
 	gtk? ( $(add_plasma_dep kde-gtk-config) )
+	mediacenter? ( $(add_plasma_dep plasma-mediacenter) )
 	networkmanager? ( $(add_plasma_dep plasma-nm) )
 	pulseaudio? ( $(add_plasma_dep plasma-pa) )
 	sddm? ( $(add_plasma_dep sddm-kcm) )
+	sdk? ( $(add_plasma_dep plasma-sdk) )
 	wallpapers? ( $(add_plasma_dep plasma-workspace-wallpapers) )
 "

--- a/kde-plasma/plasma-meta/plasma-meta-5.4.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-5.4.49.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.kde.org/workspaces/plasmadesktop/"
 LICENSE="metapackage"
 SLOT="5"
 KEYWORDS=""
-IUSE="bluetooth +display-manager gtk +sddm networkmanager pulseaudio +wallpapers"
+IUSE="bluetooth +display-manager gtk mediacenter networkmanager pulseaudio +sddm sdk +wallpapers"
 
 RDEPEND="
 	$(add_plasma_dep breeze)
@@ -38,8 +38,6 @@ RDEPEND="
 	$(add_plasma_dep oxygen)
 	$(add_plasma_dep oxygen-fonts)
 	$(add_plasma_dep plasma-desktop)
-	$(add_plasma_dep plasma-mediacenter)
-	$(add_plasma_dep plasma-sdk)
 	$(add_plasma_dep plasma-workspace)
 	$(add_plasma_dep polkit-kde-agent)
 	$(add_plasma_dep powerdevil)
@@ -53,8 +51,10 @@ RDEPEND="
 		!sddm? ( x11-misc/lightdm )
 	)
 	gtk? ( $(add_plasma_dep kde-gtk-config) )
+	mediacenter? ( $(add_plasma_dep plasma-mediacenter) )
 	networkmanager? ( $(add_plasma_dep plasma-nm) )
 	pulseaudio? ( $(add_plasma_dep plasma-pa) )
 	sddm? ( $(add_plasma_dep sddm-kcm) )
+	sdk? ( $(add_plasma_dep plasma-sdk) )
 	wallpapers? ( $(add_plasma_dep plasma-workspace-wallpapers) )
 "

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.kde.org/workspaces/plasmadesktop/"
 LICENSE="metapackage"
 SLOT="5"
 KEYWORDS=""
-IUSE="bluetooth +display-manager gtk +sddm networkmanager pulseaudio +wallpapers"
+IUSE="bluetooth +display-manager gtk mediacenter networkmanager pulseaudio +sddm sdk +wallpapers"
 
 RDEPEND="
 	$(add_plasma_dep breeze)
@@ -38,8 +38,6 @@ RDEPEND="
 	$(add_plasma_dep oxygen)
 	$(add_plasma_dep oxygen-fonts)
 	$(add_plasma_dep plasma-desktop)
-	$(add_plasma_dep plasma-mediacenter)
-	$(add_plasma_dep plasma-sdk)
 	$(add_plasma_dep plasma-workspace)
 	$(add_plasma_dep polkit-kde-agent)
 	$(add_plasma_dep powerdevil)
@@ -53,8 +51,10 @@ RDEPEND="
 		!sddm? ( x11-misc/lightdm )
 	)
 	gtk? ( $(add_plasma_dep kde-gtk-config) )
+	mediacenter? ( $(add_plasma_dep plasma-mediacenter) )
 	networkmanager? ( $(add_plasma_dep plasma-nm) )
 	pulseaudio? ( $(add_plasma_dep plasma-pa) )
 	sddm? ( $(add_plasma_dep sddm-kcm) )
+	sdk? ( $(add_plasma_dep plasma-sdk) )
 	wallpapers? ( $(add_plasma_dep plasma-workspace-wallpapers) )
 "


### PR DESCRIPTION
I think it's better this way because it's more modular (mediacenter it's not something everyone needs)