### PR TITLE
Add a live ebuild for the KF5 version of rsibreak

### DIFF
--- a/kde-misc/rsibreak/rsibreak-9999.ebuild
+++ b/kde-misc/rsibreak/rsibreak-9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+KDE_HANDBOOK=true
+inherit kde5
+
+DESCRIPTION="Small utility which bothers you at certain intervals"
+HOMEPAGE="https://userbase.kde.org/RSIBreak"
+
+LICENSE="GPL-2+ FDL-1.2"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdoctools)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep kwindowsystem)
+"
+RDEPEND="${DEPEND}
+	!kde-misc/rsibreak:4
+"


### PR DESCRIPTION
I've changed the ${LICENSE} to show that it's actually GPLv2 or later
because that's what the source files say, based on a quick grep. There's
no support for translations so far because I have no idea how they work
in "kde5".

The blocker is in place because the eclass apparently only works for
kde-apps/, not kde-misc/.