### PR TITLE
kde-apps/kdepim{libs,-runtime}: Fix Super Evil KDE PIM Bug No. 1

### DIFF
--- a/kde-apps/kdepim-runtime/files/kdepim-runtime-15.08.0-GID-based-merge.patch
+++ b/kde-apps/kdepim-runtime/files/kdepim-runtime-15.08.0-GID-based-merge.patch
@@ -1,0 +1,140 @@
+From: Dan Vrátil <dvratil@redhat.com>
+Date: Mon, 07 Sep 2015 14:20:39 +0000
+Subject: IMAP: switch to GID-based merge when the Collection can contain something else than emails
+X-Git-Url: http://quickgit.kde.org/?p=kdepim-runtime.git&a=commitdiff&h=038c604aba0cac22275e03c3497672cd254c2568
+---
+IMAP: switch to GID-based merge when the Collection can contain something else than emails
+
+In order to fix the recurrent multiple-merge-candidates issue which was breaking
+ItemSync, ItemSync switched to RID-based merging, which is way more reliable.
+However in some cases the IMAP resource still wants to use GID-based merging,
+because RID might not be stable enough.
+
+(cherry picked from commit 93a2baac05a325b688aea2cc12d9714d6b186f69)
+---
+
+
+--- a/resources/imap/autotests/dummyresourcestate.cpp
++++ b/resources/imap/autotests/dummyresourcestate.cpp
+@@ -27,7 +27,8 @@
+ 
+ DummyResourceState::DummyResourceState()
+     : m_automaticExpunge(true), m_subscriptionEnabled(true),
+-      m_disconnectedMode(true), m_intervalCheckTime(-1)
++      m_disconnectedMode(true), m_intervalCheckTime(-1),
++      m_mergeMode(Akonadi::ItemSync::RIDMerge)
+ {
+     qRegisterMetaType<QList<qint64> >();
+     qRegisterMetaType<QVector<qint64> >();
+@@ -428,6 +429,11 @@
+     return 10;
+ }
+ 
++void DummyResourceState::setItemMergingMode(Akonadi::ItemSync::MergeMode mergeMode)
++{
++    m_mergeMode = mergeMode;
++}
++
+ MessageHelper::Ptr DummyResourceState::messageHelper() const
+ {
+     return MessageHelper::Ptr(new MessageHelper());
+--- a/resources/imap/autotests/dummyresourcestate.h
++++ b/resources/imap/autotests/dummyresourcestate.h
+@@ -143,6 +143,7 @@
+     virtual void showInformationDialog(const QString &message, const QString &title, const QString &dontShowAgainName);
+ 
+     virtual int batchSize() const;
++    virtual void setItemMergingMode(Akonadi::ItemSync::MergeMode mergeMode);
+ 
+     virtual MessageHelper::Ptr messageHelper() const;
+ 
+@@ -163,6 +164,8 @@
+     int m_intervalCheckTime;
+     QChar m_separator;
+ 
++    Akonadi::ItemSync::MergeMode m_mergeMode;
++
+     Akonadi::Collection m_collection;
+     Akonadi::Item::List m_items;
+ 
+--- a/resources/imap/resourcestate.cpp
++++ b/resources/imap/resourcestate.cpp
+@@ -363,2 +363,7 @@
+     m_resource->relationsRetrieved(relations);
+ }
++ 
++void ResourceState::setItemMergingMode(Akonadi::ItemSync::MergeMode mode)
++{
++    m_resource->setItemMergingMode(mode);
++}
+--- a/resources/imap/resourcestate.h
++++ b/resources/imap/resourcestate.h
+@@ -153,6 +153,8 @@
+ 
+     MessageHelper::Ptr messageHelper() const Q_DECL_OVERRIDE;
+ 
++  void setItemMergingMode(Akonadi::ItemSync::MergeMode mergeMode);
++
+ private:
+     ImapResourceBase *m_resource;
+     const TaskArguments m_arguments;
+--- a/resources/imap/resourcestateinterface.h
++++ b/resources/imap/resourcestateinterface.h
+@@ -26,6 +26,7 @@
+ 
+ #include <Collection>
+ #include <Item>
++#include <ItemSync>
+ 
+ #include <kimap/listjob.h>
+ 
+@@ -125,6 +126,8 @@
+ 
+     virtual Akonadi::Relation::List addedRelations() const = 0;
+     virtual Akonadi::Relation::List removedRelations() const = 0;
++
++    virtual void setItemMergingMode(Akonadi::ItemSync::MergeMode mergeMode) = 0;
+ };
+ 
+ #endif
+--- a/resources/imap/resourcetask.cpp
++++ b/resources/imap/resourcetask.cpp
+@@ -592,2 +592,8 @@
+     return KIMAP::Acl::None;
+ }
++
++void ResourceTask::setItemMergingMode(Akonadi::ItemSync::MergeMode mode)
++{
++    m_resource->setItemMergingMode(mode);
++}
++
+--- a/resources/imap/resourcetask.h
++++ b/resources/imap/resourcetask.h
+@@ -140,6 +140,7 @@
+     virtual bool serverSupportsCondstore() const;
+ 
+     int batchSize() const;
++    void setItemMergingMode(Akonadi::ItemSync::MergeMode mode);
+ 
+     ResourceStateInterface::Ptr resourceState();
+ 
+--- a/resources/imap/retrieveitemstask.cpp
++++ b/resources/imap/retrieveitemstask.cpp
+@@ -89,6 +89,16 @@
+     m_session = session;
+ 
+     const Akonadi::Collection col = collection();
++    // Only with emails we can be sure that RID is persistent and thus we can use
++    // it for merging. For other potential content types (like Kolab events etc.)
++    // use GID instead.
++    QStringList cts = col.contentMimeTypes();
++    cts.removeOne(Akonadi::Collection::mimeType());
++    cts.removeOne(KMime::Message::mimeType());
++    if (!cts.isEmpty()) {
++        setItemMergingMode(Akonadi::ItemSync::GIDMerge);
++    }
++
+     if (m_fetchMissingBodies && col.cachePolicy()
+             .localParts().contains(QLatin1String(Akonadi::MessagePart::Body))) {  //disconnected mode, make sure we really have the body cached
+ 
+

--- a/kde-apps/kdepim-runtime/kdepim-runtime-15.08.0-r1.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-15.08.0-r1.ebuild
@@ -19,7 +19,7 @@ CDEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kcalutils)
 	$(add_kdeapps_dep kcontacts)
-	$(add_kdeapps_dep kdepimlibs)
+	$(add_kdeapps_dep kdepimlibs '' 15.08.0-r1)
 	$(add_kdeapps_dep kidentitymanagement)
 	$(add_kdeapps_dep kimap)
 	$(add_kdeapps_dep kmailtransport)
@@ -67,6 +67,8 @@ DEPEND="${CDEPEND}
 RDEPEND="${CDEPEND}
 	!kde-base/kdepim-runtime
 "
+
+PATCHES=( "${FILESDIR}/${PN}-15.08.0-GID-based-merge.patch" )
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-apps/kdepim-runtime/kdepim-runtime-15.08.1.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-15.08.1.ebuild
@@ -68,6 +68,8 @@ RDEPEND="${CDEPEND}
 	!kde-base/kdepim-runtime
 "
 
+PATCHES=( "${FILESDIR}/${PN}-15.08.0-GID-based-merge.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package google KF5GAPI)

--- a/kde-apps/kdepimlibs/files/kdepimlibs-15.08.0-GID-merge.patch
+++ b/kde-apps/kdepimlibs/files/kdepimlibs-15.08.0-GID-merge.patch
@@ -1,0 +1,210 @@
+From: Dan Vrátil <dvratil@redhat.com>
+Date: Mon, 07 Sep 2015 13:50:50 +0000
+Subject: ItemSync: use RID merge by default, allow optional switch to GID merge
+X-Git-Url: http://quickgit.kde.org/?p=kdepimlibs.git&a=commitdiff&h=43d5659a88a6ebb3423c6228986f0bd1e1f496f7
+---
+ItemSync: use RID merge by default, allow optional switch to GID merge
+
+GID is not guaranteed to be actually unique and is not in our control, which means
+that we can easilly run to the multiple merge candidates problem, which breaks
+ItemSync. This patch switching ItemSync to use RID, which (although not enforced) is
+basically guaranteed to be unique per Collection, thus the multiple merge candidates
+error should not happen anymore.
+
+Some resources however mandate GID-based merging (when RID is not stable), so we have
+a new API that allows resources to switch the merging mode of ItemSync optionally.
+
+(cherry picked from commit 442961918d8f3d9ff94fd4593c9b09d1e89d6bc0)
+---
+
+
+--- a/akonadi/autotests/itemsynctest.cpp
++++ b/akonadi/autotests/itemsynctest.cpp
+@@ -451,14 +451,18 @@
+         AKVERIFYEXEC(syncer);
+ 
+         Item::List resultItems = fetchItems(col);
+-        QCOMPARE(resultItems.count(), 2);
+-
+-        ItemFetchJob *fetchJob = new ItemFetchJob(modifiedItem);
++        QCOMPARE(resultItems.count(), 3);
++
++        Item item;
++        item.setGid(QStringLiteral("gid2"));
++        ItemFetchJob *fetchJob = new ItemFetchJob(item);
+         fetchJob->fetchScope().fetchFullPayload();
+         AKVERIFYEXEC(fetchJob);
+-        QCOMPARE(fetchJob->items().size(), 1);
++        QCOMPARE(fetchJob->items().size(), 2);
+         QCOMPARE(fetchJob->items().first().payload<QByteArray>(), QByteArray("payload2"));
+         QCOMPARE(fetchJob->items().first().remoteId(), QString::fromLatin1("rid3"));
++        QCOMPARE(fetchJob->items().at(1).payload<QByteArray>(), QByteArray("payload1"));
++        QCOMPARE(fetchJob->items().at(1).remoteId(), QStringLiteral("rid2"));
+     }
+ 
+     /*
+
+--- a/akonadi/src/agentbase/resourcebase.cpp
++++ b/akonadi/src/agentbase/resourcebase.cpp
+@@ -76,6 +76,7 @@
+         , mItemSyncer(0)
+         , mItemSyncFetchScope(0)
+         , mItemTransactionMode(ItemSync::SingleTransaction)
++        , mItemMergeMode(ItemSync::RIDMerge)
+         , mCollectionSyncer(0)
+         , mTagSyncer(0)
+         , mRelationSyncer(0)
+@@ -189,6 +190,7 @@
+             mItemSyncer = new ItemSync(q->currentCollection());
+             mItemSyncer->setTransactionMode(mItemTransactionMode);
+             mItemSyncer->setBatchSize(mItemSyncBatchSize);
++            mItemSyncer->setMergeMode(mItemMergeMode);
+             if (mItemSyncFetchScope) {
+                 mItemSyncer->setFetchScope(*mItemSyncFetchScope);
+             }
+@@ -456,6 +458,7 @@
+     ItemSync *mItemSyncer;
+     ItemFetchScope *mItemSyncFetchScope;
+     ItemSync::TransactionMode mItemTransactionMode;
++    ItemSync::MergeMode mItemMergeMode;
+     CollectionSync *mCollectionSyncer;
+     TagSync *mTagSyncer;
+     RelationSync *mRelationSyncer;
+@@ -1379,6 +1382,12 @@
+     *(d->mItemSyncFetchScope) = fetchScope;
+ }
+ 
++void ResourceBase::setItemMergingMode(ItemSync::MergeMode mode)
++{
++    Q_D(ResourceBase);
++    d->mItemMergeMode = mode;
++}
++
+ void ResourceBase::setAutomaticProgressReporting(bool enabled)
+ {
+     Q_D(ResourceBase);
+
+--- a/akonadi/src/agentbase/resourcebase.h
++++ b/akonadi/src/agentbase/resourcebase.h
+@@ -545,6 +545,20 @@
+      * @since 4.6
+      */
+     void setItemTransactionMode(ItemSync::TransactionMode mode);
++
++    /**
++     * Set merge mode for item sync'ing.
++     *
++     * Default merge mode is RIDMerge.
++     *
++     * @note This method must be called before first call to itemRetrieved(),
++     * itemsRetrieved() or itemsRetrievedIncremental().
++     *
++     * @param mode Item merging mode (see ItemCreateJob for details on item merging)
++     * @see Akonadi::ItemSync::MergeMode
++     * @ince 4.14.11
++     */
++    void setItemMergingMode(ItemSync::MergeMode mode);
+ 
+     /**
+      * Set the fetch scope applied for item synchronization.
+
+--- a/akonadi/src/core/itemsync.cpp
++++ b/akonadi/src/core/itemsync.cpp
+@@ -61,6 +61,7 @@
+         , mProcessingBatch(false)
+         , mDisableAutomaticDeliveryDone(false)
+         , mBatchSize(10)
++        , mMergeMode(Akonadi::ItemSync::RIDMerge)
+     {
+         // we want to fetch all data by default
+         mFetchScope.fetchFullPayload();
+@@ -116,6 +117,7 @@
+     bool mDisableAutomaticDeliveryDone;
+ 
+     int mBatchSize;
++    Akonadi::ItemSync::MergeMode mMergeMode;
+ };
+ 
+ void ItemSyncPrivate::createOrMerge(const Item &item)
+@@ -127,11 +129,13 @@
+     }
+     mPendingJobs++;
+     ItemCreateJob *create = new ItemCreateJob(item, mSyncCollection, subjobParent());
+-    if (!item.gid().isEmpty()) {
+-        create->setMerge(ItemCreateJob::GID | ItemCreateJob::Silent);
+-    } else {
+-        create->setMerge(ItemCreateJob::RID | ItemCreateJob::Silent);
+-    }
++    ItemCreateJob::MergeOptions merge = ItemCreateJob::Silent;
++    if (mMergeMode == ItemSync::RIDMerge) {
++        merge |= ItemCreateJob::RID;
++    } else if (mMergeMode == ItemSync::GIDMerge && !item.gid().isEmpty()) {
++        merge |= ItemCreateJob::GID;
++    }
++    create->setMerge(merge);
+     q->connect(create, SIGNAL(result(KJob*)), q, SLOT(slotLocalChangeDone(KJob*)));
+ }
+ 
+@@ -535,5 +539,17 @@
+     d->mBatchSize = size;
+ }
+ 
++ItemSync::MergeMode ItemSync::mergeMode() const
++{
++    Q_D(const ItemSync);
++    return d->mMergeMode;
++}
++
++void ItemSync::setMergeMode(MergeMode mergeMode)
++{
++    Q_D(ItemSync);
++    d->mMergeMode = mergeMode;
++}
++
+ #include "moc_itemsync.cpp"
+ 
+
+--- a/akonadi/src/core/itemsync.h
++++ b/akonadi/src/core/itemsync.h
+@@ -56,6 +56,12 @@
+     Q_OBJECT
+ 
+ public:
++    enum MergeMode
++    {
++        RIDMerge,
++        GIDMerge
++    };
++
+     /**
+      * Creates a new item synchronizer.
+      *
+@@ -208,6 +214,27 @@
+      * @since 4.14
+      */
+     void setDisableAutomaticDeliveryDone(bool disable);
++
++    /**
++     * Returns current merge mode
++     *
++     * @see setMergeMode()
++     * @since 5.1
++     */
++    MergeMode mergeMode() const;
++
++    /**
++     * Set what merge method should be used for next ItemSync run
++     *
++     * By default ItemSync uses RIDMerge method.
++     *
++     * See ItemCreateJob for details on Item merging.
++     *
++     * @note You must call this method before starting the sync, changes afterwards lead to undefined results.
++     * @see mergeMode
++     * @since 4.14.11
++     */
++    void setMergeMode(MergeMode mergeMode);
+ 
+ Q_SIGNALS:
+     /**
+

--- a/kde-apps/kdepimlibs/files/kdepimlibs-15.08.0-RID-fallback.patch
+++ b/kde-apps/kdepimlibs/files/kdepimlibs-15.08.0-RID-fallback.patch
@@ -1,0 +1,31 @@
+From: Dan Vrátil <dvratil@redhat.com>
+Date: Sun, 13 Sep 2015 13:05:08 +0000
+Subject: Fix ItemSync merge type fallback
+X-Git-Url: http://quickgit.kde.org/?p=kdepimlibs.git&a=commitdiff&h=ffa20e75f388bfa87530e113641f0830a5a58ec4
+---
+Fix ItemSync merge type fallback
+
+Always fallback to RID merge, even when GID merge is requsted, but no GID
+is present.
+
+(cherry picked from commit d8b5da7bb16bfd3652e83200d851af3a21816469)
+---
+
+
+--- a/akonadi/src/core/itemsync.cpp
++++ b/akonadi/src/core/itemsync.cpp
+@@ -130,10 +130,10 @@
+     mPendingJobs++;
+     ItemCreateJob *create = new ItemCreateJob(item, mSyncCollection, subjobParent());
+     ItemCreateJob::MergeOptions merge = ItemCreateJob::Silent;
+-    if (mMergeMode == ItemSync::RIDMerge) {
++    if (mMergeMode == ItemSync::GIDMerge && !item.gid().isEmpty()) {
++        merge |= ItemCreateJob::GID;
++    } else {
+         merge |= ItemCreateJob::RID;
+-    } else if (mMergeMode == ItemSync::GIDMerge && !item.gid().isEmpty()) {
+-        merge |= ItemCreateJob::GID;
+     }
+     create->setMerge(merge);
+     q->connect(create, SIGNAL(result(KJob*)), q, SLOT(slotLocalChangeDone(KJob*)));
+

--- a/kde-apps/kdepimlibs/kdepimlibs-15.08.0-r1.ebuild
+++ b/kde-apps/kdepimlibs/kdepimlibs-15.08.0-r1.ebuild
@@ -65,6 +65,10 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 src_prepare() {
+
+	epatch "${FILESDIR}/${PN}-15.08.0-GID-merge.patch" \
+		"${FILESDIR}/${PN}-15.08.0-RID-fallback.patch"
+
 	use handbook || \
 		sed -e '/^find_package.*KF5DocTools/ s/^/#/' \
 			-e '/^add_subdirectory(docs)/ s/^/#/' \

--- a/kde-apps/kdepimlibs/kdepimlibs-15.08.1.ebuild
+++ b/kde-apps/kdepimlibs/kdepimlibs-15.08.1.ebuild
@@ -65,6 +65,10 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 src_prepare() {
+
+	epatch "${FILESDIR}/${PN}-15.08.0-GID-merge.patch" \
+		"${FILESDIR}/${PN}-15.08.0-RID-fallback.patch"
+
 	use handbook || \
 		sed -e '/^find_package.*KF5DocTools/ s/^/#/' \
 			-e '/^add_subdirectory(docs)/ s/^/#/' \


### PR DESCRIPTION
(hope it works for .1 as well, had to insert two newlines at end of files that were not present in .0 but also nowhere to be found in diff to .1)