### PR TITLE
kde-apps/kpimtextedit: Fix DEPENDs

### DIFF
--- a/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
@@ -16,12 +16,18 @@ IUSE=""
 RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kemoticons)
 	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	dev-libs/grantlee:5
+	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 "


### PR DESCRIPTION
composereditor-ng was merged into kpimtextedit.

Package-Manager: portage-2.2.23