### PR TITLE
kde-plasma/kde-gtk-config: Make gtk+3 optional

### DIFF
--- a/kde-plasma/kde-gtk-config/files/kde-gtk-config-5.4.2-gtk3-optional.patch
+++ b/kde-plasma/kde-gtk-config/files/kde-gtk-config-5.4.2-gtk3-optional.patch
@@ -1,0 +1,19 @@
+--- a/CMakeLists.txt	2015-10-02 22:36:55.186480671 +0200
++++ b/CMakeLists.txt	2015-10-02 22:38:40.048169719 +0200
+@@ -17,6 +17,7 @@
+ include(ECMSetupVersion)
+ include(ECMInstallIcons)
+ include(ECMMarkAsTest)
++include(ECMOptionalAddSubdirectory)
+ include(GenerateExportHeader)
+ include(FeatureSummary)
+ include(KDEInstallDirs)
+@@ -62,7 +63,7 @@
+ install(FILES kde-gtk-config.desktop DESTINATION ${SERVICES_INSTALL_DIR})
+ 
+ add_subdirectory(gtkproxies)
+-add_subdirectory(gtk3proxies)
++ecm_optional_add_subdirectory(gtk3proxies)
+ add_subdirectory(icons)
+ add_subdirectory(tests)
+ 

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-5.4.2.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-5.4.2.ebuild
@@ -11,6 +11,7 @@ DESCRIPTION="KDE systemsettings kcm to set GTK application look&feel"
 HOMEPAGE="https://projects.kde.org/kde-gtk-config"
 LICENSE="GPL-3"
 KEYWORDS="~amd64 ~x86"
+IUSE="+gtk3"
 
 DEPEND="
 	$(add_frameworks_dep karchive)
@@ -26,7 +27,7 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	x11-libs/gtk+:2
-	x11-libs/gtk+:3
+	gtk3? ( x11-libs/gtk+:3 )
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
@@ -34,9 +35,12 @@ RDEPEND="${DEPEND}
 	!kde-misc/kde-gtk-config
 "
 
+PATCHES=( "${FILESDIR}/${PN}-5.4.2-gtk3-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		-DDATA_INSTALL_DIR="${EPREFIX}/usr/share"
+		-DBUILD_gtk3proxies=$(usex gtk3)
 	)
 
 	kde5_src_configure

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-5.4.49.9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-5.4.49.9999.ebuild
@@ -11,6 +11,7 @@ DESCRIPTION="KDE systemsettings kcm to set GTK application look&feel"
 HOMEPAGE="https://projects.kde.org/kde-gtk-config"
 LICENSE="GPL-3"
 KEYWORDS=""
+IUSE="+gtk3"
 
 DEPEND="
 	$(add_frameworks_dep karchive)
@@ -26,7 +27,7 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	x11-libs/gtk+:2
-	x11-libs/gtk+:3
+	gtk3? ( x11-libs/gtk+:3 )
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
@@ -34,9 +35,12 @@ RDEPEND="${DEPEND}
 	!kde-misc/kde-gtk-config
 "
 
+PATCHES=( "${FILESDIR}/${PN}-5.4.2-gtk3-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		-DDATA_INSTALL_DIR="${EPREFIX}/usr/share"
+		-DBUILD_gtk3proxies=$(usex gtk3)
 	)
 
 	kde5_src_configure

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
@@ -11,6 +11,7 @@ DESCRIPTION="KDE systemsettings kcm to set GTK application look&feel"
 HOMEPAGE="https://projects.kde.org/kde-gtk-config"
 LICENSE="GPL-3"
 KEYWORDS=""
+IUSE="+gtk3"
 
 DEPEND="
 	$(add_frameworks_dep karchive)
@@ -26,7 +27,7 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	x11-libs/gtk+:2
-	x11-libs/gtk+:3
+	gtk3? ( x11-libs/gtk+:3 )
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
@@ -34,9 +35,12 @@ RDEPEND="${DEPEND}
 	!kde-misc/kde-gtk-config
 "
 
+PATCHES=( "${FILESDIR}/${PN}-5.4.2-gtk3-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		-DDATA_INSTALL_DIR="${EPREFIX}/usr/share"
+		-DBUILD_gtk3proxies=$(usex gtk3)
 	)
 
 	kde5_src_configure

--- a/kde-plasma/kde-gtk-config/metadata.xml
+++ b/kde-plasma/kde-gtk-config/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
+	<use>
+		<flag name="gtk3">Add support for gtk+3-based applications.</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
gtk3proxies depends on a ui file from gtkproxies, so gtk+2 is kept unconditionally.

Package-Manager: portage-2.2.20.1