### PR TITLE
kde-frameworks: Drop dependencies

### DIFF
--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -5,13 +5,15 @@
 EAPI=5
 
 VIRTUALX_REQUIRED="test"
+KDE_HANDBOOK="true"
+KDE_DOC_DIR="docs"
 KDE_PUNT_BOGUS_DEPS=true
 inherit kde5
 
 DESCRIPTION="Framework providing transparent file and data management"
 LICENSE="LGPL-2+"
 KEYWORDS=""
-IUSE="acl kerberos X"
+IUSE="acl kerberos +kwallet X"
 
 COMMON_DEPEND="
 	$(add_frameworks_dep karchive)
@@ -29,7 +31,6 @@ COMMON_DEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep ktextwidgets)
-	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
@@ -47,10 +48,10 @@ COMMON_DEPEND="
 		virtual/acl
 	)
 	kerberos? ( virtual/krb5 )
+	kwallet? ( $(add_frameworks_dep kwallet) )
 	X? ( dev-qt/qtx11extras:5 )
 "
 DEPEND="${COMMON_DEPEND}
-	$(add_frameworks_dep kdoctools)
 	dev-qt/qtconcurrent:5
 	test? ( sys-libs/zlib )
 	X? (
@@ -72,7 +73,9 @@ RESTRICT="test"
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package acl)
+		$(cmake-utils_use_find_package handbook KF5DocTools)
 		$(cmake-utils_use_find_package kerberos GSSAPI)
+		$(cmake-utils_use_find_package kwallet KF5Wallet)
 		$(cmake-utils_use_find_package X X11)
 	)
 

--- a/kde-frameworks/kio/metadata.xml
+++ b/kde-frameworks/kio/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<herd>kde</herd>
+	<use>
+		<flag name="kwallet">Enable permanent storage of passwords for kpasswdserver with <pkg>kde-frameworks/kwallet</pkg></flag>
+	</use>
 </pkgmetadata>

--- a/kde-frameworks/kparts/kparts-9999.ebuild
+++ b/kde-frameworks/kparts/kparts-9999.ebuild
@@ -19,7 +19,6 @@ RDEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kjobwidgets)
-	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)


### PR DESCRIPTION
See also: https://git.reviewboard.kde.org/r/125673/

kwallet - not sure about use flag name - it is optional in a few places where so far "kde" has been used.

Package-Manager: portage-2.2.23