### PR TITLE
kde-apps/kholidays: DEPENDs only on dev-qt/qtcore

### DIFF
--- a/kde-apps/kholidays/kholidays-9999.ebuild
+++ b/kde-apps/kholidays/kholidays-9999.ebuild
@@ -11,23 +11,12 @@ inherit kde5
 DESCRIPTION="Library for determining holidays and other special events for a geographical region"
 LICENSE="LGPL-2+"
 KEYWORDS=""
-IUSE="designer"
+IUSE=""
 
-RDEPEND="
-	$(add_frameworks_dep kcompletion)
-	$(add_frameworks_dep kdelibs4support)
-	$(add_frameworks_dep ki18n)
-	$(add_frameworks_dep kitemviews)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	designer? ( dev-qt/designer:5 )
-"
-DEPEND="${RDEPEND}"
+DEPEND=""
+RDEPEND=""
 
-src_configure() {
-	local mycmakeargs=(
-		$(cmake-utils_use_find_package designer Qt5Designer)
-	)
-
-	kde5_src_configure
+src_prepare() {
+	sed -e "/find_package(Qt5 .*Test/ s/Test/Core/" -i CMakeLists.txt
+	kde5_src_prepare
 }


### PR DESCRIPTION
In preparation of becoming Tier 1 Framework.

Package-Manager: portage-2.2.23