### PR TITLE
[kde-misc/kdeconnect] Adjust to removed wayland USE flag of kwin

### DIFF
--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -47,7 +47,7 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}
 	!kde-misc/kdeconnect:4
 	$(add_plasma_dep plasma-workspace)
-	wayland? ( $(add_plasma_dep kwin 'wayland') )
+	wayland? ( $(add_plasma_dep kwin) )
 "
 
 [[ ${KDE_BUILD_TYPE} != live ]] && S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
The 'wayland' USE flag of kwin was removed in b0ba1ce

Package-Manager: portage-2.2.23