### PR TITLE
kde5.eclass: In kde5_src_prepare, place cmake-utils_src_prepare on top

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -449,6 +449,8 @@ kde5_src_unpack() {
 kde5_src_prepare() {
 	debug-print-function ${FUNCNAME} "$@"
 
+	cmake-utils_src_prepare
+
 	# only build examples when required
 	if ! use_if_iuse examples || ! use examples ; then
 		comment_add_subdirectory examples
@@ -525,8 +527,6 @@ kde5_src_prepare() {
 			comment_add_subdirectory tests
 		fi
 	fi
-
-	cmake-utils_src_prepare
 }
 
 # @FUNCTION: kde5_src_configure


### PR DESCRIPTION
This change makes PATCHES handling less error prone, as epatch will find
a pristine directory before there is punting and commenting.

Also tested possible negative impact with the following command in overlay dir:
``for file in $(find . -name "*ebuild" -exec grep -l PATCHES {} \;); do USE="-handbook" ebuild $file clean prepare; done``
...all good