### PR TITLE
app-text/kbibtex: Remove kdelibs4support DEPEND, add gcc check

### DIFF
--- a/app-office/skrooge/skrooge-9999.ebuild
+++ b/app-office/skrooge/skrooge-9999.ebuild
@@ -4,6 +4,7 @@
 
 EAPI=5
 
+KDE_GCC_MINIMAL="4.9"
 KDE_HANDBOOK="true"
 KDE_TEST="true"
 VIRTUALX_REQUIRED="test"
@@ -80,14 +81,6 @@ if [[ ${KDE_BUILD_TYPE} != live ]]; then
 fi
 
 DOCS=( AUTHORS CHANGELOG README TODO )
-
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary  && $(tc-getCC) == *gcc* ]]; then
-		if [[ $(gcc-major-version) -lt 4 || $(gcc-major-version) == 4 && $(gcc-minor-version) -lt 9 ]] ; then
-			die 'The active compiler needs to be gcc 4.9 (or newer)'
-		fi
-	fi
-}
 
 src_configure() {
 	local mycmakeargs=(

--- a/app-text/kbibtex/kbibtex-9999.ebuild
+++ b/app-text/kbibtex/kbibtex-9999.ebuild
@@ -4,6 +4,7 @@
 
 EAPI=5
 
+KDE_GCC_MINIMAL="4.9"
 inherit kde5
 
 DESCRIPTION="BibTeX editor to edit bibliographies used with LaTeX"
@@ -22,7 +23,6 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
@@ -47,6 +47,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	dev-tex/bibtex2html
+	!app-text/kbibtex:4
 "
 
 S=${WORKDIR}/${P/_/-}

--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -38,6 +38,11 @@ esac
 # Minimal KDE Applicaions version to require for the package.
 : ${KDE_APPS_MINIMAL:=14.12.0}
 
+# @ECLASS-VARIABLE: KDE_GCC_MINIMAL
+# @DESCRIPTION:
+# Minimal GCC version to require for the package.
+: ${KDE_GCC_MINIMAL:=4.8}
+
 # @ECLASS-VARIABLE: KDEBASE
 # @DESCRIPTION:
 # This gets set to a non-zero value when a package is considered a kde or
@@ -79,10 +84,12 @@ _check_gcc_version() {
 		local version=$(gcc-version)
 		local major=${version%.*}
 		local minor=${version#*.}
+		local min_major=${KDE_GCC_MINIMAL%.*}
+		local min_minor=${KDE_GCC_MINIMAL#*.}
 
-		[[ ${major} -lt 4 ]] || \
-				( [[ ${major} -eq 4 && ${minor} -lt 8 ]] ) \
-			&& die "Sorry, but gcc-4.8 or later is required for KDE 5."
+		[[ ${major} -lt ${min_major} ]] || \
+				( [[ ${major} -eq ${min_major} && ${minor} -lt ${min_minor} ]] ) \
+			&& die "Sorry, but gcc-${KDE_GCC_MINIMAL} or later is required for this package."
 	fi
 }
 


### PR DESCRIPTION
Package does not build using <gcc-4.9

Package-Manager: portage-2.2.20.1