### PR TITLE
kde-apps/libkcompactdisc: Add missing DEPEND

### DIFF
--- a/kde-apps/libkcompactdisc/libkcompactdisc-5.9999.ebuild
+++ b/kde-apps/libkcompactdisc/libkcompactdisc-5.9999.ebuild
@@ -13,6 +13,7 @@ IUSE="alsa"
 
 DEPEND="
 	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep solid)
 	media-libs/phonon[qt5]


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1