### PR TITLE
kde-plasma/breeze: Fix breeze-icons minimum version

### DIFF
--- a/kde-plasma/breeze/breeze-5.4.3.ebuild
+++ b/kde-plasma/breeze/breeze-5.4.3.ebuild
@@ -33,7 +33,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	$(add_frameworks_dep breeze-icons)
+	$(add_frameworks_dep breeze-icons '' '5.4.3')
 	$(add_plasma_dep kde-cli-tools)
 "
 

--- a/kde-plasma/breeze/breeze-5.4.49.9999.ebuild
+++ b/kde-plasma/breeze/breeze-5.4.49.9999.ebuild
@@ -33,7 +33,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	$(add_frameworks_dep breeze-icons)
+	$(add_frameworks_dep breeze-icons '' '5.4.3')
 	$(add_plasma_dep kde-cli-tools)
 "
 


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1