### PR TITLE
Bump the required Wayland version

### DIFF
--- a/kde-plasma/kwayland/kwayland-9999.ebuild
+++ b/kde-plasma/kwayland/kwayland-9999.ebuild
@@ -15,7 +15,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	>=dev-libs/wayland-1.3.0
+	>=dev-libs/wayland-1.7.0
 	dev-qt/qtgui:5
 	media-libs/mesa[egl]
 "


### PR DESCRIPTION
The minimal version got increased to 1.6 in upstream commit
48326670528c7068648744c524c78dada40f1ce6 (early September), and then to
1.7 in upstream commit aef4708353fa2b6b22f08358cb72def947da9863 (mid
September).