### PR TITLE
kde-apps/kdebase-runtime-meta: Make more RDEPENDs optional

### DIFF
--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.49.9999.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.49.9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS=""
-IUSE="crash-reporter minimal"
+IUSE="crash-reporter minimal +oldwallet"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell)
@@ -21,7 +21,6 @@ RDEPEND="
 	$(add_kdeapps_dep kdontchangethehostname)
 	$(add_kdeapps_dep keditfiletype)
 	$(add_kdeapps_dep kfile)
-	$(add_kdeapps_dep kglobalaccel)
 	$(add_kdeapps_dep kiconfinder)
 	$(add_kdeapps_dep kimgio)
 	$(add_kdeapps_dep kioclient)
@@ -34,20 +33,24 @@ RDEPEND="
 	$(add_kdeapps_dep kstart)
 	$(add_kdeapps_dep ktimezoned)
 	$(add_kdeapps_dep ktraderclient)
-	$(add_kdeapps_dep kuiserver)
 	$(add_kdeapps_dep kurifilter-plugins)
-	$(add_kdeapps_dep kwalletd)
 	$(add_kdeapps_dep phonon-kde)
 	$(add_kdeapps_dep plasma-runtime)
 	$(add_kdeapps_dep renamedlg-plugins)
 	$(add_kdeapps_dep solid-runtime)
 	crash-reporter? ( $(add_kdeapps_dep drkonqi ) )
-	minimal? ( $(add_kdeapps_dep solid-runtime '-bluetooth') )
+	minimal? (
+		$(add_kdeapps_dep solid-runtime '-bluetooth')
+		oldwallet? ( $(add_kdeapps_dep kwalletd) )
+	)
 	!minimal? (
 		$(add_kdeapps_dep attica)
 		$(add_kdeapps_dep kcontrol)
 		$(add_kdeapps_dep kdebase-kioslaves)
+		$(add_kdeapps_dep kglobalaccel)
 		$(add_kdeapps_dep knetattach)
+		$(add_kdeapps_dep kuiserver)
+		$(add_kdeapps_dep kwalletd)
 	)
 "
 REQUIRED_USE="minimal? ( !crash-reporter )"

--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-9999.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-9999.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS=""
-IUSE="crash-reporter minimal"
+IUSE="crash-reporter minimal +oldwallet"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell)
@@ -21,7 +21,6 @@ RDEPEND="
 	$(add_kdeapps_dep kdontchangethehostname)
 	$(add_kdeapps_dep keditfiletype)
 	$(add_kdeapps_dep kfile)
-	$(add_kdeapps_dep kglobalaccel)
 	$(add_kdeapps_dep kiconfinder)
 	$(add_kdeapps_dep kimgio)
 	$(add_kdeapps_dep kioclient)
@@ -34,20 +33,24 @@ RDEPEND="
 	$(add_kdeapps_dep kstart)
 	$(add_kdeapps_dep ktimezoned)
 	$(add_kdeapps_dep ktraderclient)
-	$(add_kdeapps_dep kuiserver)
 	$(add_kdeapps_dep kurifilter-plugins)
-	$(add_kdeapps_dep kwalletd)
 	$(add_kdeapps_dep phonon-kde)
 	$(add_kdeapps_dep plasma-runtime)
 	$(add_kdeapps_dep renamedlg-plugins)
 	$(add_kdeapps_dep solid-runtime)
 	crash-reporter? ( $(add_kdeapps_dep drkonqi ) )
-	minimal? ( $(add_kdeapps_dep solid-runtime '-bluetooth') )
+	minimal? (
+		$(add_kdeapps_dep solid-runtime '-bluetooth')
+		oldwallet? ( $(add_kdeapps_dep kwalletd) )
+	)
 	!minimal? (
 		$(add_kdeapps_dep attica)
 		$(add_kdeapps_dep kcontrol)
 		$(add_kdeapps_dep kdebase-kioslaves)
+		$(add_kdeapps_dep kglobalaccel)
 		$(add_kdeapps_dep knetattach)
+		$(add_kdeapps_dep kuiserver)
+		$(add_kdeapps_dep kwalletd)
 	)
 "
 REQUIRED_USE="minimal? ( !crash-reporter )"

--- a/kde-apps/kdebase-runtime-meta/metadata.xml
+++ b/kde-apps/kdebase-runtime-meta/metadata.xml
@@ -5,5 +5,6 @@
 	<use>
 		<flag name="crash-reporter">Builds a gui tool to submit crash information to the upstream backtracker</flag>
 		<flag name="minimal">Install a Plasma 5 compatible subset of the package</flag>
+		<flag name="oldwallet">Install <pkg>kde-apps/kwalletd</pkg> on a minimal setup for migration purposes</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
kglobalaccel, kuiserver: Do it like upstream and don't RDEPEND if USE=minimal
See upstream commit be3ee5b9a36e1b7f3c6eab466e33762ae101b3c6

kwalletd: Make it optional with USE=oldwallet

Package-Manager: portage-2.2.23