### PR TITLE
kde-frameworks/kio: Fix file collisions with kde-apps/libkonq

### DIFF
--- a/kde-apps/libkonq/libkonq-15.08.49.9999.ebuild
+++ b/kde-apps/libkonq/libkonq-15.08.49.9999.ebuild
@@ -11,9 +11,20 @@ inherit kde4-meta
 
 DESCRIPTION="The embeddable part of konqueror"
 KEYWORDS=""
-IUSE="debug"
+IUSE="debug minimal"
 RESTRICT="test"
 
 KMSAVELIBS="true"
 
 PATCHES=( "${FILESDIR}/${PN}-4.9.0-cmake.patch" )
+
+src_install() {
+	kde4-base_src_install
+
+	if use minimal; then
+		rm "${D}"/usr/share/templates/{Directory,HTMLFile,TextFile}.desktop || die
+		rm "${D}"/usr/share/templates/{linkPath,linkProgram,linkURL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{Program,URL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{HTMLFile.html,TextFile.txt} || die
+	fi
+}

--- a/kde-apps/libkonq/libkonq-5.9999.ebuild
+++ b/kde-apps/libkonq/libkonq-5.9999.ebuild
@@ -13,7 +13,7 @@ inherit kde5
 
 DESCRIPTION="The embeddable part of konqueror"
 KEYWORDS=""
-IUSE=""
+IUSE="minimal"
 
 DEPEND="
 	$(add_frameworks_dep kbookmarks)
@@ -39,3 +39,14 @@ RDEPEND="${DEPEND}"
 RESTRICT="test"
 
 S=${S}/lib/konq
+
+src_install() {
+	kde5_src_install
+
+	if use minimal; then
+		rm "${D}"/usr/share/templates/{Directory,HTMLFile,TextFile}.desktop || die
+		rm "${D}"/usr/share/templates/{linkPath,linkProgram,linkURL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{Program,URL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{HTMLFile.html,TextFile.txt} || die
+	fi
+}

--- a/kde-apps/libkonq/libkonq-9999.ebuild
+++ b/kde-apps/libkonq/libkonq-9999.ebuild
@@ -11,9 +11,20 @@ inherit kde4-meta
 
 DESCRIPTION="The embeddable part of konqueror"
 KEYWORDS=""
-IUSE="debug"
+IUSE="debug minimal"
 RESTRICT="test"
 
 KMSAVELIBS="true"
 
 PATCHES=( "${FILESDIR}/${PN}-4.9.0-cmake.patch" )
+
+src_install() {
+	kde4-base_src_install
+
+	if use minimal; then
+		rm "${D}"/usr/share/templates/{Directory,HTMLFile,TextFile}.desktop || die
+		rm "${D}"/usr/share/templates/{linkPath,linkProgram,linkURL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{Program,URL}.desktop || die
+		rm "${D}"/usr/share/templates/.source/{HTMLFile.html,TextFile.txt} || die
+	fi
+}

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="LGPL-2+"
 KEYWORDS=""
 IUSE="acl kerberos X"
 
-RDEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep karchive)
 	$(add_frameworks_dep kbookmarks)
 	$(add_frameworks_dep kcodecs)
@@ -49,7 +49,7 @@ RDEPEND="
 	kerberos? ( virtual/krb5 )
 	X? ( dev-qt/qtx11extras:5 )
 "
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kdoctools)
 	dev-qt/qtconcurrent:5
 	test? ( sys-libs/zlib )
@@ -61,6 +61,9 @@ DEPEND="${RDEPEND}
 "
 PDEPEND="
 	$(add_frameworks_dep kded)
+"
+RDEPEND="${COMMON_DEPEND}
+	!kde-apps/libkonq[-minimal(-)]
 "
 
 # tests hang


### PR DESCRIPTION
File collisions in the template directory, see also:
https://quickgit.kde.org/?p=kio.git&a=commit&h=1b98a313983b75f3340639e5cd9519c56fca7113