### PR TITLE
kde-apps/okular: Add USE=kde, fix CamelCase switch

### DIFF
--- a/kde-apps/okular/metadata.xml
+++ b/kde-apps/okular/metadata.xml
@@ -5,6 +5,7 @@
 		<flag name="chm">Enable support for Microsoft Compiled HTML Help files</flag>
 		<flag name="dpi">DPI detection support for PDF rendering via <pkg>x11-libs/libkscreen</pkg></flag>
 		<flag name="ebook">Add E-Book support</flag>
+		<flag name="kde">Enable kactivities support</flag>
 		<flag name="mobi">Add mobipocket support</flag>
 	</use>
 	<herd>kde</herd>

--- a/kde-apps/okular/okular-15.11.90.ebuild
+++ b/kde-apps/okular/okular-15.11.90.ebuild
@@ -15,7 +15,7 @@ inherit kde4-base
 DESCRIPTION="Okular is a universal document viewer based on KPDF for KDE 4"
 HOMEPAGE="https://okular.kde.org https://www.kde.org/applications/graphics/okular"
 KEYWORDS="~amd64 ~x86"
-IUSE="chm crypt debug djvu dpi ebook +jpeg mobi +postscript +pdf +tiff"
+IUSE="chm crypt debug djvu dpi ebook +jpeg kde mobi +postscript +pdf +tiff"
 
 DEPEND="
 	media-libs/freetype
@@ -30,6 +30,7 @@ DEPEND="
 		$(add_kdeapps_dep libkexiv2)
 		virtual/jpeg:0
 	)
+	kde? ( $(add_kdebase_dep kactivities '' 4.13.3) )
 	mobi? ( $(add_kdeapps_dep kdegraphics-mobipocket) )
 	pdf? ( >=app-text/poppler-0.20[qt4,-exceptions(-)] )
 	postscript? ( app-text/libspectre )
@@ -46,7 +47,8 @@ src_configure() {
 		$(cmake-utils_use_with ebook EPub)
 		$(cmake-utils_use_with jpeg)
 		$(cmake-utils_use_with jpeg Kexiv2)
-		$(cmake-utils_use_with mobi QMobiPocket)
+		$(cmake-utils_use_with kde KActivities)
+		$(cmake-utils_use_with mobi QMobipocket)
 		$(cmake-utils_use_with postscript LibSpectre)
 		$(cmake-utils_use_with pdf PopplerQt4)
 		$(cmake-utils_use_with pdf Poppler)

--- a/kde-apps/okular/okular-15.12.49.9999.ebuild
+++ b/kde-apps/okular/okular-15.12.49.9999.ebuild
@@ -15,7 +15,7 @@ inherit kde4-base
 DESCRIPTION="Okular is a universal document viewer based on KPDF for KDE 4"
 HOMEPAGE="https://okular.kde.org https://www.kde.org/applications/graphics/okular"
 KEYWORDS=""
-IUSE="chm crypt debug djvu dpi ebook +jpeg mobi +postscript +pdf +tiff"
+IUSE="chm crypt debug djvu dpi ebook +jpeg kde mobi +postscript +pdf +tiff"
 
 DEPEND="
 	media-libs/freetype
@@ -30,6 +30,7 @@ DEPEND="
 		$(add_kdeapps_dep libkexiv2)
 		virtual/jpeg:0
 	)
+	kde? ( $(add_kdebase_dep kactivities '' 4.13.3) )
 	mobi? ( $(add_kdeapps_dep kdegraphics-mobipocket) )
 	pdf? ( >=app-text/poppler-0.20[qt4,-exceptions(-)] )
 	postscript? ( app-text/libspectre )
@@ -46,7 +47,8 @@ src_configure() {
 		$(cmake-utils_use_with ebook EPub)
 		$(cmake-utils_use_with jpeg)
 		$(cmake-utils_use_with jpeg Kexiv2)
-		$(cmake-utils_use_with mobi QMobiPocket)
+		$(cmake-utils_use_with kde KActivities)
+		$(cmake-utils_use_with mobi QMobipocket)
 		$(cmake-utils_use_with postscript LibSpectre)
 		$(cmake-utils_use_with pdf PopplerQt4)
 		$(cmake-utils_use_with pdf Poppler)

--- a/kde-apps/okular/okular-9999.ebuild
+++ b/kde-apps/okular/okular-9999.ebuild
@@ -15,7 +15,7 @@ inherit kde4-base
 DESCRIPTION="Okular is a universal document viewer based on KPDF for KDE 4"
 HOMEPAGE="https://okular.kde.org https://www.kde.org/applications/graphics/okular"
 KEYWORDS=""
-IUSE="chm crypt debug djvu dpi ebook +jpeg mobi +postscript +pdf +tiff"
+IUSE="chm crypt debug djvu dpi ebook +jpeg kde mobi +postscript +pdf +tiff"
 
 DEPEND="
 	media-libs/freetype
@@ -30,6 +30,7 @@ DEPEND="
 		$(add_kdeapps_dep libkexiv2)
 		virtual/jpeg:0
 	)
+	kde? ( $(add_kdebase_dep kactivities '' 4.13.3) )
 	mobi? ( $(add_kdeapps_dep kdegraphics-mobipocket) )
 	pdf? ( >=app-text/poppler-0.20[qt4,-exceptions(-)] )
 	postscript? ( app-text/libspectre )
@@ -46,7 +47,8 @@ src_configure() {
 		$(cmake-utils_use_with ebook EPub)
 		$(cmake-utils_use_with jpeg)
 		$(cmake-utils_use_with jpeg Kexiv2)
-		$(cmake-utils_use_with mobi QMobiPocket)
+		$(cmake-utils_use_with kde KActivities)
+		$(cmake-utils_use_with mobi QMobipocket)
 		$(cmake-utils_use_with postscript LibSpectre)
 		$(cmake-utils_use_with pdf PopplerQt4)
 		$(cmake-utils_use_with pdf Poppler)


### PR DESCRIPTION
Package-Manager: portage-2.2.24

See also: https://github.com/gentoo/gentoo/pull/451