### PR TITLE
kde-plasma/plasma-workspace: RDEPEND on kio-extras for wp thumbs

### DIFF
--- a/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
@@ -96,6 +96,7 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kded)
+	$(add_kdeapps_dep kio-extras)
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep milou)
 	dev-qt/qdbus:5

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -93,6 +93,7 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kded)
+	$(add_kdeapps_dep kio-extras)
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep ksysguard)
 	$(add_plasma_dep milou)


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1