### PR TITLE
kde-apps/kcalc: Add missing DEPENDs, bug 568818

### DIFF
--- a/kde-apps/kcalc/kcalc-15.12.0-r1.ebuild
+++ b/kde-apps/kcalc/kcalc-15.12.0-r1.ebuild
@@ -30,6 +30,8 @@ COMMON_DEPEND="
 	dev-qt/qtxml:5
 "
 DEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kinit)
 	dev-libs/mpfr:0
+	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}"

--- a/kde-apps/kcalc/kcalc-15.12.49.9999.ebuild
+++ b/kde-apps/kcalc/kcalc-15.12.49.9999.ebuild
@@ -30,6 +30,8 @@ COMMON_DEPEND="
 	dev-qt/qtxml:5
 "
 DEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kinit)
 	dev-libs/mpfr:0
+	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}"

--- a/kde-apps/kcalc/kcalc-9999.ebuild
+++ b/kde-apps/kcalc/kcalc-9999.ebuild
@@ -30,6 +30,8 @@ COMMON_DEPEND="
 	dev-qt/qtxml:5
 "
 DEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kinit)
 	dev-libs/mpfr:0
+	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}"


### PR DESCRIPTION
Package-Manager: portage-2.2.24