### PR TITLE
Remove obsolete problematic blockers

### DIFF
--- a/kde-apps/kio-extras/kio-extras-15.08.1.ebuild
+++ b/kde-apps/kio-extras/kio-extras-15.08.1.ebuild
@@ -51,8 +51,6 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kded)
 	!<kde-apps/kcontrol-15.08.0-r1:4
-	!kde-base/kio-extras
-	!kde-plasma/kio-extras
 "
 DEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info

--- a/kde-apps/kio-extras/kio-extras-15.08.49.9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-15.08.49.9999.ebuild
@@ -51,8 +51,6 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kded)
 	!<kde-apps/kcontrol-15.08.0-r1:4
-	!kde-base/kio-extras
-	!kde-plasma/kio-extras
 "
 DEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info

--- a/kde-apps/kio-extras/kio-extras-9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-9999.ebuild
@@ -51,8 +51,6 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kded)
 	!<kde-apps/kcontrol-15.08.0-r1:4
-	!kde-base/kio-extras
-	!kde-plasma/kio-extras
 "
 DEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
@@ -117,7 +117,6 @@ RDEPEND="${COMMON_DEPEND}
 	!kde-base/ksmserver
 	!kde-base/ksplash
 	!kde-base/plasma-workspace
-	!kde-plasma/kio-extras
 "
 DEPEND="${COMMON_DEPEND}
 	x11-proto/xproto

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -117,7 +117,6 @@ RDEPEND="${COMMON_DEPEND}
 	!kde-base/ksmserver
 	!kde-base/ksplash
 	!kde-base/plasma-workspace
-	!kde-plasma/kio-extras
 "
 DEPEND="${COMMON_DEPEND}
 	x11-proto/xproto

--- a/profiles/updates/3Q-2015
+++ b/profiles/updates/3Q-2015
@@ -1,7 +1,7 @@
 slotmove dev-util/kdevelop-pg-qt 0 5
 move kde-plasma/baloo-widgets kde-apps/baloo-widgets
 move kde-plasma/kio-extras kde-apps/kio-extras
-
+move kde-base/kio-extras kde-apps/kio-extras
 move app-office/akonadi-server kde-apps/akonadi
 slotmove kde-apps/akonadi 0 5
 move kde-apps/akonadi app-office/akonadi-server


### PR DESCRIPTION
This changes fix unresolvable portage blocks while keeping the transition of the kio-extras package from former categories