### PR TITLE
gwenview, kipi-plugins, libkexiv2: Fix dependencies

### DIFF
--- a/kde-apps/gwenview/gwenview-15.08.1-r1.ebuild
+++ b/kde-apps/gwenview/gwenview-15.08.1-r1.ebuild
@@ -16,7 +16,7 @@ IUSE="kipi raw semantic-desktop X"
 # requires running environment
 RESTRICT="test"
 
-RDEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kactivities)
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
@@ -52,9 +52,12 @@ RDEPEND="
 		x11-libs/libX11
 	)
 "
-
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	dev-qt/qtconcurrent:5
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kimageformats)
+	dev-qt/qtimageformats:5
 "
 
 PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )

--- a/kde-apps/gwenview/gwenview-15.08.49.9999.ebuild
+++ b/kde-apps/gwenview/gwenview-15.08.49.9999.ebuild
@@ -16,7 +16,7 @@ IUSE="kipi raw semantic-desktop X"
 # requires running environment
 RESTRICT="test"
 
-RDEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kactivities)
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
@@ -52,9 +52,12 @@ RDEPEND="
 		x11-libs/libX11
 	)
 "
-
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	dev-qt/qtconcurrent:5
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kimageformats)
+	dev-qt/qtimageformats:5
 "
 
 PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )

--- a/kde-apps/gwenview/gwenview-9999.ebuild
+++ b/kde-apps/gwenview/gwenview-9999.ebuild
@@ -16,7 +16,7 @@ IUSE="kipi raw semantic-desktop X"
 # requires running environment
 RESTRICT="test"
 
-RDEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kactivities)
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
@@ -52,9 +52,12 @@ RDEPEND="
 		x11-libs/libX11
 	)
 "
-
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	dev-qt/qtconcurrent:5
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kimageformats)
+	dev-qt/qtimageformats:5
 "
 
 PATCHES=( "${FILESDIR}/${PN}-15.08.1-fix-menu-items.patch" )

--- a/kde-apps/libkexiv2/libkexiv2-5.9999.ebuild
+++ b/kde-apps/libkexiv2/libkexiv2-5.9999.ebuild
@@ -12,16 +12,9 @@ KEYWORDS=""
 IUSE="+xmp"
 
 DEPEND="
-	$(add_frameworks_dep kcompletion)
-	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
-	$(add_frameworks_dep khtml)
-	$(add_frameworks_dep kiconthemes)
-	$(add_frameworks_dep ki18n)
-	$(add_frameworks_dep ktextwidgets)
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
-	>=media-gfx/exiv2-0.24:=[xmp=]
+	>=media-gfx/exiv2-0.25:=[xmp=]
 "
 RDEPEND="${DEPEND}"

--- a/media-plugins/kipi-plugins/kipi-plugins-9999.ebuild
+++ b/media-plugins/kipi-plugins/kipi-plugins-9999.ebuild
@@ -24,7 +24,7 @@ HOMEPAGE="http://www.digikam.org/"
 
 LICENSE="GPL-2"
 KEYWORDS=""
-IUSE="cdr calendar expoblending geolocator +imagemagick mediawiki opengl panorama vkontakte"
+IUSE="cdr calendar expoblending +imagemagick mediawiki opengl panorama vkontakte"
 
 if [[ ${KDE_BUILD_TYPE} != live ]]; then
 	LICENSE="${LICENSE} handbook? ( FDL-1.2 )"
@@ -50,11 +50,9 @@ COMMONDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep khtml)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
-	$(add_frameworks_dep kitemmodels)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kservice)
@@ -103,7 +101,7 @@ RDEPEND="${COMMONDEPEND}
 	imagemagick? ( || ( media-gfx/imagemagick media-gfx/graphicsmagick[imagemagick] ) )
 	panorama? (
 		media-gfx/enblend
-		>=media-gfx/hugin-2011.0.0
+		media-gfx/hugin
 	)
 "
 

--- a/media-plugins/kipi-plugins/metadata.xml
+++ b/media-plugins/kipi-plugins/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="expoblending">Build the expoblending plugin, which requires media-gfx/hugin</flag>
-		<flag name="geolocator">Build the geolocator plugin, which requires kde-apps/libkgeomap and thereby marble</flag>
 		<flag name="mediawiki">Build the mediawiki export plugin</flag>
 		<flag name="panorama">Pull in dependencies needed by panorama plugin</flag>
 		<flag name="vkontakte">Build plugin for vkontakte.ru</flag>


### PR DESCRIPTION
libkexiv2 depends on https://github.com/gentoo/gentoo/pull/18 (merged)