### PR TITLE
kde-apps/{kdepim,ktp}-l10n: Add missing DEPEND

### DIFF
--- a/kde-apps/kdepim-l10n/kdepim-l10n-15.08.1.ebuild
+++ b/kde-apps/kdepim-l10n/kdepim-l10n-15.08.1.ebuild
@@ -12,6 +12,7 @@ HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
+	dev-qt/linguist-tools:5
 	sys-devel/gettext
 "
 RDEPEND="

--- a/kde-apps/ktp-l10n/ktp-l10n-15.08.1.ebuild
+++ b/kde-apps/ktp-l10n/ktp-l10n-15.08.1.ebuild
@@ -7,11 +7,12 @@ EAPI=5
 KDE_HANDBOOK="false"
 inherit kde5
 
-DESCRIPTION="KDE PIM internationalization package"
+DESCRIPTION="KDE Telepathy internationalization package"
 HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
+	dev-qt/linguist-tools:5
 	sys-devel/gettext
 "
 RDEPEND="


### PR DESCRIPTION
See also: https://bugs.gentoo.org/show_bug.cgi?id=561066

Package-Manager: portage-2.2.20.1