### PR TITLE
kde-plasma/plasma-workspace: Fix dead button in drkonqi

### DIFF
--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.4.3-fix-drkonqi.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.4.3-fix-drkonqi.patch
@@ -1,0 +1,32 @@
+From: David Edmundson <kde@davidedmundson.co.uk>
+Date: Wed, 21 Oct 2015 16:42:01 +0000
+Subject: Don't connect to signals which don't exist
+X-Git-Url: http://quickgit.kde.org/?p=plasma-workspace.git&a=commitdiff&h=2441d350ef571329b67848f79668f3956534806e
+---
+Don't connect to signals which don't exist
+
+Fix KDialog porting
+---
+
+
+--- a/drkonqi/bugzillaintegration/reportassistantpages_bugzilla_duplicates.cpp
++++ b/drkonqi/bugzillaintegration/reportassistantpages_bugzilla_duplicates.cpp
+@@ -574,7 +574,7 @@
+                                   QIcon::fromTheme("view-refresh"),
+                                   i18nc("@info:tooltip", "Use this button to retry "
+                                                   "loading the bug report.")));
+-    connect(ui.m_retryButton, SIGNAL(clicked()), this, SLOT(reloadReport()));
++    connect(ui.m_retryButton, &QPushButton::clicked, this, &BugzillaReportInformationDialog::reloadReport);
+ 
+     m_suggestButton = new QPushButton(this);
+     ui.buttonBox->addButton(m_suggestButton, QDialogButtonBox::ActionRole);
+@@ -583,7 +583,7 @@
+                     QIcon::fromTheme("list-add"), i18nc("@info:tooltip", "Use this button to suggest that "
+                                              "the crash you experienced is related to this bug "
+                                              "report")));
+-    connect(this, SIGNAL(user1Clicked()) , this, SLOT(relatedReportClicked()));
++    connect(m_suggestButton, &QPushButton::clicked, this, &BugzillaReportInformationDialog::relatedReportClicked);
+ 
+     connect(ui.m_showOwnBacktraceCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleShowOwnBacktrace(bool)));
+ 
+

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.4.3.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.4.3.ebuild
@@ -126,6 +126,7 @@ DEPEND="${COMMON_DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-5.4-startkde-script.patch"
 	"${FILESDIR}/${PN}-5.4-consolekit2.patch"
+	"${FILESDIR}/${PN}-5.4.3-fix-drkonqi.patch"	#Upstream bug 354110
 )
 
 RESTRICT="test"

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.4.49.9999.ebuild
@@ -126,6 +126,7 @@ DEPEND="${COMMON_DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-5.4-startkde-script.patch"
 	"${FILESDIR}/${PN}-5.4-consolekit2.patch"
+	"${FILESDIR}/${PN}-5.4.3-fix-drkonqi.patch"	#Upstream bug 354110
 )
 
 RESTRICT="test"


### PR DESCRIPTION
Not nice: Getting a crash, then going through drkonqi and encountering a usability bug.

Package-Manager: portage-2.2.20.1