### PR TITLE
kde-plasma/plasma-nm: Add DEPEND on app-crypt/qca

### DIFF
--- a/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
@@ -32,6 +32,7 @@ DEPEND="
 	$(add_frameworks_dep networkmanager-qt 'teamd=')
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
+	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
 	dev-qt/qtdbus:5
 	dev-qt/qtdeclarative:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
Upstream commit: edc29fb7ca7c9610156bfe571c4bcec2cef44be4

Depends on https://github.com/gentoo/gentoo/pull/128

Package-Manager: portage-2.2.20.1