### PR TITLE
[WIP] [kde-plasma/kscreenlocker] Add live ebuild

### DIFF
--- a/kde-plasma/kscreenlocker/files/kde-np.pam
+++ b/kde-plasma/kscreenlocker/files/kde-np.pam
@@ -1,0 +1,10 @@
+#%PAM-1.0
+
+auth       required     pam_nologin.so
+auth	   required     pam_permit.so
+
+account    include      system-local-login
+
+password   include      system-local-login
+
+session    include      system-local-login

--- a/kde-plasma/kscreenlocker/files/kde.pam
+++ b/kde-plasma/kscreenlocker/files/kde.pam
@@ -1,0 +1,11 @@
+#%PAM-1.0
+
+auth       required     pam_nologin.so
+
+auth       include      system-local-login
+
+account    include      system-local-login
+
+password   include      system-local-login
+
+session    include      system-local-login

--- a/kde-plasma/kscreenlocker/files/kscreenlocker-5.4.90-no-SUID-no-GUID.patch
+++ b/kde-plasma/kscreenlocker/files/kscreenlocker-5.4.90-no-SUID-no-GUID.patch
@@ -1,0 +1,16 @@
+diff --git a/kcheckpass/CMakeLists.txt b/kcheckpass/CMakeLists.txt
+index a63fa1403e897e70989dc2e1ba7eed4bc69cbb51..12d1bfb3c690eca1acf344045a92eb942669da83 100644
+--- a/kcheckpass/CMakeLists.txt
++++ b/kcheckpass/CMakeLists.txt
+@@ -22,10 +22,6 @@ endif ()
+ 
+ set_property(TARGET kcheckpass APPEND_STRING PROPERTY COMPILE_FLAGS " -U_REENTRANT")
+ target_link_libraries(kcheckpass ${UNIXAUTH_LIBRARIES} ${SOCKET_LIBRARIES})
+-install(TARGETS kcheckpass DESTINATION ${KDE_INSTALL_LIBEXECDIR})
+-install(CODE "
+-    set(KCP_PATH \"\$ENV{DESTDIR}${KDE_INSTALL_LIBEXECDIR}/kcheckpass\")
+-    execute_process(COMMAND sh -c \"chown root '\${KCP_PATH}' && chmod +s '\${KCP_PATH}'\")
+-")
++install(TARGETS kcheckpass DESTINATION ${LIBEXEC_INSTALL_DIR})
+ 
+ #EXTRA_DIST = README

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -11,8 +11,6 @@ KEYWORDS=""
 IUSE=""
 
 COMMON_DEPEND="
-"
-RDEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kcrash)
 	$(add_frameworks_dep kdeclarative)
@@ -28,4 +26,8 @@ RDEPEND="
 	x11-libs/libxcb
 	x11-libs/xcb-util-keysyms
 "
-DEPEND="${RDEPEND}"
+RDEPEND="
+    ${COMMON_DEPEND}
+	!<kde-plasma/plasma-workspace-5.4.50
+"
+DEPEND="${COMMON_DEPEND}"

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="KDE Plasma Screen Locker"
+KEYWORDS=""
+IUSE=""
+
+COMMON_DEPEND="
+"
+RDEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcrash)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep plasma)
+	$(add_plasma_dep kwayland)
+	dev-libs/wayland
+	dev-qt/qtx11extras:5
+	x11-libs/libX11
+	x11-libs/libXi
+	x11-libs/libxcb
+	x11-libs/xcb-util-keysyms
+"
+DEPEND="${RDEPEND}"

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -45,7 +45,8 @@ COMMON_DEPEND="
 DEPEND="${COMMON_DEPEND}"
 
 RDEPEND="${COMMON_DEPEND}
-	!kde-base/kcheckpass:4
+	!<kde-base/kcheckpass-4.11.22-r1:4
+	!kde-base/kdebase-pam:4
 	!<kde-plasma/plasma-workspace-5.4.50
 "
 

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -67,11 +67,12 @@ src_configure() {
 
 src_install() {
 	kde5_src_install
+
+	newpamd "${FILESDIR}/kde.pam" kde
+	newpamd "${FILESDIR}/kde-np.pam" kde-np
+
 	if ! use pam; then
-		chown root "${ED}"usr/lib64/libexec/kcheckpass || die
-		chmod +s "${ED}"usr/lib64/libexec/kcheckpass || die
-	else
-		newpamd "${FILESDIR}/kde.pam" kde
-		newpamd "${FILESDIR}/kde-np.pam" kde-np
+		chown root "${ED}"usr/$(get_libdir)/libexec/kcheckpass || die
+		chmod +s "${ED}"usr/$(get_libdir)/libexec/kcheckpass || die
 	fi
 }

--- a/kde-plasma/kscreenlocker/metadata.xml
+++ b/kde-plasma/kscreenlocker/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+	<use>
+	</use>
+</pkgmetadata>

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -38,6 +38,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
 	$(add_plasma_dep kdecoration)
+	$(add_plasma_dep kscreenlocker)
 	$(add_plasma_dep kwayland)
 	>=dev-libs/libinput-0.10
 	>=dev-libs/wayland-1.2

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -15,6 +15,7 @@ KEYWORDS=""
 IUSE="dbus +drkonqi +geolocation gps prison qalculate"
 
 COMMON_DEPEND="
+	$(add_plasma_dep kscreenlocker)
 	$(add_plasma_dep kwayland)
 	$(add_plasma_dep kwin)
 	$(add_plasma_dep libkscreen)


### PR DESCRIPTION
This is a preliminary ebuild for `kde-plasma/kscreenlocker-9999`.

**TODO:**
- [x] Find a fix for the missing `$ENV{DESTDIR}` in `kcheckpass/CMakeLists.txt` - causes `chown` and `chmod` of `kcheckpass` to fail
- [x] Add dependencies in `kde-plasma/workspace-9999` and `kde-plasma/kwin-9999`
- [x] Add blocker for `<kde-plasma/plasma-workspace-5.4.50`
- [x] Add autotests
- [x] Check setuid requirements for `kcheckpass` with `USE="-pam"`
- [ ] Add blocker on `kde-base/kcheckpass` in:
  - [ ] `kde-plasma/kscreenlocker`
  - [ ] `kde-plasma/plasma-workspace`
- [ ] Check for further transitive deps using `lddtree` and add them
- [x] Check `CMakeLists.txt` for further Qt deps