### PR TITLE
kde-apps/kate: Drop knotifications dependency

### DIFF
--- a/kde-apps/kate/kate-9999.ebuild
+++ b/kde-apps/kate/kate-9999.ebuild
@@ -44,7 +44,6 @@ DEPEND="
 	addons? (
 		$(add_frameworks_dep kbookmarks)
 		$(add_frameworks_dep knewstuff)
-		$(add_frameworks_dep knotifications)
 		$(add_frameworks_dep kwallet)
 		$(add_frameworks_dep plasma)
 		$(add_frameworks_dep threadweaver)


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1