### PR TITLE
kde-plasma/kwin: Support multimedia USE flag instead gstreamer

### DIFF
--- a/kde-plasma/kwin/kwin-5.4.49.9999.ebuild
+++ b/kde-plasma/kwin/kwin-5.4.49.9999.ebuild
@@ -12,7 +12,7 @@ inherit kde5
 DESCRIPTION="KDE window manager"
 LICENSE="GPL-2+"
 KEYWORDS=""
-IUSE="gles2 gstreamer wayland"
+IUSE="gles2 multimedia wayland"
 
 COMMON_DEPEND="
 	$(add_frameworks_dep kactivities)
@@ -63,7 +63,10 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
-	gstreamer? ( dev-qt/qtmultimedia:5[gstreamer,qml] )
+	multimedia? ( ||
+        ( dev-qt/qtmultimedia:5[gstreamer,-gstreamer010,qml]
+          dev-qt/qtmultimedia:5[-gstreamer,gstreamer010,qml] )
+    )
 	!kde-base/kwin:4
 	!kde-base/systemsettings:4
 "
@@ -77,8 +80,7 @@ DEPEND="${COMMON_DEPEND}
 
 src_prepare() {
 	kde5_src_prepare
-
-	use gstreamer || epatch "${FILESDIR}/${PN}-gstreamer-optional.patch"
+	use multimedia || epatch "${FILESDIR}/${PN}-gstreamer-optional.patch"
 }
 
 src_configure() {

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -12,7 +12,7 @@ inherit kde5
 DESCRIPTION="KDE window manager"
 LICENSE="GPL-2+"
 KEYWORDS=""
-IUSE="gles2 gstreamer"
+IUSE="gles2 multimedia"
 
 COMMON_DEPEND="
 	$(add_frameworks_dep kactivities)
@@ -61,7 +61,10 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
-	gstreamer? ( dev-qt/qtmultimedia:5[gstreamer,qml] )
+	multimedia? ( ||
+        ( dev-qt/qtmultimedia:5[gstreamer,-gstreamer010,qml]
+          dev-qt/qtmultimedia:5[-gstreamer,gstreamer010,qml] )
+    )
 	!kde-base/kwin:4
 	!kde-base/systemsettings:4
 "
@@ -75,6 +78,5 @@ DEPEND="${COMMON_DEPEND}
 
 src_prepare() {
 	kde5_src_prepare
-
-	use gstreamer || epatch "${FILESDIR}/${PN}-gstreamer-optional.patch"
+	use multimedia || epatch "${FILESDIR}/${PN}-gstreamer-optional.patch"
 }

--- a/kde-plasma/kwin/metadata.xml
+++ b/kde-plasma/kwin/metadata.xml
@@ -4,5 +4,6 @@
 	<herd>kde</herd>
 	<use>
 		<flag name="gles2">Use OpenGL ES 2 instead of full GL</flag>
+		<flag name="multimedia">Enable support for effect video button</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Not sure if this may be useful, I don't personally use gstreamer010, but someone may need it. QtMultimedia supports both gstreamer1.0 and gstreamer010 in their API, and kwin requires QtMultimedia with gstreamer for the video plugin. So basically here my idea is supporting gstreamer010 for the same implementation instead just avoiding it.