### PR TITLE
kde-apps/libkdcraw: Remove any kf5 dependencies

### DIFF
--- a/kde-apps/libkdcraw/libkdcraw-5.9999.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-5.9999.ebuild
@@ -7,22 +7,12 @@ EAPI=5
 EGIT_BRANCH="frameworks"
 inherit kde5
 
-DESCRIPTION="KDE digital camera raw image library wrapper"
+DESCRIPTION="Digital camera raw image library wrapper"
 KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	$(add_frameworks_dep kcompletion)
-	$(add_frameworks_dep kconfig)
-	$(add_frameworks_dep kdelibs4support)
-	$(add_frameworks_dep ki18n)
-	$(add_frameworks_dep kiconthemes)
-	$(add_frameworks_dep kio)
-	$(add_frameworks_dep kservice)
-	$(add_frameworks_dep kwidgetsaddons)
-	$(add_frameworks_dep threadweaver)
 	>=media-libs/libraw-0.16:=
 	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
See also https://quickgit.kde.org/?p=libkdcraw.git&a=commit&h=750bf689076d8e15a88dc89b18294fbfc9238fb3

Package-Manager: portage-2.2.23