### PR TITLE
kde-apps/gwenview: Fix missing menu items

### DIFF
--- a/kde-apps/gwenview/files/gwenview-15.08.1-fix-menu-items.patch
+++ b/kde-apps/gwenview/files/gwenview-15.08.1-fix-menu-items.patch
@@ -1,0 +1,12 @@
+--- a/app/CMakeLists.txt	2015-09-18 23:08:00.449716542 +0200
++++ b/app/CMakeLists.txt	2015-09-18 23:11:31.939072561 +0200
+@@ -88,7 +88,8 @@
+     ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ install(FILES gwenviewui.rc
+-    DESTINATION ${KDE_INSTALL_KXMLGUI5DIR}/gwenview)
++    DESTINATION ${KDE_INSTALL_KXMLGUI5DIR}/org.kde.gwenview
++    RENAME org.kde.gwenviewui.rc)
+ 
+ install(PROGRAMS org.kde.gwenview.desktop
+     DESTINATION ${KDE_INSTALL_APPDIR})

--- a/kde-apps/gwenview/gwenview-15.08.1.ebuild
+++ b/kde-apps/gwenview/gwenview-15.08.1.ebuild
@@ -57,6 +57,8 @@ DEPEND="${RDEPEND}
 	dev-qt/qtconcurrent:5
 "
 
+PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package kipi KF5Kipi)

--- a/kde-apps/gwenview/gwenview-15.08.49.9999.ebuild
+++ b/kde-apps/gwenview/gwenview-15.08.49.9999.ebuild
@@ -57,6 +57,8 @@ DEPEND="${RDEPEND}
 	dev-qt/qtconcurrent:5
 "
 
+PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package kipi KF5Kipi)

--- a/kde-apps/gwenview/gwenview-9999.ebuild
+++ b/kde-apps/gwenview/gwenview-9999.ebuild
@@ -57,6 +57,8 @@ DEPEND="${RDEPEND}
 	dev-qt/qtconcurrent:5
 "
 
+PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package kipi KF5Kipi)


### PR DESCRIPTION
Upstream bug: https://bugs.kde.org/show_bug.cgi?id=351431
Bad commit: https://quickgit.kde.org/?p=gwenview.git&a=commit&h=78e4e57af3a5476dd949797c559a3d25d8ce50a1

Package-Manager: portage-2.2.20.1