### PR TITLE
kde-frameworks/kio: Drop obsolete blocker

### DIFF
--- a/kde-frameworks/kio/kio-5.18.0.ebuild
+++ b/kde-frameworks/kio/kio-5.18.0.ebuild
@@ -62,9 +62,7 @@ DEPEND="${COMMON_DEPEND}
 PDEPEND="
 	$(add_frameworks_dep kded)
 "
-RDEPEND="${COMMON_DEPEND}
-	!kde-apps/libkonq:5[-minimal(-)]
-"
+RDEPEND="${COMMON_DEPEND}"
 
 # tests hang
 RESTRICT="test"

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -62,9 +62,7 @@ DEPEND="${COMMON_DEPEND}
 PDEPEND="
 	$(add_frameworks_dep kded)
 "
-RDEPEND="${COMMON_DEPEND}
-	!kde-apps/libkonq:5[-minimal(-)]
-"
+RDEPEND="${COMMON_DEPEND}"
 
 # tests hang
 RESTRICT="test"


### PR DESCRIPTION
Enough time has passed since 5326546d73684ffa3453977d7dfe34952ea9a473
so no one should be on old and conflicting libkonq anymore.

Package-Manager: portage-2.2.26