### PR TITLE
kde5-functions.eclass punt_bogus_dep case insensitivity; app-office/skrooge: force handbook, tests optional

### DIFF
--- a/app-office/skrooge/skrooge-9999.ebuild
+++ b/app-office/skrooge/skrooge-9999.ebuild
@@ -5,8 +5,8 @@
 EAPI=5
 
 KDE_GCC_MINIMAL="4.9"
-KDE_HANDBOOK="true"
-KDE_TEST="true"
+KDE_HANDBOOK="forceoptional"
+KDE_TEST="forceoptional"
 VIRTUALX_REQUIRED="test"
 inherit kde5
 

--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -229,7 +229,7 @@ punt_bogus_dep() {
 	local prefix=${1}
 	local dep=${2}
 
-	pcregrep -Mn "(?s)find_package\s*\(\s*${prefix}.[^)]*?${dep}.*?\)" CMakeLists.txt > "${T}/bogus${dep}"
+	pcregrep -Mni "(?s)find_package\s*\(\s*${prefix}.[^)]*?${dep}.*?\)" CMakeLists.txt > "${T}/bogus${dep}"
 
 	# pcregrep returns non-zero on no matches/error
 	if [[ $? != 0 ]] ; then
@@ -243,7 +243,7 @@ punt_bogus_dep() {
 	sed -e "${first},${last}s/${dep}//" -i CMakeLists.txt || die
 
 	if [[ ${length} = 1 ]] ; then
-		sed -e "/find_package\s*(\s*${prefix}\s*REQUIRED\s*COMPONENTS\s*)/d" -i CMakeLists.txt || die
+		sed -e "/find_package\s*(\s*${prefix}\s*REQUIRED\s*COMPONENTS\s*)/I d" -i CMakeLists.txt || die
 	fi
 }
 


### PR DESCRIPTION
See also: https://github.com/gentoo/gentoo/pull/427