### PR TITLE
[RFC] kde5-functions.eclass: Introduce add_qt_dep for consistent Qt version deps

### DIFF
--- a/app-office/kexi/kexi-9999.ebuild
+++ b/app-office/kexi/kexi-9999.ebuild
@@ -33,12 +33,12 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kdb 'mysql?,postgres?,sqlite?')
 	$(add_kdeapps_dep kproperty)
 	$(add_kdeapps_dep kreport)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	activities? ( $(add_frameworks_dep kactivities) )
 	marble? ( $(add_kdeapps_dep marble) )
 	mdb? ( dev-libs/glib:2 )
@@ -48,7 +48,7 @@ COMMON_DEPEND="
 		dev-libs/libpqxx
 	)
 	sybase? ( dev-db/freetds )
-	webform? ( dev-qt/qtwebkit:5 )
+	webform? ( $(add_qt_dep qtwebkit) )
 	xbase? ( dev-db/xbase )
 "
 DEPEND="${COMMON_DEPEND}

--- a/app-office/kmymoney/kmymoney-9999.ebuild
+++ b/app-office/kmymoney/kmymoney-9999.ebuild
@@ -50,21 +50,21 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_kdeapps_dep akonadi)
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kdiagram)
 	$(add_kdeapps_dep kholidays)
 	$(add_kdeapps_dep kidentitymanagement)
-	$(add_kdeapps_dep libakonadi)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	app-office/libalkimia:5
 	dev-libs/gmp:0
 	dev-libs/libgpg-error
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
 	x11-misc/shared-mime-info
 	calendar? ( dev-libs/libical:= )
 	crypt? ( $(add_kdeapps_dep gpgmepp) )

--- a/app-office/libalkimia/libalkimia-9999.ebuild
+++ b/app-office/libalkimia/libalkimia-9999.ebuild
@@ -17,15 +17,15 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
+	$(add_qt_dep qtdbus)
 	dev-libs/gmp[cxx]
-	dev-qt/qtdbus:5
 "
 DEPEND="${RDEPEND}
 	!app-office/libalkimia:4
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtxml)
 	virtual/pkgconfig
 "

--- a/app-office/skrooge/skrooge-9999.ebuild
+++ b/app-office/skrooge/skrooge-9999.ebuild
@@ -40,19 +40,19 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	app-crypt/qca:2[qt5]
 	dev-libs/grantlee:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
 	activities? ( $(add_frameworks_dep kactivities) )
 	crypt? ( dev-db/sqlcipher )
 	!crypt? ( dev-db/sqlite:3 )
@@ -63,8 +63,8 @@ DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep kwindowsystem)
+	$(add_qt_dep designer)
 	dev-libs/libxslt
-	dev-qt/designer:5
 	virtual/pkgconfig
 	x11-misc/shared-mime-info
 "

--- a/eclass/kde4-meta.eclass
+++ b/eclass/kde4-meta.eclass
@@ -28,7 +28,7 @@ case ${KMNAME} in
 		case ${PN} in
 			akregator|kaddressbook|kjots|kmail|knode|knotes|korganizer|ktimetracker)
 				IUSE+=" +kontact"
-				RDEPEND+=" kontact? ( $(add_kdeapps_dep kontact) )"
+				RDEPEND+=" kontact? ( $(add_kdeapps_dep kontact '' ${PV}) )"
 				;;
 		esac
 		;;

--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -93,11 +93,12 @@ _check_gcc_version() {
 	fi
 }
 
-# @FUNCTION: _add_kdecategory_dep
+# @FUNCTION: _add_category_dep
 # @INTERNAL
 # @DESCRIPTION:
-# Implementation of add_plasma_dep and add_frameworks_dep.
-_add_kdecategory_dep() {
+# Implementation of add_plasma_dep, add_frameworks_dep, add_kdeapps_dep,
+# and finally, add_qt_dep.
+_add_category_dep() {
 	debug-print-function ${FUNCNAME} "$@"
 
 	local category=${1}
@@ -145,7 +146,7 @@ add_frameworks_dep() {
 		version=${FRAMEWORKS_MINIMAL}
 	fi
 
-	_add_kdecategory_dep kde-frameworks "${1}" "${2}" "${version}"
+	_add_category_dep kde-frameworks "${1}" "${2}" "${version}"
 }
 
 # @FUNCTION: add_plasma_dep
@@ -171,7 +172,7 @@ add_plasma_dep() {
 		version=${PLASMA_MINIMAL}
 	fi
 
-	_add_kdecategory_dep kde-plasma "${1}" "${2}" "${version}"
+	_add_category_dep kde-plasma "${1}" "${2}" "${version}"
 }
 
 # @FUNCTION: add_kdeapps_dep
@@ -202,7 +203,31 @@ add_kdeapps_dep() {
 		fi
 	fi
 
-	_add_kdecategory_dep kde-apps "${1}" "${2}" "${version}"
+	_add_category_dep kde-apps "${1}" "${2}" "${version}"
+}
+
+# @FUNCTION: add_qt_dep
+# @USAGE: <package> [USE flags] [minimum version]
+# @DESCRIPTION:
+# Create proper dependency for dev-qt/ dependencies.
+# This takes 1 to 3 arguments. The first being the package name, the optional
+# second is additional USE flags to append, and the optional third is the
+# version to use instead of the automatic version (use sparingly).
+# The output of this should be added directly to DEPEND/RDEPEND, and may be
+# wrapped in a USE conditional (but not an || conditional without an extra set
+# of parentheses).
+add_qt_dep() {
+	debug-print-function ${FUNCNAME} "$@"
+
+	local version
+
+	if [[ -n ${3} ]]; then
+		version=${3}
+	elif [[ -z "${version}" ]] ; then
+		version=${QT_MINIMAL}
+	fi
+
+	_add_category_dep dev-qt "${1}" "${2}" "${version}"
 }
 
 # @FUNCTION: get_kde_version

--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -105,7 +105,7 @@ _add_category_dep() {
 	local package=${2}
 	local use=${3}
 	local version=${4}
-	local slot=
+	local slot=${5}
 
 	if [[ -n ${use} ]] ; then
 		local use="[${use}]"
@@ -116,8 +116,10 @@ _add_category_dep() {
 		local version="-$(get_version_component_range 1-3 ${version})"
 	fi
 
-	if [[ ${SLOT} = 4 || ${SLOT} = 5 ]] && ! has kde5-meta-pkg ${INHERITED} ; then
-		slot=":${SLOT}"
+	if [[ -n ${slot} ]] ; then
+		slot=":${slot}"
+	elif [[ ${SLOT%\/*} = 4 || ${SLOT%\/*} = 5 ]] && ! has kde5-meta-pkg ${INHERITED} ; then
+		slot=":${SLOT%\/*}"
 	fi
 
 	echo " ${operator}${category}/${package}${version}${slot}${use}"
@@ -210,9 +212,11 @@ add_kdeapps_dep() {
 # @USAGE: <package> [USE flags] [minimum version]
 # @DESCRIPTION:
 # Create proper dependency for dev-qt/ dependencies.
-# This takes 1 to 3 arguments. The first being the package name, the optional
+# This takes 1 to 4 arguments. The first being the package name, the optional
 # second is additional USE flags to append, and the optional third is the
-# version to use instead of the automatic version (use sparingly).
+# version to use instead of the automatic version (use sparingly). In addition,
+# the optional fourth argument defines slot+operator instead of automatic slot
+# (use even more sparingly).
 # The output of this should be added directly to DEPEND/RDEPEND, and may be
 # wrapped in a USE conditional (but not an || conditional without an extra set
 # of parentheses).
@@ -227,7 +231,7 @@ add_qt_dep() {
 		version=${QT_MINIMAL}
 	fi
 
-	_add_category_dep dev-qt "${1}" "${2}" "${version}"
+	_add_category_dep dev-qt "${1}" "${2}" "${version}" "${4}"
 }
 
 # @FUNCTION: get_kde_version

--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -152,6 +152,12 @@ case ${KDE_AUTODEPS} in
 			esac
 		fi
 
+		if [[ ${CATEGORY} = kde-plasma ]]; then
+			if [[ ${PV} = 5.5* || ${PV} = 9999 ]]; then
+				QT_MINIMAL=5.5.0
+			fi
+		fi
+
 		DEPEND+=" $(add_frameworks_dep extra-cmake-modules)"
 		RDEPEND+=" >=kde-frameworks/kf-env-3"
 		COMMONDEPEND+="	>=dev-qt/qtcore-${QT_MINIMAL}:5"

--- a/games-board/knights/knights-9999.ebuild
+++ b/games-board/knights/knights-9999.ebuild
@@ -31,12 +31,12 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!games-board/knights:4

--- a/games-puzzle/ksokoban/ksokoban-9999.ebuild
+++ b/games-puzzle/ksokoban/ksokoban-9999.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!games-puzzle/ksokoban:0

--- a/kde-apps/akonadi-calendar/akonadi-calendar-15.12.1.ebuild
+++ b/kde-apps/akonadi-calendar/akonadi-calendar-15.12.1.ebuild
@@ -36,9 +36,9 @@ RDEPEND="
 	$(add_kdeapps_dep kmailtransport)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/akonadi-calendar/akonadi-calendar-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-calendar/akonadi-calendar-15.12.49.9999.ebuild
@@ -36,9 +36,9 @@ RDEPEND="
 	$(add_kdeapps_dep kmailtransport)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/akonadi-calendar/akonadi-calendar-9999.ebuild
+++ b/kde-apps/akonadi-calendar/akonadi-calendar-9999.ebuild
@@ -36,9 +36,9 @@ RDEPEND="
 	$(add_kdeapps_dep kidentitymanagement)
 	$(add_kdeapps_dep kmailtransport)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/akonadi-contact/akonadi-contact-15.12.1.ebuild
+++ b/kde-apps/akonadi-contact/akonadi-contact-15.12.1.ebuild
@@ -36,9 +36,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	prison? ( media-libs/prison:5 )
 "

--- a/kde-apps/akonadi-contact/akonadi-contact-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-contact/akonadi-contact-15.12.49.9999.ebuild
@@ -36,9 +36,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	prison? ( media-libs/prison:5 )
 "

--- a/kde-apps/akonadi-contact/akonadi-contact-9999.ebuild
+++ b/kde-apps/akonadi-contact/akonadi-contact-9999.ebuild
@@ -36,9 +36,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	prison? ( media-libs/prison:5 )
 "

--- a/kde-apps/akonadi-mime/akonadi-mime-15.12.1.ebuild
+++ b/kde-apps/akonadi-mime/akonadi-mime-15.12.1.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep kmime)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi-mime/akonadi-mime-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-mime/akonadi-mime-15.12.49.9999.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep kmime)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi-mime/akonadi-mime-9999.ebuild
+++ b/kde-apps/akonadi-mime/akonadi-mime-9999.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep akonadi)
 	$(add_kdeapps_dep kmime)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi-notes/akonadi-notes-15.12.1.ebuild
+++ b/kde-apps/akonadi-notes/akonadi-notes-15.12.1.ebuild
@@ -19,8 +19,8 @@ RESTRICT="test"
 COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_kdeapps_dep libakonadi)

--- a/kde-apps/akonadi-notes/akonadi-notes-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-notes/akonadi-notes-15.12.49.9999.ebuild
@@ -19,8 +19,8 @@ RESTRICT="test"
 COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_kdeapps_dep libakonadi)

--- a/kde-apps/akonadi-notes/akonadi-notes-9999.ebuild
+++ b/kde-apps/akonadi-notes/akonadi-notes-9999.ebuild
@@ -19,8 +19,8 @@ RESTRICT="test"
 COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_kdeapps_dep akonadi)

--- a/kde-apps/akonadi-search/akonadi-search-15.12.1.ebuild
+++ b/kde-apps/akonadi-search/akonadi-search-15.12.1.ebuild
@@ -26,9 +26,9 @@ RDEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	>=dev-libs/xapian-1.3:=[chert]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	dev-libs/boost

--- a/kde-apps/akonadi-search/akonadi-search-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-search/akonadi-search-15.12.49.9999.ebuild
@@ -26,9 +26,9 @@ RDEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	>=dev-libs/xapian-1.3:=[chert]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	dev-libs/boost

--- a/kde-apps/akonadi-search/akonadi-search-9999.ebuild
+++ b/kde-apps/akonadi-search/akonadi-search-9999.ebuild
@@ -26,9 +26,9 @@ RDEPEND="
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kmime)
 	>=dev-libs/xapian-1.3:=[chert]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	dev-libs/boost

--- a/kde-apps/akonadi-socialutils/akonadi-socialutils-15.12.1.ebuild
+++ b/kde-apps/akonadi-socialutils/akonadi-socialutils-15.12.1.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kitemmodels)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi-socialutils/akonadi-socialutils-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi-socialutils/akonadi-socialutils-15.12.49.9999.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kitemmodels)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi-socialutils/akonadi-socialutils-9999.ebuild
+++ b/kde-apps/akonadi-socialutils/akonadi-socialutils-9999.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kitemmodels)
 	$(add_kdeapps_dep akonadi)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	x11-misc/shared-mime-info
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/akonadi/akonadi-15.12.1.ebuild
+++ b/kde-apps/akonadi/akonadi-15.12.1.ebuild
@@ -17,13 +17,13 @@ IUSE="+mysql postgres sqlite test"
 REQUIRED_USE="|| ( sqlite mysql postgres )"
 
 CDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5[mysql?,postgres?]
-	dev-qt/qttest:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql 'mysql?,postgres?')
+	$(add_qt_dep qttest)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	x11-misc/shared-mime-info
 	sqlite? ( dev-db/sqlite:3 )
 "

--- a/kde-apps/akonadi/akonadi-15.12.49.9999.ebuild
+++ b/kde-apps/akonadi/akonadi-15.12.49.9999.ebuild
@@ -17,13 +17,13 @@ IUSE="+mysql postgres sqlite test"
 REQUIRED_USE="|| ( sqlite mysql postgres )"
 
 CDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5[mysql?,postgres?]
-	dev-qt/qttest:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql 'mysql?,postgres?')
+	$(add_qt_dep qttest)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	x11-misc/shared-mime-info
 	sqlite? ( dev-db/sqlite:3 )
 "

--- a/kde-apps/akonadi/akonadi-9999.ebuild
+++ b/kde-apps/akonadi/akonadi-9999.ebuild
@@ -34,15 +34,15 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5[mysql?,postgres?]
-	dev-qt/qttest:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql 'mysql?,postgres?')
+	$(add_qt_dep qttest)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	x11-misc/shared-mime-info
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 	sqlite? ( dev-db/sqlite:3 )
 	tools? ( xml? ( dev-libs/libxml2 ) )
 "

--- a/kde-apps/analitza/analitza-15.08.3.ebuild
+++ b/kde-apps/analitza/analitza-15.08.3.ebuild
@@ -13,14 +13,14 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE="eigen opengl"
 
 DEPEND="
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	eigen? ( dev-cpp/eigen:3 )
 	opengl? (
-		dev-qt/qtopengl:5
+		$(add_qt_dep qtopengl)
 		virtual/opengl
 	)
 "

--- a/kde-apps/analitza/analitza-15.12.1.ebuild
+++ b/kde-apps/analitza/analitza-15.12.1.ebuild
@@ -13,14 +13,14 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE="eigen opengl"
 
 DEPEND="
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	eigen? ( dev-cpp/eigen:3 )
 	opengl? (
-		dev-qt/qtopengl:5
+		$(add_qt_dep qtopengl)
 		virtual/opengl
 	)
 "

--- a/kde-apps/analitza/analitza-15.12.49.9999.ebuild
+++ b/kde-apps/analitza/analitza-15.12.49.9999.ebuild
@@ -13,14 +13,14 @@ KEYWORDS=""
 IUSE="eigen opengl"
 
 DEPEND="
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	eigen? ( dev-cpp/eigen:3 )
 	opengl? (
-		dev-qt/qtopengl:5
+		$(add_qt_dep qtopengl)
 		virtual/opengl
 	)
 "

--- a/kde-apps/analitza/analitza-9999.ebuild
+++ b/kde-apps/analitza/analitza-9999.ebuild
@@ -13,14 +13,14 @@ KEYWORDS=""
 IUSE="eigen opengl"
 
 DEPEND="
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	eigen? ( dev-cpp/eigen:3 )
 	opengl? (
-		dev-qt/qtopengl:5
+		$(add_qt_dep qtopengl)
 		virtual/opengl
 	)
 "

--- a/kde-apps/ark/ark-15.12.1.ebuild
+++ b/kde-apps/ark/ark-15.12.1.ebuild
@@ -32,9 +32,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/ark/ark-15.12.49.9999.ebuild
+++ b/kde-apps/ark/ark-15.12.49.9999.ebuild
@@ -32,9 +32,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/ark/ark-9999.ebuild
+++ b/kde-apps/ark/ark-9999.ebuild
@@ -32,9 +32,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/artikulate/artikulate-15.12.1.ebuild
+++ b/kde-apps/artikulate/artikulate-15.12.1.ebuild
@@ -5,7 +5,6 @@
 EAPI=5
 
 KDE_HANDBOOK="true"
-QT_MINIMAL="5.5.0"
 inherit kde5
 
 DESCRIPTION="Language learning application that helps improving pronunciation skills"
@@ -22,12 +21,12 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	>=media-libs/qt-gstreamer-1.2.0[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/artikulate/artikulate-15.12.49.9999.ebuild
+++ b/kde-apps/artikulate/artikulate-15.12.49.9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=5
 
 KDE_HANDBOOK="true"
-QT_MINIMAL="5.5.0"
 inherit kde5
 
 DESCRIPTION="Language learning application that helps improving pronunciation skills"
@@ -22,12 +21,12 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	>=media-libs/qt-gstreamer-1.2.0[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/artikulate/artikulate-9999.ebuild
+++ b/kde-apps/artikulate/artikulate-9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=5
 
 KDE_HANDBOOK="true"
-QT_MINIMAL="5.5.0"
 inherit kde5
 
 DESCRIPTION="Language learning application that helps improving pronunciation skills"
@@ -22,12 +21,12 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	>=media-libs/qt-gstreamer-1.2.0[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/baloo-widgets/baloo-widgets-15.12.1.ebuild
+++ b/kde-apps/baloo-widgets/baloo-widgets-15.12.1.ebuild
@@ -19,8 +19,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/baloo-widgets

--- a/kde-apps/baloo-widgets/baloo-widgets-15.12.49.9999.ebuild
+++ b/kde-apps/baloo-widgets/baloo-widgets-15.12.49.9999.ebuild
@@ -19,8 +19,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/baloo-widgets

--- a/kde-apps/baloo-widgets/baloo-widgets-9999.ebuild
+++ b/kde-apps/baloo-widgets/baloo-widgets-9999.ebuild
@@ -19,8 +19,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/baloo-widgets

--- a/kde-apps/blinken/blinken-15.08.3.ebuild
+++ b/kde-apps/blinken/blinken-15.08.3.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/blinken/blinken-15.12.1.ebuild
+++ b/kde-apps/blinken/blinken-15.12.1.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/blinken/blinken-15.12.49.9999.ebuild
+++ b/kde-apps/blinken/blinken-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/blinken/blinken-9999.ebuild
+++ b/kde-apps/blinken/blinken-9999.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/bomber/bomber-15.12.1.ebuild
+++ b/kde-apps/bomber/bomber-15.12.1.ebuild
@@ -21,8 +21,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/bomber/bomber-15.12.49.9999.ebuild
+++ b/kde-apps/bomber/bomber-15.12.49.9999.ebuild
@@ -21,8 +21,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/bomber/bomber-9999.ebuild
+++ b/kde-apps/bomber/bomber-9999.ebuild
@@ -21,8 +21,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/bovo/bovo-15.12.1.ebuild
+++ b/kde-apps/bovo/bovo-15.12.1.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/bovo/bovo-15.12.49.9999.ebuild
+++ b/kde-apps/bovo/bovo-15.12.49.9999.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/bovo/bovo-9999.ebuild
+++ b/kde-apps/bovo/bovo-9999.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/calendarsupport/calendarsupport-15.12.1.ebuild
+++ b/kde-apps/calendarsupport/calendarsupport-15.12.1.ebuild
@@ -39,10 +39,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libkdepimdbusinterfaces)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/calendarsupport/calendarsupport-15.12.49.9999.ebuild
+++ b/kde-apps/calendarsupport/calendarsupport-15.12.49.9999.ebuild
@@ -39,10 +39,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libkdepimdbusinterfaces)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/calendarsupport/calendarsupport-9999.ebuild
+++ b/kde-apps/calendarsupport/calendarsupport-9999.ebuild
@@ -37,10 +37,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/cantor/cantor-15.08.3.ebuild
+++ b/kde-apps/cantor/cantor-15.08.3.ebuild
@@ -33,11 +33,11 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	analitza? ( $(add_kdeapps_dep analitza) )
 	lua? ( dev-lang/luajit:2 )
 	qalculate? (

--- a/kde-apps/cantor/cantor-15.12.1.ebuild
+++ b/kde-apps/cantor/cantor-15.12.1.ebuild
@@ -34,11 +34,11 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	analitza? ( $(add_kdeapps_dep analitza) )
 	lua? ( dev-lang/luajit:2 )
 	qalculate? (

--- a/kde-apps/cantor/cantor-15.12.49.9999.ebuild
+++ b/kde-apps/cantor/cantor-15.12.49.9999.ebuild
@@ -34,11 +34,11 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	analitza? ( $(add_kdeapps_dep analitza) )
 	lua? ( dev-lang/luajit:2 )
 	qalculate? (

--- a/kde-apps/cantor/cantor-9999.ebuild
+++ b/kde-apps/cantor/cantor-9999.ebuild
@@ -34,11 +34,11 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 	analitza? ( $(add_kdeapps_dep analitza) )
 	lua? ( dev-lang/luajit:2 )
 	qalculate? (

--- a/kde-apps/composereditor/composereditor-15.12.1.ebuild
+++ b/kde-apps/composereditor/composereditor-15.12.1.ebuild
@@ -29,11 +29,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/composereditor/composereditor-15.12.49.9999.ebuild
+++ b/kde-apps/composereditor/composereditor-15.12.49.9999.ebuild
@@ -29,11 +29,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/dolphin-plugins/dolphin-plugins-15.12.1.ebuild
+++ b/kde-apps/dolphin-plugins/dolphin-plugins-15.12.1.ebuild
@@ -21,9 +21,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep dolphin)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	git? (
 		$(add_frameworks_dep kcompletion)
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/dolphin-plugins/dolphin-plugins-15.12.49.9999.ebuild
+++ b/kde-apps/dolphin-plugins/dolphin-plugins-15.12.49.9999.ebuild
@@ -21,9 +21,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep dolphin)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	git? (
 		$(add_frameworks_dep kcompletion)
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/dolphin-plugins/dolphin-plugins-9999.ebuild
+++ b/kde-apps/dolphin-plugins/dolphin-plugins-9999.ebuild
@@ -21,9 +21,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep dolphin)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	git? (
 		$(add_frameworks_dep kcompletion)
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/dolphin/dolphin-15.12.1.ebuild
+++ b/kde-apps/dolphin/dolphin-15.12.1.ebuild
@@ -40,11 +40,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	semantic-desktop? (
 		$(add_frameworks_dep baloo)

--- a/kde-apps/dolphin/dolphin-15.12.49.9999.ebuild
+++ b/kde-apps/dolphin/dolphin-15.12.49.9999.ebuild
@@ -40,11 +40,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	semantic-desktop? (
 		$(add_frameworks_dep baloo)

--- a/kde-apps/dolphin/dolphin-9999.ebuild
+++ b/kde-apps/dolphin/dolphin-9999.ebuild
@@ -40,11 +40,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	semantic-desktop? (
 		$(add_frameworks_dep baloo)

--- a/kde-apps/dragon/dragon-15.12.1.ebuild
+++ b/kde-apps/dragon/dragon-15.12.1.ebuild
@@ -26,9 +26,9 @@ RDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${RDEPEND}

--- a/kde-apps/dragon/dragon-15.12.49.9999.ebuild
+++ b/kde-apps/dragon/dragon-15.12.49.9999.ebuild
@@ -26,9 +26,9 @@ RDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${RDEPEND}

--- a/kde-apps/dragon/dragon-9999.ebuild
+++ b/kde-apps/dragon/dragon-9999.ebuild
@@ -27,9 +27,9 @@ RDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${RDEPEND}

--- a/kde-apps/eventviews/eventviews-15.12.1.ebuild
+++ b/kde-apps/eventviews/eventviews-15.12.1.ebuild
@@ -37,9 +37,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/eventviews/eventviews-15.12.49.9999.ebuild
+++ b/kde-apps/eventviews/eventviews-15.12.49.9999.ebuild
@@ -37,9 +37,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/eventviews/eventviews-9999.ebuild
+++ b/kde-apps/eventviews/eventviews-9999.ebuild
@@ -36,9 +36,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libical
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/ffmpegthumbs/ffmpegthumbs-15.12.1.ebuild
+++ b/kde-apps/ffmpegthumbs/ffmpegthumbs-15.12.1.ebuild
@@ -12,7 +12,7 @@ IUSE="libav"
 
 RDEPEND="
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	libav? ( media-video/libav:= )
 	!libav? ( media-video/ffmpeg:= )
 "

--- a/kde-apps/ffmpegthumbs/ffmpegthumbs-15.12.49.9999.ebuild
+++ b/kde-apps/ffmpegthumbs/ffmpegthumbs-15.12.49.9999.ebuild
@@ -12,7 +12,7 @@ IUSE="libav"
 
 RDEPEND="
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	libav? ( media-video/libav:= )
 	!libav? ( media-video/ffmpeg:= )
 "

--- a/kde-apps/ffmpegthumbs/ffmpegthumbs-9999.ebuild
+++ b/kde-apps/ffmpegthumbs/ffmpegthumbs-9999.ebuild
@@ -12,7 +12,7 @@ IUSE="libav"
 
 RDEPEND="
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	libav? ( media-video/libav:= )
 	!libav? ( media-video/ffmpeg:= )
 "

--- a/kde-apps/filelight/filelight-15.12.1.ebuild
+++ b/kde-apps/filelight/filelight-15.12.1.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/filelight/filelight-15.12.49.9999.ebuild
+++ b/kde-apps/filelight/filelight-15.12.49.9999.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/filelight/filelight-9999.ebuild
+++ b/kde-apps/filelight/filelight-9999.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/granatier/granatier-15.12.1.ebuild
+++ b/kde-apps/granatier/granatier-15.12.1.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/granatier/granatier-15.12.49.9999.ebuild
+++ b/kde-apps/granatier/granatier-15.12.49.9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/granatier/granatier-9999.ebuild
+++ b/kde-apps/granatier/granatier-9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/grantleetheme/grantleetheme-15.12.1.ebuild
+++ b/kde-apps/grantleetheme/grantleetheme-15.12.1.ebuild
@@ -21,11 +21,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/grantleetheme/grantleetheme-15.12.49.9999.ebuild
+++ b/kde-apps/grantleetheme/grantleetheme-15.12.49.9999.ebuild
@@ -21,11 +21,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/grantleetheme/grantleetheme-9999.ebuild
+++ b/kde-apps/grantleetheme/grantleetheme-9999.ebuild
@@ -20,11 +20,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 	sys-devel/gettext
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/gwenview/gwenview-15.12.1.ebuild
+++ b/kde-apps/gwenview/gwenview-15.12.1.ebuild
@@ -38,11 +38,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-gfx/exiv2:=
 	media-libs/lcms:2
 	media-libs/libpng:0=
@@ -55,16 +55,16 @@ COMMON_DEPEND="
 		$(add_frameworks_dep kfilemetadata)
 	)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep qtconcurrent)
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kimageformats)
-	dev-qt/qtimageformats:5
+	$(add_qt_dep qtimageformats)
 "
 
 src_configure() {

--- a/kde-apps/gwenview/gwenview-15.12.49.9999.ebuild
+++ b/kde-apps/gwenview/gwenview-15.12.49.9999.ebuild
@@ -38,11 +38,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-gfx/exiv2:=
 	media-libs/lcms:2
 	media-libs/libpng:0=
@@ -55,16 +55,16 @@ COMMON_DEPEND="
 		$(add_frameworks_dep kfilemetadata)
 	)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep qtconcurrent)
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kimageformats)
-	dev-qt/qtimageformats:5
+	$(add_qt_dep qtimageformats)
 "
 
 src_configure() {

--- a/kde-apps/gwenview/gwenview-9999.ebuild
+++ b/kde-apps/gwenview/gwenview-9999.ebuild
@@ -38,11 +38,11 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-gfx/exiv2:=
 	media-libs/lcms:2
 	media-libs/libpng:0=
@@ -55,16 +55,16 @@ COMMON_DEPEND="
 		$(add_frameworks_dep kfilemetadata)
 	)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep qtconcurrent)
 "
 RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kimageformats)
-	dev-qt/qtimageformats:5
+	$(add_qt_dep qtimageformats)
 "
 
 src_configure() {

--- a/kde-apps/incidenceeditor/incidenceeditor-15.12.1.ebuild
+++ b/kde-apps/incidenceeditor/incidenceeditor-15.12.1.ebuild
@@ -46,11 +46,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep libkdepimdbusinterfaces)
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/incidenceeditor/incidenceeditor-15.12.49.9999.ebuild
+++ b/kde-apps/incidenceeditor/incidenceeditor-15.12.49.9999.ebuild
@@ -46,11 +46,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep libkdepimdbusinterfaces)
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/incidenceeditor/incidenceeditor-9999.ebuild
+++ b/kde-apps/incidenceeditor/incidenceeditor-9999.ebuild
@@ -44,11 +44,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kmailtransport)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libkdepim)
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kaccounts-integration/kaccounts-integration-15.12.1.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-15.12.1.ebuild
@@ -21,10 +21,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kdeclarative)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 "

--- a/kde-apps/kaccounts-integration/kaccounts-integration-15.12.49.9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-15.12.49.9999.ebuild
@@ -21,10 +21,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kdeclarative)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 "

--- a/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
@@ -21,10 +21,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kdeclarative)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 "

--- a/kde-apps/kaccounts-mobile/kaccounts-mobile-9999.ebuild
+++ b/kde-apps/kaccounts-mobile/kaccounts-mobile-9999.ebuild
@@ -19,14 +19,14 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kcontacts)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtxml)
 	net-libs/accounts-qt
 	net-libs/signond
 	google? (
-		dev-qt/qtwebkit:5
+		$(add_qt_dep qtwebkit)
 		net-libs/libkgapi:5
 	)
 "

--- a/kde-apps/kaccounts-providers/kaccounts-providers-15.12.1.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-15.12.1.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kpackage)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	dev-util/intltool

--- a/kde-apps/kaccounts-providers/kaccounts-providers-15.12.49.9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kpackage)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	dev-util/intltool

--- a/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kpackage)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	dev-util/intltool

--- a/kde-apps/kaddressbookgrantlee/kaddressbookgrantlee-15.12.1.ebuild
+++ b/kde-apps/kaddressbookgrantlee/kaddressbookgrantlee-15.12.1.ebuild
@@ -27,9 +27,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkleo)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	prison? ( media-libs/prison:5 )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kaddressbookgrantlee/kaddressbookgrantlee-15.12.49.9999.ebuild
+++ b/kde-apps/kaddressbookgrantlee/kaddressbookgrantlee-15.12.49.9999.ebuild
@@ -27,9 +27,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkleo)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	prison? ( media-libs/prison:5 )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kalarmcal/kalarmcal-15.12.1.ebuild
+++ b/kde-apps/kalarmcal/kalarmcal-15.12.1.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	$(add_kdeapps_dep kholidays)
 	$(add_kdeapps_dep kidentitymanagement)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/kalarmcal/kalarmcal-15.12.49.9999.ebuild
+++ b/kde-apps/kalarmcal/kalarmcal-15.12.49.9999.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	$(add_kdeapps_dep kholidays)
 	$(add_kdeapps_dep kidentitymanagement)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/kalarmcal/kalarmcal-9999.ebuild
+++ b/kde-apps/kalarmcal/kalarmcal-9999.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kholidays)
 	$(add_kdeapps_dep kidentitymanagement)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/kalgebra/kalgebra-15.08.3.ebuild
+++ b/kde-apps/kalgebra/kalgebra-15.08.3.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep analitza opengl?)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 	opengl? (
-		dev-qt/qtopengl:5
-		dev-qt/qtprintsupport:5
+		$(add_qt_dep qtopengl)
+		$(add_qt_dep qtprintsupport)
 		virtual/glu
 	)
 	readline? ( sys-libs/readline:0= )

--- a/kde-apps/kalgebra/kalgebra-15.12.1.ebuild
+++ b/kde-apps/kalgebra/kalgebra-15.12.1.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep analitza opengl?)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 	opengl? (
-		dev-qt/qtopengl:5
-		dev-qt/qtprintsupport:5
+		$(add_qt_dep qtopengl)
+		$(add_qt_dep qtprintsupport)
 		virtual/glu
 	)
 	readline? ( sys-libs/readline:0= )

--- a/kde-apps/kalgebra/kalgebra-15.12.49.9999.ebuild
+++ b/kde-apps/kalgebra/kalgebra-15.12.49.9999.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep analitza opengl?)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 	opengl? (
-		dev-qt/qtopengl:5
-		dev-qt/qtprintsupport:5
+		$(add_qt_dep qtopengl)
+		$(add_qt_dep qtprintsupport)
 		virtual/glu
 	)
 	readline? ( sys-libs/readline:0= )

--- a/kde-apps/kalgebra/kalgebra-9999.ebuild
+++ b/kde-apps/kalgebra/kalgebra-9999.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep analitza opengl?)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 	opengl? (
-		dev-qt/qtopengl:5
-		dev-qt/qtprintsupport:5
+		$(add_qt_dep qtopengl)
+		$(add_qt_dep qtprintsupport)
 		virtual/glu
 	)
 	readline? ( sys-libs/readline:0= )

--- a/kde-apps/kamera/kamera-15.12.1.ebuild
+++ b/kde-apps/kamera/kamera-15.12.1.ebuild
@@ -19,8 +19,8 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/libgphoto2:=
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kamera/kamera-15.12.49.9999.ebuild
+++ b/kde-apps/kamera/kamera-15.12.49.9999.ebuild
@@ -19,8 +19,8 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/libgphoto2:=
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kamera/kamera-9999.ebuild
+++ b/kde-apps/kamera/kamera-9999.ebuild
@@ -19,8 +19,8 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/libgphoto2:=
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kanagram/kanagram-15.08.3.ebuild
+++ b/kde-apps/kanagram/kanagram-15.08.3.ebuild
@@ -25,13 +25,13 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)
-	dev-qt/qtquickcontrols:5
-	dev-qt/qtwebkit:5[qml]
+	$(add_qt_dep qtquickcontrols)
+	$(add_qt_dep qtwebkit 'qml')
 "

--- a/kde-apps/kanagram/kanagram-15.12.1.ebuild
+++ b/kde-apps/kanagram/kanagram-15.12.1.ebuild
@@ -25,13 +25,13 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)
-	dev-qt/qtquickcontrols:5
-	dev-qt/qtwebkit:5[qml]
+	$(add_qt_dep qtquickcontrols)
+	$(add_qt_dep qtwebkit 'qml')
 "

--- a/kde-apps/kanagram/kanagram-15.12.49.9999.ebuild
+++ b/kde-apps/kanagram/kanagram-15.12.49.9999.ebuild
@@ -25,13 +25,13 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)
-	dev-qt/qtquickcontrols:5
-	dev-qt/qtwebkit:5[qml]
+	$(add_qt_dep qtquickcontrols)
+	$(add_qt_dep qtwebkit 'qml')
 "

--- a/kde-apps/kanagram/kanagram-9999.ebuild
+++ b/kde-apps/kanagram/kanagram-9999.ebuild
@@ -25,13 +25,13 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)
-	dev-qt/qtquickcontrols:5
-	dev-qt/qtwebkit:5[qml]
+	$(add_qt_dep qtquickcontrols)
+	$(add_qt_dep qtwebkit 'qml')
 "

--- a/kde-apps/kapman/kapman-15.12.1.ebuild
+++ b/kde-apps/kapman/kapman-15.12.1.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kapman/kapman-15.12.49.9999.ebuild
+++ b/kde-apps/kapman/kapman-15.12.49.9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kapman/kapman-9999.ebuild
+++ b/kde-apps/kapman/kapman-9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kapptemplate/kapptemplate-15.12.1.ebuild
+++ b/kde-apps/kapptemplate/kapptemplate-15.12.1.ebuild
@@ -23,8 +23,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kapptemplate/kapptemplate-15.12.49.9999.ebuild
+++ b/kde-apps/kapptemplate/kapptemplate-15.12.49.9999.ebuild
@@ -23,8 +23,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kapptemplate/kapptemplate-9999.ebuild
+++ b/kde-apps/kapptemplate/kapptemplate-9999.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kate/kate-15.12.1.ebuild
+++ b/kde-apps/kate/kate-15.12.1.ebuild
@@ -36,18 +36,18 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	addons? (
 		$(add_frameworks_dep kbookmarks)
 		$(add_frameworks_dep knewstuff)
 		$(add_frameworks_dep kwallet)
 		$(add_frameworks_dep plasma)
 		$(add_frameworks_dep threadweaver)
-		dev-qt/qtsql:5
+		$(add_qt_dep qtsql)
 		>=dev-libs/libgit2-0.22.0:=
 	)
 "

--- a/kde-apps/kate/kate-15.12.49.9999.ebuild
+++ b/kde-apps/kate/kate-15.12.49.9999.ebuild
@@ -36,18 +36,18 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	addons? (
 		$(add_frameworks_dep kbookmarks)
 		$(add_frameworks_dep knewstuff)
 		$(add_frameworks_dep kwallet)
 		$(add_frameworks_dep plasma)
 		$(add_frameworks_dep threadweaver)
-		dev-qt/qtsql:5
+		$(add_qt_dep qtsql)
 		>=dev-libs/libgit2-0.22.0:=
 	)
 "

--- a/kde-apps/kate/kate-9999.ebuild
+++ b/kde-apps/kate/kate-9999.ebuild
@@ -36,18 +36,18 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	addons? (
 		$(add_frameworks_dep kbookmarks)
 		$(add_frameworks_dep knewstuff)
 		$(add_frameworks_dep kwallet)
 		$(add_frameworks_dep plasma)
 		$(add_frameworks_dep threadweaver)
-		dev-qt/qtsql:5
+		$(add_qt_dep qtsql)
 		>=dev-libs/libgit2-0.22.0:=
 	)
 "

--- a/kde-apps/katomic/katomic-15.12.1.ebuild
+++ b/kde-apps/katomic/katomic-15.12.1.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/katomic/katomic-15.12.49.9999.ebuild
+++ b/kde-apps/katomic/katomic-15.12.49.9999.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/katomic/katomic-9999.ebuild
+++ b/kde-apps/katomic/katomic-9999.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kblackbox/kblackbox-15.12.1.ebuild
+++ b/kde-apps/kblackbox/kblackbox-15.12.1.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kblackbox/kblackbox-15.12.49.9999.ebuild
+++ b/kde-apps/kblackbox/kblackbox-15.12.49.9999.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kblackbox/kblackbox-9999.ebuild
+++ b/kde-apps/kblackbox/kblackbox-9999.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kblocks/kblocks-15.12.1.ebuild
+++ b/kde-apps/kblocks/kblocks-15.12.1.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/kblocks/kblocks-15.12.49.9999.ebuild
+++ b/kde-apps/kblocks/kblocks-15.12.49.9999.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/kblocks/kblocks-9999.ebuild
+++ b/kde-apps/kblocks/kblocks-9999.ebuild
@@ -20,10 +20,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/kblog/kblog-15.12.1.ebuild
+++ b/kde-apps/kblog/kblog-15.12.1.ebuild
@@ -21,6 +21,6 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlrpcclient)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kblog/kblog-15.12.49.9999.ebuild
+++ b/kde-apps/kblog/kblog-15.12.49.9999.ebuild
@@ -21,6 +21,6 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlrpcclient)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kblog/kblog-9999.ebuild
+++ b/kde-apps/kblog/kblog-9999.ebuild
@@ -21,6 +21,6 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlrpcclient)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kbounce/kbounce-15.12.1.ebuild
+++ b/kde-apps/kbounce/kbounce-15.12.1.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbounce/kbounce-15.12.49.9999.ebuild
+++ b/kde-apps/kbounce/kbounce-15.12.49.9999.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbounce/kbounce-9999.ebuild
+++ b/kde-apps/kbounce/kbounce-9999.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbreakout/kbreakout-15.12.1.ebuild
+++ b/kde-apps/kbreakout/kbreakout-15.12.1.ebuild
@@ -24,9 +24,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbreakout/kbreakout-15.12.49.9999.ebuild
+++ b/kde-apps/kbreakout/kbreakout-15.12.49.9999.ebuild
@@ -24,9 +24,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbreakout/kbreakout-9999.ebuild
+++ b/kde-apps/kbreakout/kbreakout-9999.ebuild
@@ -24,9 +24,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbruch/kbruch-15.08.3.ebuild
+++ b/kde-apps/kbruch/kbruch-15.08.3.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbruch/kbruch-15.12.1.ebuild
+++ b/kde-apps/kbruch/kbruch-15.12.1.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbruch/kbruch-15.12.49.9999.ebuild
+++ b/kde-apps/kbruch/kbruch-15.12.49.9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kbruch/kbruch-9999.ebuild
+++ b/kde-apps/kbruch/kbruch-9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcachegrind/kcachegrind-5.9999.ebuild
+++ b/kde-apps/kcachegrind/kcachegrind-5.9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	media-gfx/graphviz

--- a/kde-apps/kcalc/kcalc-15.12.1.ebuild
+++ b/kde-apps/kcalc/kcalc-15.12.1.ebuild
@@ -25,9 +25,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/gmp:0
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kinit)

--- a/kde-apps/kcalc/kcalc-15.12.49.9999.ebuild
+++ b/kde-apps/kcalc/kcalc-15.12.49.9999.ebuild
@@ -25,9 +25,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/gmp:0
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kinit)

--- a/kde-apps/kcalc/kcalc-9999.ebuild
+++ b/kde-apps/kcalc/kcalc-9999.ebuild
@@ -25,9 +25,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/gmp:0
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kinit)

--- a/kde-apps/kcalcore/kcalcore-15.12.1.ebuild
+++ b/kde-apps/kcalcore/kcalcore-15.12.1.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	dev-libs/libical:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	sys-apps/util-linux
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcalcore/kcalcore-15.12.49.9999.ebuild
+++ b/kde-apps/kcalcore/kcalcore-15.12.49.9999.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	dev-libs/libical:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	sys-apps/util-linux
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcalcore/kcalcore-9999.ebuild
+++ b/kde-apps/kcalcore/kcalcore-9999.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	dev-libs/libical:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	sys-apps/util-linux
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcalutils/kcalutils-15.12.1.ebuild
+++ b/kde-apps/kcalutils/kcalutils-15.12.1.ebuild
@@ -25,8 +25,8 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kidentitymanagement)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kcalutils/kcalutils-15.12.49.9999.ebuild
+++ b/kde-apps/kcalutils/kcalutils-15.12.49.9999.ebuild
@@ -25,8 +25,8 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kidentitymanagement)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kcalutils/kcalutils-9999.ebuild
+++ b/kde-apps/kcalutils/kcalutils-9999.ebuild
@@ -25,8 +25,8 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcalcore)
 	$(add_kdeapps_dep kidentitymanagement)
 	dev-libs/grantlee:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kcharselect/kcharselect-15.12.1.ebuild
+++ b/kde-apps/kcharselect/kcharselect-15.12.1.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcharselect/kcharselect-15.12.49.9999.ebuild
+++ b/kde-apps/kcharselect/kcharselect-15.12.49.9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcharselect/kcharselect-9999.ebuild
+++ b/kde-apps/kcharselect/kcharselect-9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kcontacts/kcontacts-15.12.1.ebuild
+++ b/kde-apps/kcontacts/kcontacts-15.12.1.ebuild
@@ -19,8 +19,8 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/kcontacts/kcontacts-15.12.49.9999.ebuild
+++ b/kde-apps/kcontacts/kcontacts-15.12.49.9999.ebuild
@@ -19,8 +19,8 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/kcontacts/kcontacts-9999.ebuild
+++ b/kde-apps/kcontacts/kcontacts-9999.ebuild
@@ -19,8 +19,8 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/kcron/kcron-15.12.1.ebuild
+++ b/kde-apps/kcron/kcron-15.12.1.ebuild
@@ -18,9 +18,9 @@ DEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!prefix? ( virtual/cron )

--- a/kde-apps/kcron/kcron-15.12.49.9999.ebuild
+++ b/kde-apps/kcron/kcron-15.12.49.9999.ebuild
@@ -18,9 +18,9 @@ DEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!prefix? ( virtual/cron )

--- a/kde-apps/kcron/kcron-9999.ebuild
+++ b/kde-apps/kcron/kcron-9999.ebuild
@@ -18,9 +18,9 @@ DEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!prefix? ( virtual/cron )

--- a/kde-apps/kdb/kdb-9999.ebuild
+++ b/kde-apps/kdb/kdb-9999.ebuild
@@ -16,9 +16,9 @@ IUSE="mysql postgres sqlite"
 RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	dev-libs/icu:=
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	mysql? ( virtual/mysql )
 	postgres? ( dev-db/postgresql:* )
 	sqlite? ( dev-db/sqlite:3 )

--- a/kde-apps/kde-l10n/kde-l10n-15.12.1.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-15.12.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
-	dev-qt/linguist-tools:5
+	$(add_qt_dep linguist-tools)
 	sys-devel/gettext
 "
 RDEPEND="

--- a/kde-apps/kdebugsettings/kdebugsettings-15.12.1.ebuild
+++ b/kde-apps/kdebugsettings/kdebugsettings-15.12.1.ebuild
@@ -20,8 +20,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdebugsettings/kdebugsettings-15.12.49.9999.ebuild
+++ b/kde-apps/kdebugsettings/kdebugsettings-15.12.49.9999.ebuild
@@ -20,8 +20,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdebugsettings/kdebugsettings-9999.ebuild
+++ b/kde-apps/kdebugsettings/kdebugsettings-9999.ebuild
@@ -20,8 +20,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-15.12.1.ebuild
+++ b/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-15.12.1.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-15.12.49.9999.ebuild
+++ b/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-15.12.49.9999.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-9999.ebuild
+++ b/kde-apps/kdenetwork-filesharing/kdenetwork-filesharing-9999.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kdenlive/kdenlive-15.12.1.ebuild
+++ b/kde-apps/kdenlive/kdenlive-15.12.1.ebuild
@@ -38,14 +38,14 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=]
-	dev-qt/qtnetwork:5
-	dev-qt/qtscript:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/mlt-0.9.8-r1[ffmpeg,kdenlive,melt,qt5,sdl,xml]
 	virtual/ffmpeg[encode,sdl,X]
 	virtual/opengl

--- a/kde-apps/kdenlive/kdenlive-15.12.49.9999.ebuild
+++ b/kde-apps/kdenlive/kdenlive-15.12.49.9999.ebuild
@@ -38,14 +38,14 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=]
-	dev-qt/qtnetwork:5
-	dev-qt/qtscript:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/mlt-0.9.8-r1[ffmpeg,kdenlive,melt,qt5,sdl,xml]
 	virtual/ffmpeg[encode,sdl,X]
 	virtual/opengl

--- a/kde-apps/kdenlive/kdenlive-9999.ebuild
+++ b/kde-apps/kdenlive/kdenlive-9999.ebuild
@@ -38,14 +38,14 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=]
-	dev-qt/qtnetwork:5
-	dev-qt/qtscript:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/mlt-0.9.8-r1[ffmpeg,kdenlive,melt,qt5,sdl,xml]
 	virtual/ffmpeg[encode,sdl,X]
 	virtual/opengl

--- a/kde-apps/kdepim-addons/kdepim-addons-9999.ebuild
+++ b/kde-apps/kdepim-addons/kdepim-addons-9999.ebuild
@@ -42,10 +42,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep mailcommon)
 	$(add_kdeapps_dep messagelib)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kdepim-apps-libs/kdepim-apps-libs-9999.ebuild
+++ b/kde-apps/kdepim-apps-libs/kdepim-apps-libs-9999.ebuild
@@ -37,12 +37,12 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libkleo)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 	prison? ( media-libs/prison:5 )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim-kioslaves/kdepim-kioslaves-15.12.1.ebuild
+++ b/kde-apps/kdepim-kioslaves/kdepim-kioslaves-15.12.1.ebuild
@@ -22,9 +22,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmbox)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	ssl? ( dev-libs/cyrus-sasl )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim-kioslaves/kdepim-kioslaves-15.12.49.9999.ebuild
+++ b/kde-apps/kdepim-kioslaves/kdepim-kioslaves-15.12.49.9999.ebuild
@@ -22,9 +22,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmbox)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	ssl? ( dev-libs/cyrus-sasl )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim-kioslaves/kdepim-kioslaves-9999.ebuild
+++ b/kde-apps/kdepim-kioslaves/kdepim-kioslaves-9999.ebuild
@@ -22,9 +22,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmbox)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	ssl? ( dev-libs/cyrus-sasl )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim-l10n/kdepim-l10n-15.12.1.ebuild
+++ b/kde-apps/kdepim-l10n/kdepim-l10n-15.12.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
-	dev-qt/linguist-tools:5
+	$(add_qt_dep linguist-tools)
 	sys-devel/gettext
 "
 RDEPEND="

--- a/kde-apps/kdepim-runtime/kdepim-runtime-15.12.1.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-15.12.1.ebuild
@@ -51,12 +51,12 @@ CDEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	dev-libs/libical:=
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${CDEPEND}
 	$(add_frameworks_dep kross)

--- a/kde-apps/kdepim-runtime/kdepim-runtime-15.12.49.9999.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-15.12.49.9999.ebuild
@@ -51,12 +51,12 @@ CDEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	dev-libs/libical:=
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${CDEPEND}
 	$(add_frameworks_dep kross)

--- a/kde-apps/kdepim-runtime/kdepim-runtime-9999.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-9999.ebuild
@@ -50,12 +50,12 @@ CDEPEND="
 	$(add_kdeapps_dep kmbox)
 	$(add_kdeapps_dep kmime)
 	dev-libs/libical:=
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${CDEPEND}
 	$(add_frameworks_dep kross)

--- a/kde-apps/kdepim/kdepim-15.12.1.ebuild
+++ b/kde-apps/kdepim/kdepim-15.12.1.ebuild
@@ -100,19 +100,19 @@ COMMON_DEPEND="
 	dev-libs/boost:=
 	dev-libs/grantlee:5
 	dev-libs/libxslt
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 	google? ( net-libs/libkgapi:5 )
 	prison? ( media-libs/prison:5 )
 	kdepim_features_kleopatra? (
@@ -128,7 +128,7 @@ DEPEND="${COMMON_DEPEND}
 	test? (
 		$(add_kdeapps_dep akonadi sqlite)
 		$(add_kdeapps_dep libakonadi tools)
-		dev-qt/qtsql:5[sqlite]
+		$(add_qt_dep qtsql 'sqlite')
 	)
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim/kdepim-15.12.49.9999.ebuild
+++ b/kde-apps/kdepim/kdepim-15.12.49.9999.ebuild
@@ -100,19 +100,19 @@ COMMON_DEPEND="
 	dev-libs/boost:=
 	dev-libs/grantlee:5
 	dev-libs/libxslt
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 	google? ( net-libs/libkgapi:5 )
 	prison? ( media-libs/prison:5 )
 	kdepim_features_kleopatra? (
@@ -128,7 +128,7 @@ DEPEND="${COMMON_DEPEND}
 	test? (
 		$(add_kdeapps_dep akonadi sqlite)
 		$(add_kdeapps_dep libakonadi tools)
-		dev-qt/qtsql:5[sqlite]
+		$(add_qt_dep qtsql 'sqlite')
 	)
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdepim/kdepim-9999.ebuild
+++ b/kde-apps/kdepim/kdepim-9999.ebuild
@@ -91,19 +91,19 @@ COMMON_DEPEND="
 	dev-libs/boost:=
 	dev-libs/grantlee:5
 	dev-libs/libxslt
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 	google? ( net-libs/libkgapi:5 )
 	prison? ( media-libs/prison:5 )
 	kdepim_features_kleopatra? (
@@ -115,7 +115,7 @@ DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
 	test? (
 		$(add_kdeapps_dep akonadi 'sqlite,tools')
-		dev-qt/qtsql:5[sqlite]
+		$(add_qt_dep qtsql 'sqlite')
 	)
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-15.12.1.ebuild
+++ b/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-15.12.1.ebuild
@@ -15,8 +15,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-15.12.49.9999.ebuild
+++ b/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-15.12.49.9999.ebuild
@@ -15,8 +15,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-9999.ebuild
+++ b/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-9999.ebuild
@@ -15,8 +15,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdgantt2/kdgantt2-15.12.1.ebuild
+++ b/kde-apps/kdgantt2/kdgantt2-15.12.1.ebuild
@@ -15,9 +15,9 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kdgantt2/kdgantt2-15.12.49.9999.ebuild
+++ b/kde-apps/kdgantt2/kdgantt2-15.12.49.9999.ebuild
@@ -15,9 +15,9 @@ KEYWORDS=""
 IUSE=""
 
 COMMON_DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kdgantt2/kdgantt2-9999.ebuild
+++ b/kde-apps/kdgantt2/kdgantt2-9999.ebuild
@@ -14,9 +14,9 @@ KEYWORDS=""
 IUSE=""
 
 COMMON_DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/kdiagram/kdiagram-9999.ebuild
+++ b/kde-apps/kdiagram/kdiagram-9999.ebuild
@@ -12,9 +12,9 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdialog/kdialog-5.9999.ebuild
+++ b/kde-apps/kdialog/kdialog-5.9999.ebuild
@@ -17,5 +17,5 @@ S=${WORKDIR}/${P}/${PN}
 DEPEND="
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtdbus:5"
+	$(add_qt_dep qtdbus)"
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdiamond/kdiamond-15.12.1.ebuild
+++ b/kde-apps/kdiamond/kdiamond-15.12.1.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdiamond/kdiamond-15.12.49.9999.ebuild
+++ b/kde-apps/kdiamond/kdiamond-15.12.49.9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kdiamond/kdiamond-9999.ebuild
+++ b/kde-apps/kdiamond/kdiamond-9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kfind/kfind-5.9999.ebuild
+++ b/kde-apps/kfind/kfind-5.9999.ebuild
@@ -28,8 +28,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkonq)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kfourinline/kfourinline-15.12.1.ebuild
+++ b/kde-apps/kfourinline/kfourinline-15.12.1.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kfourinline/kfourinline-15.12.49.9999.ebuild
+++ b/kde-apps/kfourinline/kfourinline-15.12.49.9999.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kfourinline/kfourinline-9999.ebuild
+++ b/kde-apps/kfourinline/kfourinline-9999.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kgeography/kgeography-15.08.3-r1.ebuild
+++ b/kde-apps/kgeography/kgeography-15.08.3-r1.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kgeography/kgeography-15.12.1.ebuild
+++ b/kde-apps/kgeography/kgeography-15.12.1.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kgeography/kgeography-15.12.49.9999.ebuild
+++ b/kde-apps/kgeography/kgeography-15.12.49.9999.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kgeography/kgeography-9999.ebuild
+++ b/kde-apps/kgeography/kgeography-9999.ebuild
@@ -23,8 +23,8 @@ DEPEND="
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kget/kget-5.9999.ebuild
+++ b/kde-apps/kget/kget-5.9999.ebuild
@@ -33,12 +33,12 @@ RDEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qttest:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qttest)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	gpg? ( $(add_kdeapps_dep gpgmepp) )
 	mms? ( media-libs/libmms )
 	sqlite? ( dev-db/sqlite:3 )

--- a/kde-apps/kgoldrunner/kgoldrunner-5.9999.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-5.9999.ebuild
@@ -27,8 +27,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/libsndfile
 	media-libs/openal
 "

--- a/kde-apps/khangman/khangman-15.08.3.ebuild
+++ b/kde-apps/khangman/khangman-15.08.3.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/khangman/khangman-15.12.1.ebuild
+++ b/kde-apps/khangman/khangman-15.12.1.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/khangman/khangman-15.12.49.9999.ebuild
+++ b/kde-apps/khangman/khangman-15.12.49.9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/khangman/khangman-9999.ebuild
+++ b/kde-apps/khangman/khangman-9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/kidentitymanagement/kidentitymanagement-15.12.1.ebuild
+++ b/kde-apps/kidentitymanagement/kidentitymanagement-15.12.1.ebuild
@@ -24,9 +24,9 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kidentitymanagement/kidentitymanagement-15.12.49.9999.ebuild
+++ b/kde-apps/kidentitymanagement/kidentitymanagement-15.12.49.9999.ebuild
@@ -24,9 +24,9 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kidentitymanagement/kidentitymanagement-9999.ebuild
+++ b/kde-apps/kidentitymanagement/kidentitymanagement-9999.ebuild
@@ -24,9 +24,9 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kig/kig-15.08.3.ebuild
+++ b/kde-apps/kig/kig-15.08.3.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	scripting? ( >=dev-libs/boost-1.48:=[python,${PYTHON_USEDEP}] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kig/kig-15.12.1.ebuild
+++ b/kde-apps/kig/kig-15.12.1.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	scripting? ( >=dev-libs/boost-1.48:=[python,${PYTHON_USEDEP}] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kig/kig-15.12.49.9999.ebuild
+++ b/kde-apps/kig/kig-15.12.49.9999.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	scripting? ( >=dev-libs/boost-1.48:=[python,${PYTHON_USEDEP}] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kig/kig-9999.ebuild
+++ b/kde-apps/kig/kig-9999.ebuild
@@ -29,11 +29,11 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	scripting? ( >=dev-libs/boost-1.48:=[python,${PYTHON_USEDEP}] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kigo/kigo-5.9999.ebuild
+++ b/kde-apps/kigo/kigo-5.9999.ebuild
@@ -27,9 +27,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	games-board/gnugo

--- a/kde-apps/killbots/killbots-15.12.1.ebuild
+++ b/kde-apps/killbots/killbots-15.12.1.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/killbots/killbots-15.12.49.9999.ebuild
+++ b/kde-apps/killbots/killbots-15.12.49.9999.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/killbots/killbots-9999.ebuild
+++ b/kde-apps/killbots/killbots-9999.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kimap/kimap-15.12.1.ebuild
+++ b/kde-apps/kimap/kimap-15.12.1.ebuild
@@ -20,6 +20,6 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kmime)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kimap/kimap-15.12.49.9999.ebuild
+++ b/kde-apps/kimap/kimap-15.12.49.9999.ebuild
@@ -20,6 +20,6 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kmime)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kimap/kimap-9999.ebuild
+++ b/kde-apps/kimap/kimap-9999.ebuild
@@ -20,6 +20,6 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep kmime)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kio-extras/kio-extras-15.12.1.ebuild
+++ b/kde-apps/kio-extras/kio-extras-15.12.1.ebuild
@@ -34,12 +34,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	virtual/jpeg:0
 	exif? ( media-gfx/exiv2:= )
 	mtp? ( media-libs/libmtp:= )

--- a/kde-apps/kio-extras/kio-extras-15.12.49.9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-15.12.49.9999.ebuild
@@ -34,12 +34,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	virtual/jpeg:0
 	exif? ( media-gfx/exiv2:= )
 	mtp? ( media-libs/libmtp:= )

--- a/kde-apps/kio-extras/kio-extras-9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-9999.ebuild
@@ -34,12 +34,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	virtual/jpeg:0
 	exif? ( media-gfx/exiv2:= )
 	mtp? ( media-libs/libmtp:= )

--- a/kde-apps/kiriki/kiriki-15.12.1.ebuild
+++ b/kde-apps/kiriki/kiriki-15.12.1.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiriki/kiriki-15.12.49.9999.ebuild
+++ b/kde-apps/kiriki/kiriki-15.12.49.9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiriki/kiriki-9999.ebuild
+++ b/kde-apps/kiriki/kiriki-9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiten/kiten-15.08.3.ebuild
+++ b/kde-apps/kiten/kiten-15.08.3.ebuild
@@ -24,8 +24,8 @@ DEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiten/kiten-15.12.1.ebuild
+++ b/kde-apps/kiten/kiten-15.12.1.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiten/kiten-15.12.49.9999.ebuild
+++ b/kde-apps/kiten/kiten-15.12.49.9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kiten/kiten-9999.ebuild
+++ b/kde-apps/kiten/kiten-9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kjots/kjots-9999.ebuild
+++ b/kde-apps/kjots/kjots-9999.ebuild
@@ -31,10 +31,10 @@ RDEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	dev-libs/grantlee:5
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext

--- a/kde-apps/kjumpingcube/kjumpingcube-15.12.1.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-15.12.1.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kjumpingcube/kjumpingcube-15.12.49.9999.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-15.12.49.9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kldap/kldap-15.12.1.ebuild
+++ b/kde-apps/kldap/kldap-15.12.1.ebuild
@@ -18,8 +18,8 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-nds/openldap
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kldap/kldap-15.12.49.9999.ebuild
+++ b/kde-apps/kldap/kldap-15.12.49.9999.ebuild
@@ -18,8 +18,8 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-nds/openldap
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kldap/kldap-9999.ebuild
+++ b/kde-apps/kldap/kldap-9999.ebuild
@@ -18,8 +18,8 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/cyrus-sasl
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-nds/openldap
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/klettres/klettres-15.08.3.ebuild
+++ b/kde-apps/klettres/klettres-15.08.3.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/klettres/klettres-15.12.1.ebuild
+++ b/kde-apps/klettres/klettres-15.12.1.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/klettres/klettres-15.12.49.9999.ebuild
+++ b/kde-apps/klettres/klettres-15.12.49.9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/klettres/klettres-9999.ebuild
+++ b/kde-apps/klettres/klettres-9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/klickety/klickety-15.12.1.ebuild
+++ b/kde-apps/klickety/klickety-15.12.1.ebuild
@@ -24,8 +24,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/klickety/klickety-15.12.49.9999.ebuild
+++ b/kde-apps/klickety/klickety-15.12.49.9999.ebuild
@@ -24,8 +24,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/klickety/klickety-9999.ebuild
+++ b/kde-apps/klickety/klickety-9999.ebuild
@@ -24,8 +24,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/klines/klines-15.12.1.ebuild
+++ b/kde-apps/klines/klines-15.12.1.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/klines/klines-15.12.49.9999.ebuild
+++ b/kde-apps/klines/klines-15.12.49.9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/klines/klines-9999.ebuild
+++ b/kde-apps/klines/klines-9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kmag/kmag-5.9999.ebuild
+++ b/kde-apps/kmag/kmag-5.9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	keyboardfocus? ( media-libs/libkdeaccessibilityclient )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kmahjongg/kmahjongg-9999.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-9999.ebuild
@@ -29,9 +29,9 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
 	$(add_kdeapps_dep libkmahjongg)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kmailtransport/kmailtransport-15.12.1.ebuild
+++ b/kde-apps/kmailtransport/kmailtransport-15.12.1.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_kdeapps_dep akonadi-mime)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kmailtransport/kmailtransport-15.12.49.9999.ebuild
+++ b/kde-apps/kmailtransport/kmailtransport-15.12.49.9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_kdeapps_dep akonadi-mime)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kmailtransport/kmailtransport-9999.ebuild
+++ b/kde-apps/kmailtransport/kmailtransport-9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_kdeapps_dep akonadi)
 	$(add_kdeapps_dep akonadi-mime)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kmines/kmines-15.12.1.ebuild
+++ b/kde-apps/kmines/kmines-15.12.1.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	phonon? ( media-libs/phonon[qt5] )
 "
 

--- a/kde-apps/kmines/kmines-15.12.49.9999.ebuild
+++ b/kde-apps/kmines/kmines-15.12.49.9999.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	phonon? ( media-libs/phonon[qt5] )
 "
 

--- a/kde-apps/kmines/kmines-9999.ebuild
+++ b/kde-apps/kmines/kmines-9999.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	phonon? ( media-libs/phonon[qt5] )
 "
 

--- a/kde-apps/kmix/kmix-15.12.1.ebuild
+++ b/kde-apps/kmix/kmix-15.12.1.ebuild
@@ -28,10 +28,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	alsa? ( >=media-libs/alsa-lib-1.0.14a )
 	pulseaudio? (
 		media-libs/libcanberra

--- a/kde-apps/kmix/kmix-15.12.49.9999.ebuild
+++ b/kde-apps/kmix/kmix-15.12.49.9999.ebuild
@@ -28,10 +28,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	alsa? ( >=media-libs/alsa-lib-1.0.14a )
 	pulseaudio? (
 		media-libs/libcanberra

--- a/kde-apps/kmix/kmix-9999.ebuild
+++ b/kde-apps/kmix/kmix-9999.ebuild
@@ -28,10 +28,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	alsa? ( >=media-libs/alsa-lib-1.0.14a )
 	pulseaudio? (
 		media-libs/libcanberra

--- a/kde-apps/kmousetool/kmousetool-5.9999.ebuild
+++ b/kde-apps/kmousetool/kmousetool-5.9999.ebuild
@@ -22,8 +22,8 @@ RDEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	x11-libs/libX11
 	x11-libs/libXtst

--- a/kde-apps/kmouth/kmouth-5.9999.ebuild
+++ b/kde-apps/kmouth/kmouth-5.9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtspeech:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtspeech)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kmplot/kmplot-15.08.3.ebuild
+++ b/kde-apps/kmplot/kmplot-15.08.3.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kmplot/kmplot-15.12.1.ebuild
+++ b/kde-apps/kmplot/kmplot-15.12.1.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kmplot/kmplot-15.12.49.9999.ebuild
+++ b/kde-apps/kmplot/kmplot-15.12.49.9999.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kmplot/kmplot-9999.ebuild
+++ b/kde-apps/kmplot/kmplot-9999.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/knavalbattle/knavalbattle-15.12.1.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-15.12.1.ebuild
@@ -27,10 +27,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/knavalbattle/knavalbattle-15.12.49.9999.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-15.12.49.9999.ebuild
@@ -27,10 +27,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/knavalbattle/knavalbattle-9999.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-9999.ebuild
@@ -27,10 +27,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/knetwalk/knetwalk-15.12.1.ebuild
+++ b/kde-apps/knetwalk/knetwalk-15.12.1.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/knetwalk/knetwalk-15.12.49.9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-15.12.49.9999.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/knetwalk/knetwalk-9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-9999.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kolf/kolf-5.9999.ebuild
+++ b/kde-apps/kolf/kolf-5.9999.ebuild
@@ -28,8 +28,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kollision/kollision-15.12.1.ebuild
+++ b/kde-apps/kollision/kollision-15.12.1.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kollision/kollision-15.12.49.9999.ebuild
+++ b/kde-apps/kollision/kollision-15.12.49.9999.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kollision/kollision-9999.ebuild
+++ b/kde-apps/kollision/kollision-9999.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kompare/kompare-15.12.1.ebuild
+++ b/kde-apps/kompare/kompare-15.12.1.ebuild
@@ -29,9 +29,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkomparediff2)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 
 DEPEND="${RDEPEND}"

--- a/kde-apps/kompare/kompare-15.12.49.9999.ebuild
+++ b/kde-apps/kompare/kompare-15.12.49.9999.ebuild
@@ -29,9 +29,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkomparediff2)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 
 DEPEND="${RDEPEND}"

--- a/kde-apps/kompare/kompare-9999.ebuild
+++ b/kde-apps/kompare/kompare-9999.ebuild
@@ -29,9 +29,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkomparediff2)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 "
 
 DEPEND="${RDEPEND}"

--- a/kde-apps/konquest/konquest-5.9999.ebuild
+++ b/kde-apps/konquest/konquest-5.9999.ebuild
@@ -33,11 +33,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/konsole/konsole-15.12.1.ebuild
+++ b/kde-apps/konsole/konsole-15.12.1.ebuild
@@ -37,13 +37,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	X? ( x11-libs/libX11 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/konsole/konsole-15.12.49.9999.ebuild
+++ b/kde-apps/konsole/konsole-15.12.49.9999.ebuild
@@ -37,13 +37,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	X? ( x11-libs/libX11 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/konsole/konsole-9999.ebuild
+++ b/kde-apps/konsole/konsole-9999.ebuild
@@ -37,13 +37,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	X? ( x11-libs/libX11 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kontactinterface/kontactinterface-15.12.1.ebuild
+++ b/kde-apps/kontactinterface/kontactinterface-15.12.1.ebuild
@@ -19,9 +19,9 @@ RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kontactinterface/kontactinterface-15.12.49.9999.ebuild
+++ b/kde-apps/kontactinterface/kontactinterface-15.12.49.9999.ebuild
@@ -19,9 +19,9 @@ RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kontactinterface/kontactinterface-9999.ebuild
+++ b/kde-apps/kontactinterface/kontactinterface-9999.ebuild
@@ -19,9 +19,9 @@ RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kpat/kpat-15.12.1.ebuild
+++ b/kde-apps/kpat/kpat-15.12.1.ebuild
@@ -34,11 +34,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	x11-misc/shared-mime-info
 "

--- a/kde-apps/kpat/kpat-15.12.49.9999.ebuild
+++ b/kde-apps/kpat/kpat-15.12.49.9999.ebuild
@@ -34,11 +34,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	x11-misc/shared-mime-info
 "

--- a/kde-apps/kpat/kpat-9999.ebuild
+++ b/kde-apps/kpat/kpat-9999.ebuild
@@ -34,11 +34,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	x11-misc/shared-mime-info
 "

--- a/kde-apps/kpeoplevcard/kpeoplevcard-9999.ebuild
+++ b/kde-apps/kpeoplevcard/kpeoplevcard-9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kpeople)
 	$(add_kdeapps_dep kcontacts)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kpimtextedit/kpimtextedit-15.12.1.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-15.12.1.ebuild
@@ -28,8 +28,8 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	dev-libs/grantlee:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kpimtextedit/kpimtextedit-15.12.49.9999.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-15.12.49.9999.ebuild
@@ -28,8 +28,8 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	dev-libs/grantlee:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
@@ -28,8 +28,8 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	dev-libs/grantlee:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/kproperty/kproperty-9999.ebuild
+++ b/kde-apps/kproperty/kproperty-9999.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kqtquickcharts/kqtquickcharts-5.9999.ebuild
+++ b/kde-apps/kqtquickcharts/kqtquickcharts-5.9999.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/krdc/krdc-5.9999.ebuild
+++ b/kde-apps/krdc/krdc-5.9999.ebuild
@@ -31,9 +31,9 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-dns/avahi
 	vnc? ( >=net-libs/libvncserver-0.9 )
 "

--- a/kde-apps/kreport/kreport-9999.ebuild
+++ b/kde-apps/kreport/kreport-9999.ebuild
@@ -18,10 +18,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kross)
 	$(add_kdeapps_dep kproperty)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/kreversi/kreversi-5.9999.ebuild
+++ b/kde-apps/kreversi/kreversi-5.9999.ebuild
@@ -30,11 +30,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/krfb/krfb-15.12.1.ebuild
+++ b/kde-apps/krfb/krfb-15.12.1.ebuild
@@ -26,11 +26,11 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	>=net-libs/libvncserver-0.9.9
 	sys-libs/zlib
 	virtual/jpeg:0

--- a/kde-apps/krfb/krfb-15.12.49.9999.ebuild
+++ b/kde-apps/krfb/krfb-15.12.49.9999.ebuild
@@ -26,11 +26,11 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	>=net-libs/libvncserver-0.9.9
 	sys-libs/zlib
 	virtual/jpeg:0

--- a/kde-apps/krfb/krfb-9999.ebuild
+++ b/kde-apps/krfb/krfb-9999.ebuild
@@ -26,11 +26,11 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	>=net-libs/libvncserver-0.9.9
 	sys-libs/zlib
 	virtual/jpeg:0

--- a/kde-apps/kross-interpreters/kross-interpreters-15.08.3.ebuild
+++ b/kde-apps/kross-interpreters/kross-interpreters-15.08.3.ebuild
@@ -15,8 +15,8 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kross)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kross-interpreters/kross-interpreters-15.12.1.ebuild
+++ b/kde-apps/kross-interpreters/kross-interpreters-15.12.1.ebuild
@@ -15,8 +15,8 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kross)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kross-interpreters/kross-interpreters-15.12.49.9999.ebuild
+++ b/kde-apps/kross-interpreters/kross-interpreters-15.12.49.9999.ebuild
@@ -15,8 +15,8 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kross)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kross-interpreters/kross-interpreters-9999.ebuild
+++ b/kde-apps/kross-interpreters/kross-interpreters-9999.ebuild
@@ -15,8 +15,8 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kross)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kruler/kruler-15.12.1.ebuild
+++ b/kde-apps/kruler/kruler-15.12.1.ebuild
@@ -21,10 +21,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 	)
 "

--- a/kde-apps/kruler/kruler-15.12.49.9999.ebuild
+++ b/kde-apps/kruler/kruler-15.12.49.9999.ebuild
@@ -21,10 +21,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 	)
 "

--- a/kde-apps/kruler/kruler-9999.ebuild
+++ b/kde-apps/kruler/kruler-9999.ebuild
@@ -21,10 +21,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 	)
 "

--- a/kde-apps/kshisen/kshisen-15.12.1.ebuild
+++ b/kde-apps/kshisen/kshisen-15.12.1.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
 	$(add_kdeapps_dep libkmahjongg)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kshisen/kshisen-15.12.49.9999.ebuild
+++ b/kde-apps/kshisen/kshisen-15.12.49.9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
 	$(add_kdeapps_dep libkmahjongg)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kshisen/kshisen-9999.ebuild
+++ b/kde-apps/kshisen/kshisen-9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
 	$(add_kdeapps_dep libkmahjongg)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ksnakeduel/ksnakeduel-5.9999.ebuild
+++ b/kde-apps/ksnakeduel/ksnakeduel-5.9999.ebuild
@@ -30,11 +30,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/kspaceduel/kspaceduel-5.9999.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-5.9999.ebuild
@@ -33,11 +33,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/ksquares/ksquares-15.12.1.ebuild
+++ b/kde-apps/ksquares/ksquares-15.12.1.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ksquares/ksquares-15.12.49.9999.ebuild
+++ b/kde-apps/ksquares/ksquares-15.12.49.9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ksquares/ksquares-9999.ebuild
+++ b/kde-apps/ksquares/ksquares-9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kstars/kstars-15.08.3-r1.ebuild
+++ b/kde-apps/kstars/kstars-15.08.3-r1.ebuild
@@ -32,15 +32,15 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtmultimedia)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=sci-libs/cfitsio-0.390
 	sys-libs/zlib
 	indi? ( >=sci-libs/indilib-1.0.0 )

--- a/kde-apps/kstars/kstars-15.12.1.ebuild
+++ b/kde-apps/kstars/kstars-15.12.1.ebuild
@@ -29,12 +29,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kplotting)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=sci-libs/cfitsio-0.390
 	sys-libs/zlib
 	indi? (

--- a/kde-apps/kstars/kstars-15.12.49.9999.ebuild
+++ b/kde-apps/kstars/kstars-15.12.49.9999.ebuild
@@ -29,12 +29,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kplotting)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=sci-libs/cfitsio-0.390
 	sys-libs/zlib
 	indi? (

--- a/kde-apps/kstars/kstars-9999.ebuild
+++ b/kde-apps/kstars/kstars-9999.ebuild
@@ -29,12 +29,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kplotting)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=sci-libs/cfitsio-0.390
 	sys-libs/zlib
 	indi? (
@@ -46,7 +46,7 @@ COMMON_DEPEND="
 "
 # TODO: Add back when re-enabled by upstream
 # 	opengl? (
-# 		dev-qt/qtopengl:5
+# 		$(add_qt_dep qtopengl)
 # 		virtual/opengl
 # 	)
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/ksudoku/ksudoku-5.9999.ebuild
+++ b/kde-apps/ksudoku/ksudoku-5.9999.ebuild
@@ -27,13 +27,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	opengl? (
-		dev-qt/qtopengl:5
+		$(add_qt_dep qtopengl)
 		virtual/glu
 	)
 "

--- a/kde-apps/ksystemlog/ksystemlog-15.12.1.ebuild
+++ b/kde-apps/ksystemlog/ksystemlog-15.12.1.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	systemd? ( sys-apps/systemd )
 "
 

--- a/kde-apps/ksystemlog/ksystemlog-15.12.49.9999.ebuild
+++ b/kde-apps/ksystemlog/ksystemlog-15.12.49.9999.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	systemd? ( sys-apps/systemd )
 "
 

--- a/kde-apps/ksystemlog/ksystemlog-9999.ebuild
+++ b/kde-apps/ksystemlog/ksystemlog-9999.ebuild
@@ -32,9 +32,9 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	systemd? ( sys-apps/systemd )
 "
 

--- a/kde-apps/kteatime/kteatime-15.12.1.ebuild
+++ b/kde-apps/kteatime/kteatime-15.12.1.ebuild
@@ -23,8 +23,8 @@ DEPEND="
 	$(add_frameworks_dep knotifyconfig)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kteatime/kteatime-15.12.49.9999.ebuild
+++ b/kde-apps/kteatime/kteatime-15.12.49.9999.ebuild
@@ -23,8 +23,8 @@ DEPEND="
 	$(add_frameworks_dep knotifyconfig)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kteatime/kteatime-9999.ebuild
+++ b/kde-apps/kteatime/kteatime-9999.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep knotifyconfig)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ktimer/ktimer-15.12.1.ebuild
+++ b/kde-apps/ktimer/ktimer-15.12.1.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ktimer/ktimer-15.12.49.9999.ebuild
+++ b/kde-apps/ktimer/ktimer-15.12.49.9999.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ktimer/ktimer-9999.ebuild
+++ b/kde-apps/ktimer/ktimer-9999.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-15.12.1.ebuild
+++ b/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-15.12.1.ebuild
@@ -24,10 +24,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-15.12.49.9999.ebuild
@@ -24,10 +24,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
+++ b/kde-apps/ktp-accounts-kcm/ktp-accounts-kcm-9999.ebuild
@@ -24,10 +24,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep kaccounts-integration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-approver/ktp-approver-15.12.1.ebuild
+++ b/kde-apps/ktp-approver/ktp-approver-15.12.1.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]"
 
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-approver/ktp-approver-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-approver/ktp-approver-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]"
 
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-approver/ktp-approver-9999.ebuild
+++ b/kde-apps/ktp-approver/ktp-approver-9999.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]"
 
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-auth-handler/ktp-auth-handler-15.12.1.ebuild
+++ b/kde-apps/ktp-auth-handler/ktp-auth-handler-15.12.1.ebuild
@@ -23,10 +23,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kaccounts-integration)
 	$(add_kdeapps_dep ktp-common-internals)
 	app-crypt/qca:2[qt5]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-auth-handler/ktp-auth-handler-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-auth-handler/ktp-auth-handler-15.12.49.9999.ebuild
@@ -23,10 +23,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kaccounts-integration)
 	$(add_kdeapps_dep ktp-common-internals)
 	app-crypt/qca:2[qt5]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-auth-handler/ktp-auth-handler-9999.ebuild
+++ b/kde-apps/ktp-auth-handler/ktp-auth-handler-9999.ebuild
@@ -23,10 +23,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kaccounts-integration)
 	$(add_kdeapps_dep ktp-common-internals)
 	app-crypt/qca:2[qt5]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-libs/accounts-qt
 	net-libs/signond
 	net-libs/telepathy-qt[qt5]

--- a/kde-apps/ktp-call-ui/ktp-call-ui-9999.ebuild
+++ b/kde-apps/ktp-call-ui/ktp-call-ui-9999.ebuild
@@ -27,9 +27,9 @@ DEPEND="
 	$(add_kdeapps_dep ktp-common-internals)
 	dev-libs/boost
 	dev-libs/glib:2
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	media-libs/qt-gstreamer[qt5]
 	net-libs/farstream:0.2

--- a/kde-apps/ktp-common-internals/ktp-common-internals-15.12.1.ebuild
+++ b/kde-apps/ktp-common-internals/ktp-common-internals-15.12.1.ebuild
@@ -31,12 +31,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-logger-qt:5
 	>=net-libs/telepathy-qt-0.9.5[qt5]
 	sso? (
@@ -52,7 +52,7 @@ COMMON_DEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	$(add_frameworks_dep kio)
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-common-internals/ktp-common-internals-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-common-internals/ktp-common-internals-15.12.49.9999.ebuild
@@ -31,12 +31,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-logger-qt:5
 	>=net-libs/telepathy-qt-0.9.5[qt5]
 	sso? (
@@ -52,7 +52,7 @@ COMMON_DEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	$(add_frameworks_dep kio)
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-common-internals/ktp-common-internals-9999.ebuild
+++ b/kde-apps/ktp-common-internals/ktp-common-internals-9999.ebuild
@@ -31,12 +31,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-logger-qt:5
 	>=net-libs/telepathy-qt-0.9.5[qt5]
 	sso? (
@@ -52,7 +52,7 @@ COMMON_DEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	$(add_frameworks_dep kio)
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-contact-list/ktp-contact-list-15.12.1.ebuild
+++ b/kde-apps/ktp-contact-list/ktp-contact-list-15.12.1.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="
@@ -38,7 +38,7 @@ DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifyconfig)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-contact-list/ktp-contact-list-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-contact-list/ktp-contact-list-15.12.49.9999.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="
@@ -38,7 +38,7 @@ DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifyconfig)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-contact-list/ktp-contact-list-9999.ebuild
+++ b/kde-apps/ktp-contact-list/ktp-contact-list-9999.ebuild
@@ -28,9 +28,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="
@@ -38,7 +38,7 @@ DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifyconfig)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-contact-runner/ktp-contact-runner-15.12.1.ebuild
+++ b/kde-apps/ktp-contact-runner/ktp-contact-runner-15.12.1.ebuild
@@ -18,9 +18,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep krunner)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-contact-runner/ktp-contact-runner-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-contact-runner/ktp-contact-runner-15.12.49.9999.ebuild
@@ -18,9 +18,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep krunner)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-contact-runner/ktp-contact-runner-9999.ebuild
+++ b/kde-apps/ktp-contact-runner/ktp-contact-runner-9999.ebuild
@@ -18,9 +18,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep krunner)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-desktop-applets/ktp-desktop-applets-15.12.1.ebuild
+++ b/kde-apps/ktp-desktop-applets/ktp-desktop-applets-15.12.1.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 
 COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdeclarative:5
+	$(add_qt_dep qtdeclarative)
 "
 DEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-desktop-applets/ktp-desktop-applets-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-desktop-applets/ktp-desktop-applets-15.12.49.9999.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 
 COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdeclarative:5
+	$(add_qt_dep qtdeclarative)
 "
 DEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-desktop-applets/ktp-desktop-applets-9999.ebuild
+++ b/kde-apps/ktp-desktop-applets/ktp-desktop-applets-9999.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 
 COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdeclarative:5
+	$(add_qt_dep qtdeclarative)
 "
 DEPEND="
 	${COMMON_DEPEND}

--- a/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-15.12.1.ebuild
+++ b/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-15.12.1.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-15.12.49.9999.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-9999.ebuild
+++ b/kde-apps/ktp-filetransfer-handler/ktp-filetransfer-handler-9999.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-kded-module/ktp-kded-module-15.12.1.ebuild
+++ b/kde-apps/ktp-kded-module/ktp-kded-module-15.12.1.ebuild
@@ -23,12 +23,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-kded-module/ktp-kded-module-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-kded-module/ktp-kded-module-15.12.49.9999.ebuild
@@ -23,12 +23,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-kded-module/ktp-kded-module-9999.ebuild
+++ b/kde-apps/ktp-kded-module/ktp-kded-module-9999.ebuild
@@ -23,12 +23,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep knotifications)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-l10n/ktp-l10n-15.12.1.ebuild
+++ b/kde-apps/ktp-l10n/ktp-l10n-15.12.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
-	dev-qt/linguist-tools:5
+	$(add_qt_dep linguist-tools)
 	sys-devel/gettext
 "
 RDEPEND="

--- a/kde-apps/ktp-send-file/ktp-send-file-15.12.1.ebuild
+++ b/kde-apps/ktp-send-file/ktp-send-file-15.12.1.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-send-file/ktp-send-file-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-send-file/ktp-send-file-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-send-file/ktp-send-file-9999.ebuild
+++ b/kde-apps/ktp-send-file/ktp-send-file-9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep ktp-common-internals)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	net-libs/telepathy-qt[qt5]
 "
 DEPEND="

--- a/kde-apps/ktp-text-ui/ktp-text-ui-15.12.1.ebuild
+++ b/kde-apps/ktp-text-ui/ktp-text-ui-15.12.1.ebuild
@@ -35,11 +35,11 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep ktp-common-internals otr)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-text-ui/ktp-text-ui-15.12.49.9999.ebuild
+++ b/kde-apps/ktp-text-ui/ktp-text-ui-15.12.49.9999.ebuild
@@ -35,11 +35,11 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep ktp-common-internals otr)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktp-text-ui/ktp-text-ui-9999.ebuild
+++ b/kde-apps/ktp-text-ui/ktp-text-ui-9999.ebuild
@@ -35,11 +35,11 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
 	$(add_kdeapps_dep ktp-common-internals otr)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	net-libs/telepathy-qt[qt5]
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/ktuberling/ktuberling-15.12.1.ebuild
+++ b/kde-apps/ktuberling/ktuberling-15.12.1.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/ktuberling/ktuberling-15.12.49.9999.ebuild
+++ b/kde-apps/ktuberling/ktuberling-15.12.49.9999.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/ktuberling/ktuberling-9999.ebuild
+++ b/kde-apps/ktuberling/ktuberling-9999.ebuild
@@ -28,11 +28,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 "
 

--- a/kde-apps/kturtle/kturtle-15.08.3.ebuild
+++ b/kde-apps/kturtle/kturtle-15.08.3.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kturtle/kturtle-15.12.1.ebuild
+++ b/kde-apps/kturtle/kturtle-15.12.1.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kturtle/kturtle-15.12.49.9999.ebuild
+++ b/kde-apps/kturtle/kturtle-15.12.49.9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kturtle/kturtle-9999.ebuild
+++ b/kde-apps/kturtle/kturtle-9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kubrick/kubrick-5.9999.ebuild
+++ b/kde-apps/kubrick/kubrick-5.9999.ebuild
@@ -22,10 +22,10 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	virtual/glu
 "
 DEPEND="${RDEPEND}

--- a/kde-apps/kwalletmanager/kwalletmanager-15.12.1.ebuild
+++ b/kde-apps/kwalletmanager/kwalletmanager-15.12.1.ebuild
@@ -32,10 +32,10 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	!kde-apps/kwalletmanager:4[-minimal(-)]

--- a/kde-apps/kwalletmanager/kwalletmanager-15.12.49.9999.ebuild
+++ b/kde-apps/kwalletmanager/kwalletmanager-15.12.49.9999.ebuild
@@ -32,10 +32,10 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	!kde-apps/kwalletmanager:4[-minimal(-)]

--- a/kde-apps/kwalletmanager/kwalletmanager-9999.ebuild
+++ b/kde-apps/kwalletmanager/kwalletmanager-9999.ebuild
@@ -32,10 +32,10 @@ DEPEND="
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	!kde-apps/kwalletmanager:4[-minimal(-)]

--- a/kde-apps/kwordquiz/kwordquiz-15.08.3.ebuild
+++ b/kde-apps/kwordquiz/kwordquiz-15.08.3.ebuild
@@ -29,8 +29,8 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND=${DEPEND}

--- a/kde-apps/kwordquiz/kwordquiz-15.12.1.ebuild
+++ b/kde-apps/kwordquiz/kwordquiz-15.12.1.ebuild
@@ -29,8 +29,8 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND=${DEPEND}

--- a/kde-apps/kwordquiz/kwordquiz-15.12.49.9999.ebuild
+++ b/kde-apps/kwordquiz/kwordquiz-15.12.49.9999.ebuild
@@ -29,8 +29,8 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND=${DEPEND}

--- a/kde-apps/kwordquiz/kwordquiz-9999.ebuild
+++ b/kde-apps/kwordquiz/kwordquiz-9999.ebuild
@@ -29,8 +29,8 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkeduvocdocument)
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 RDEPEND=${DEPEND}

--- a/kde-apps/kwrite/kwrite-15.12.1.ebuild
+++ b/kde-apps/kwrite/kwrite-15.12.1.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kwrite/kwrite-15.12.49.9999.ebuild
+++ b/kde-apps/kwrite/kwrite-15.12.49.9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/kwrite/kwrite-9999.ebuild
+++ b/kde-apps/kwrite/kwrite-9999.ebuild
@@ -26,8 +26,8 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/libakonadi/libakonadi-15.12.1.ebuild
+++ b/kde-apps/libakonadi/libakonadi-15.12.1.ebuild
@@ -35,13 +35,13 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep akonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qtxml:5
-	dev-qt/qtwidgets:5
-	designer? ( dev-qt/designer:5 )
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtwidgets)
+	designer? ( $(add_qt_dep designer) )
 	tools? ( dev-libs/libxml2 )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/libakonadi/libakonadi-15.12.49.9999.ebuild
+++ b/kde-apps/libakonadi/libakonadi-15.12.49.9999.ebuild
@@ -35,13 +35,13 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep akonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5
-	dev-qt/qtxml:5
-	dev-qt/qtwidgets:5
-	designer? ( dev-qt/designer:5 )
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtwidgets)
+	designer? ( $(add_qt_dep designer) )
 	tools? ( dev-libs/libxml2 )
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-apps/libfollowupreminder/libfollowupreminder-15.12.1.ebuild
+++ b/kde-apps/libfollowupreminder/libfollowupreminder-15.12.1.ebuild
@@ -19,8 +19,8 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knewstuff)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libfollowupreminder/libfollowupreminder-15.12.49.9999.ebuild
+++ b/kde-apps/libfollowupreminder/libfollowupreminder-15.12.49.9999.ebuild
@@ -19,8 +19,8 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knewstuff)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libgravatar/libgravatar-15.12.1.ebuild
+++ b/kde-apps/libgravatar/libgravatar-15.12.1.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libgravatar/libgravatar-15.12.49.9999.ebuild
+++ b/kde-apps/libgravatar/libgravatar-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libgravatar/libgravatar-9999.ebuild
+++ b/kde-apps/libgravatar/libgravatar-9999.ebuild
@@ -19,9 +19,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkcddb/libkcddb-5.9999.ebuild
+++ b/kde-apps/libkcddb/libkcddb-5.9999.ebuild
@@ -24,9 +24,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	musicbrainz? ( media-libs/musicbrainz:5 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkcompactdisc/libkcompactdisc-5.9999.ebuild
+++ b/kde-apps/libkcompactdisc/libkcompactdisc-5.9999.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep solid)
 	media-libs/phonon[qt5]
-	dev-qt/qtdbus:5
+	$(add_qt_dep qtdbus)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-apps/libkdcraw/libkdcraw-15.12.1.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-15.12.1.ebuild
@@ -13,6 +13,6 @@ IUSE=""
 
 DEPEND="
 	>=media-libs/libraw-0.16:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkdcraw/libkdcraw-15.12.49.9999.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-15.12.49.9999.ebuild
@@ -13,6 +13,6 @@ IUSE=""
 
 DEPEND="
 	>=media-libs/libraw-0.16:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkdcraw/libkdcraw-9999.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-9999.ebuild
@@ -13,6 +13,6 @@ IUSE=""
 
 DEPEND="
 	>=media-libs/libraw-0.16:=
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkdegames/libkdegames-15.12.1.ebuild
+++ b/kde-apps/libkdegames/libkdegames-15.12.1.ebuild
@@ -38,12 +38,12 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtsvg:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtxml)
 	media-libs/libsndfile
 	media-libs/openal
 "

--- a/kde-apps/libkdegames/libkdegames-15.12.49.9999.ebuild
+++ b/kde-apps/libkdegames/libkdegames-15.12.49.9999.ebuild
@@ -38,12 +38,12 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtsvg:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtxml)
 	media-libs/libsndfile
 	media-libs/openal
 "

--- a/kde-apps/libkdegames/libkdegames-9999.ebuild
+++ b/kde-apps/libkdegames/libkdegames-9999.ebuild
@@ -38,12 +38,12 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtsvg:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtxml)
 	media-libs/libsndfile
 	media-libs/openal
 "

--- a/kde-apps/libkdepim/libkdepim-15.12.1.ebuild
+++ b/kde-apps/libkdepim/libkdepim-15.12.1.ebuild
@@ -27,14 +27,14 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/libkdepim/libkdepim-15.12.49.9999.ebuild
+++ b/kde-apps/libkdepim/libkdepim-15.12.49.9999.ebuild
@@ -27,14 +27,14 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/libkdepim/libkdepim-9999.ebuild
+++ b/kde-apps/libkdepim/libkdepim-9999.ebuild
@@ -26,14 +26,14 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kcontacts)
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmime)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/libkdepimdbusinterfaces/libkdepimdbusinterfaces-15.12.1.ebuild
+++ b/kde-apps/libkdepimdbusinterfaces/libkdepimdbusinterfaces-15.12.1.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_kdeapps_dep akonadi-contact)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkdepimdbusinterfaces/libkdepimdbusinterfaces-15.12.49.9999.ebuild
+++ b/kde-apps/libkdepimdbusinterfaces/libkdepimdbusinterfaces-15.12.49.9999.ebuild
@@ -20,9 +20,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_kdeapps_dep akonadi-contact)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkeduvocdocument/libkeduvocdocument-15.08.3.ebuild
+++ b/kde-apps/libkeduvocdocument/libkeduvocdocument-15.08.3.ebuild
@@ -16,6 +16,6 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkeduvocdocument/libkeduvocdocument-15.12.1.ebuild
+++ b/kde-apps/libkeduvocdocument/libkeduvocdocument-15.12.1.ebuild
@@ -16,6 +16,6 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkeduvocdocument/libkeduvocdocument-15.12.49.9999.ebuild
+++ b/kde-apps/libkeduvocdocument/libkeduvocdocument-15.12.49.9999.ebuild
@@ -16,6 +16,6 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkeduvocdocument/libkeduvocdocument-9999.ebuild
+++ b/kde-apps/libkeduvocdocument/libkeduvocdocument-9999.ebuild
@@ -16,6 +16,6 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkexiv2/libkexiv2-15.12.1.ebuild
+++ b/kde-apps/libkexiv2/libkexiv2-15.12.1.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE="+xmp"
 
 DEPEND="
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	>=media-gfx/exiv2-0.25:=[xmp=]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkexiv2/libkexiv2-15.12.49.9999.ebuild
+++ b/kde-apps/libkexiv2/libkexiv2-15.12.49.9999.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 IUSE="+xmp"
 
 DEPEND="
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	>=media-gfx/exiv2-0.25:=[xmp=]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkexiv2/libkexiv2-9999.ebuild
+++ b/kde-apps/libkexiv2/libkexiv2-9999.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 IUSE="+xmp"
 
 DEPEND="
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	>=media-gfx/exiv2-0.25:=[xmp=]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkface/libkface-15.12.1.ebuild
+++ b/kde-apps/libkface/libkface-15.12.1.ebuild
@@ -15,10 +15,10 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE=""
 
 DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/opencv-3[contrib]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkface/libkface-15.12.49.9999.ebuild
+++ b/kde-apps/libkface/libkface-15.12.49.9999.ebuild
@@ -15,10 +15,10 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/opencv-3[contrib]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkface/libkface-9999.ebuild
+++ b/kde-apps/libkface/libkface-9999.ebuild
@@ -15,10 +15,10 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=media-libs/opencv-3[contrib]
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkgeomap/libkgeomap-15.12.1.ebuild
+++ b/kde-apps/libkgeomap/libkgeomap-15.12.1.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep ktextwidgets)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	kde-apps/libkexiv2:5=
 	kde-apps/marble:5=[kde]
 "

--- a/kde-apps/libkgeomap/libkgeomap-15.12.49.9999.ebuild
+++ b/kde-apps/libkgeomap/libkgeomap-15.12.49.9999.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep ktextwidgets)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	kde-apps/libkexiv2:5=
 	kde-apps/marble:5=[kde]
 "

--- a/kde-apps/libkgeomap/libkgeomap-9999.ebuild
+++ b/kde-apps/libkgeomap/libkgeomap-9999.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep ktextwidgets)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	kde-apps/libkexiv2:5=
 	kde-apps/marble:5=[kde]
 "

--- a/kde-apps/libkipi/libkipi-15.12.1.ebuild
+++ b/kde-apps/libkipi/libkipi-15.12.1.ebuild
@@ -17,9 +17,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}

--- a/kde-apps/libkipi/libkipi-15.12.49.9999.ebuild
+++ b/kde-apps/libkipi/libkipi-15.12.49.9999.ebuild
@@ -17,9 +17,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}

--- a/kde-apps/libkipi/libkipi-9999.ebuild
+++ b/kde-apps/libkipi/libkipi-9999.ebuild
@@ -17,9 +17,9 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 
 RDEPEND="${DEPEND}

--- a/kde-apps/libkleo/libkleo-15.12.1.ebuild
+++ b/kde-apps/libkleo/libkleo-15.12.1.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep gpgmepp)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkleo/libkleo-15.12.49.9999.ebuild
+++ b/kde-apps/libkleo/libkleo-15.12.49.9999.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep gpgmepp)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkleo/libkleo-9999.ebuild
+++ b/kde-apps/libkleo/libkleo-9999.ebuild
@@ -24,10 +24,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep gpgmepp)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libkmahjongg/libkmahjongg-15.12.1.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-15.12.1.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkmahjongg/libkmahjongg-15.12.49.9999.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-15.12.49.9999.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkmahjongg/libkmahjongg-9999.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-9999.ebuild
@@ -19,9 +19,9 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkomparediff2/libkomparediff2-15.12.1.ebuild
+++ b/kde-apps/libkomparediff2/libkomparediff2-15.12.1.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkomparediff2/libkomparediff2-15.12.49.9999.ebuild
+++ b/kde-apps/libkomparediff2/libkomparediff2-15.12.49.9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkomparediff2/libkomparediff2-9999.ebuild
+++ b/kde-apps/libkomparediff2/libkomparediff2-9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libkonq/libkonq-5.9999.ebuild
+++ b/kde-apps/libkonq/libkonq-5.9999.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sys-libs/zlib
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libksane/libksane-15.12.1.ebuild
+++ b/kde-apps/libksane/libksane-15.12.1.ebuild
@@ -18,8 +18,8 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-gfx/sane-backends
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libksane/libksane-15.12.49.9999.ebuild
+++ b/kde-apps/libksane/libksane-15.12.49.9999.ebuild
@@ -18,8 +18,8 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-gfx/sane-backends
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libksane/libksane-9999.ebuild
+++ b/kde-apps/libksane/libksane-9999.ebuild
@@ -17,8 +17,8 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-gfx/sane-backends
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/libksieve/libksieve-15.12.1.ebuild
+++ b/kde-apps/libksieve/libksieve-15.12.1.ebuild
@@ -25,11 +25,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libksieve/libksieve-15.12.49.9999.ebuild
+++ b/kde-apps/libksieve/libksieve-15.12.49.9999.ebuild
@@ -25,11 +25,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libksieve/libksieve-9999.ebuild
+++ b/kde-apps/libksieve/libksieve-9999.ebuild
@@ -24,11 +24,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libkdepim)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libsendlater/libsendlater-15.12.1.ebuild
+++ b/kde-apps/libsendlater/libsendlater-15.12.1.ebuild
@@ -18,10 +18,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/libsendlater/libsendlater-15.12.49.9999.ebuild
+++ b/kde-apps/libsendlater/libsendlater-15.12.49.9999.ebuild
@@ -18,10 +18,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_kdeapps_dep libakonadi)
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/lokalize/lokalize-15.12.1.ebuild
+++ b/kde-apps/lokalize/lokalize-15.12.1.ebuild
@@ -6,7 +6,6 @@ EAPI=5
 
 KDE_HANDBOOK="forceoptional"
 PYTHON_COMPAT=( python2_7 )
-QT_MINIMAL="5.5"
 inherit python-single-r1 kde5
 
 DESCRIPTION="KDE Applications 5 translation tool"
@@ -34,13 +33,13 @@ DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql 'sqlite')
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=app-text/hunspell-1.2.8
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5[sqlite]
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
 "
 RDEPEND="${DEPEND}
 	dev-python/translate-toolkit[${PYTHON_USEDEP}]

--- a/kde-apps/lokalize/lokalize-15.12.49.9999.ebuild
+++ b/kde-apps/lokalize/lokalize-15.12.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=5
 
 KDE_HANDBOOK="forceoptional"
 PYTHON_COMPAT=( python2_7 )
-QT_MINIMAL="5.5"
 inherit python-single-r1 kde5
 
 DESCRIPTION="KDE Applications 5 translation tool"
@@ -34,13 +33,13 @@ DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql 'sqlite')
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=app-text/hunspell-1.2.8
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5[sqlite]
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
 "
 RDEPEND="${DEPEND}
 	dev-python/translate-toolkit[${PYTHON_USEDEP}]

--- a/kde-apps/lokalize/lokalize-9999.ebuild
+++ b/kde-apps/lokalize/lokalize-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=5
 
 KDE_HANDBOOK="forceoptional"
 PYTHON_COMPAT=( python2_7 )
-QT_MINIMAL="5.5"
 inherit python-single-r1 kde5
 
 DESCRIPTION="KDE Applications 5 translation tool"
@@ -34,13 +33,13 @@ DEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql 'sqlite')
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	>=app-text/hunspell-1.2.8
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5[sqlite]
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
 "
 RDEPEND="${DEPEND}
 	dev-python/translate-toolkit[${PYTHON_USEDEP}]

--- a/kde-apps/lskat/lskat-5.9999.ebuild
+++ b/kde-apps/lskat/lskat-5.9999.ebuild
@@ -25,9 +25,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/mailcommon/mailcommon-15.12.1.ebuild
+++ b/kde-apps/mailcommon/mailcommon-15.12.1.ebuild
@@ -37,13 +37,13 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep pimcommon)
 	$(add_kdeapps_dep templateparser)
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/mailcommon/mailcommon-15.12.49.9999.ebuild
+++ b/kde-apps/mailcommon/mailcommon-15.12.49.9999.ebuild
@@ -37,13 +37,13 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep pimcommon)
 	$(add_kdeapps_dep templateparser)
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/mailcommon/mailcommon-9999.ebuild
+++ b/kde-apps/mailcommon/mailcommon-9999.ebuild
@@ -33,13 +33,13 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep messagelib)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/mailimporter/mailimporter-15.12.1.ebuild
+++ b/kde-apps/mailimporter/mailimporter-15.12.1.ebuild
@@ -23,10 +23,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/mailimporter/mailimporter-15.12.49.9999.ebuild
+++ b/kde-apps/mailimporter/mailimporter-15.12.49.9999.ebuild
@@ -23,10 +23,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/mailimporter/mailimporter-9999.ebuild
+++ b/kde-apps/mailimporter/mailimporter-9999.ebuild
@@ -22,10 +22,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep akonadi-mime)
 	$(add_kdeapps_dep kmime)
 	$(add_kdeapps_dep libkdepim)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/marble/marble-15.08.3.ebuild
+++ b/kde-apps/marble/marble-15.08.3.ebuild
@@ -18,19 +18,19 @@ IUSE="aprs designer-plugin gps +kde phonon shapefile zip"
 # libwlocate, WLAN-based geolocation
 # qextserialport, interface to old fashioned serial ports
 RDEPEND="
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	gps? ( >=sci-geosciences/gpsd-2.95 )
 	kde? (
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/marble/marble-15.12.1.ebuild
+++ b/kde-apps/marble/marble-15.12.1.ebuild
@@ -18,19 +18,19 @@ IUSE="aprs designer-plugin gps +kde phonon shapefile zip"
 # libwlocate, WLAN-based geolocation
 # qextserialport, interface to old fashioned serial ports
 RDEPEND="
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	gps? ( >=sci-geosciences/gpsd-2.95 )
 	kde? (
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/marble/marble-15.12.49.9999.ebuild
+++ b/kde-apps/marble/marble-15.12.49.9999.ebuild
@@ -18,19 +18,19 @@ IUSE="aprs designer-plugin gps +kde phonon shapefile zip"
 # libwlocate, WLAN-based geolocation
 # qextserialport, interface to old fashioned serial ports
 RDEPEND="
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	gps? ( >=sci-geosciences/gpsd-2.95 )
 	kde? (
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/marble/marble-9999.ebuild
+++ b/kde-apps/marble/marble-9999.ebuild
@@ -18,19 +18,19 @@ IUSE="aprs designer-plugin gps +kde phonon shapefile zip"
 # libwlocate, WLAN-based geolocation
 # qextserialport, interface to old fashioned serial ports
 RDEPEND="
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	gps? ( >=sci-geosciences/gpsd-2.95 )
 	kde? (
 		$(add_frameworks_dep kconfig)

--- a/kde-apps/messagecomposer/messagecomposer-15.12.1.ebuild
+++ b/kde-apps/messagecomposer/messagecomposer-15.12.1.ebuild
@@ -32,10 +32,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep pimcommon)
 	$(add_kdeapps_dep templateparser)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagecomposer/messagecomposer-15.12.49.9999.ebuild
+++ b/kde-apps/messagecomposer/messagecomposer-15.12.49.9999.ebuild
@@ -32,10 +32,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep pimcommon)
 	$(add_kdeapps_dep templateparser)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagecore/messagecore-15.12.1.ebuild
+++ b/kde-apps/messagecore/messagecore-15.12.1.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkleo)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagecore/messagecore-15.12.49.9999.ebuild
+++ b/kde-apps/messagecore/messagecore-15.12.49.9999.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkleo)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagelib/messagelib-9999.ebuild
+++ b/kde-apps/messagelib/messagelib-9999.ebuild
@@ -56,12 +56,12 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libkleo)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagelist/messagelist-15.12.1.ebuild
+++ b/kde-apps/messagelist/messagelist-15.12.1.ebuild
@@ -30,9 +30,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messagelist/messagelist-15.12.49.9999.ebuild
+++ b/kde-apps/messagelist/messagelist-15.12.49.9999.ebuild
@@ -30,9 +30,9 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messageviewer/messageviewer-15.12.1.ebuild
+++ b/kde-apps/messageviewer/messageviewer-15.12.1.ebuild
@@ -52,12 +52,12 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/messageviewer/messageviewer-15.12.49.9999.ebuild
+++ b/kde-apps/messageviewer/messageviewer-15.12.49.9999.ebuild
@@ -52,12 +52,12 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/grantlee:5
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/noteshared/noteshared-15.12.1.ebuild
+++ b/kde-apps/noteshared/noteshared-15.12.1.ebuild
@@ -32,11 +32,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libxslt
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/noteshared/noteshared-15.12.49.9999.ebuild
+++ b/kde-apps/noteshared/noteshared-15.12.49.9999.ebuild
@@ -32,11 +32,11 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep pimcommon)
 	dev-libs/libxslt
-	dev-qt/designer:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/okteta/okteta-15.12.1.ebuild
+++ b/kde-apps/okteta/okteta-15.12.1.ebuild
@@ -29,12 +29,12 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtnetwork:5
-	dev-qt/designer:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtscript:5[scripttools]
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep designer)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtscript 'scripttools')
 	crypt? ( app-crypt/qca:2[qt5] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/okteta/okteta-15.12.49.9999.ebuild
+++ b/kde-apps/okteta/okteta-15.12.49.9999.ebuild
@@ -29,12 +29,12 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtnetwork:5
-	dev-qt/designer:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtscript:5[scripttools]
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep designer)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtscript 'scripttools')
 	crypt? ( app-crypt/qca:2[qt5] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/okteta/okteta-9999.ebuild
+++ b/kde-apps/okteta/okteta-9999.ebuild
@@ -29,12 +29,12 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtnetwork:5
-	dev-qt/designer:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtscript:5[scripttools]
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep designer)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtscript 'scripttools')
 	crypt? ( app-crypt/qca:2[qt5] )
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/okular/okular-5.9999.ebuild
+++ b/kde-apps/okular/okular-5.9999.ebuild
@@ -32,11 +32,11 @@ DEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep threadweaver)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	media-libs/freetype
 	media-libs/phonon[qt5]
 	sys-devel/gettext

--- a/kde-apps/palapeli/palapeli-5.9999.ebuild
+++ b/kde-apps/palapeli/palapeli-5.9999.ebuild
@@ -28,9 +28,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/parley/parley-15.08.3.ebuild
+++ b/kde-apps/parley/parley-15.08.3.ebuild
@@ -35,12 +35,12 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtmultimedia)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)

--- a/kde-apps/parley/parley-15.12.1.ebuild
+++ b/kde-apps/parley/parley-15.12.1.ebuild
@@ -35,12 +35,12 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtmultimedia)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)

--- a/kde-apps/parley/parley-15.12.49.9999.ebuild
+++ b/kde-apps/parley/parley-15.12.49.9999.ebuild
@@ -35,12 +35,12 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtmultimedia)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)

--- a/kde-apps/parley/parley-9999.ebuild
+++ b/kde-apps/parley/parley-9999.ebuild
@@ -35,12 +35,12 @@ DEPEND="
 	$(add_frameworks_dep sonnet)
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtmultimedia)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_kdeapps_dep kdeedu-data)

--- a/kde-apps/picmi/picmi-15.12.1.ebuild
+++ b/kde-apps/picmi/picmi-15.12.1.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/picmi/picmi-15.12.49.9999.ebuild
+++ b/kde-apps/picmi/picmi-15.12.49.9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/picmi/picmi-9999.ebuild
+++ b/kde-apps/picmi/picmi-9999.ebuild
@@ -25,10 +25,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libkdegames)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/pimcommon/pimcommon-15.12.1.ebuild
+++ b/kde-apps/pimcommon/pimcommon-15.12.1.ebuild
@@ -45,16 +45,16 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/pimcommon/pimcommon-15.12.49.9999.ebuild
+++ b/kde-apps/pimcommon/pimcommon-15.12.49.9999.ebuild
@@ -45,16 +45,16 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep libakonadi)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/pimcommon/pimcommon-9999.ebuild
+++ b/kde-apps/pimcommon/pimcommon-9999.ebuild
@@ -44,16 +44,16 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kpimtextedit)
 	$(add_kdeapps_dep libkdepim)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext
-	designer? ( dev-qt/designer:5 )
+	designer? ( $(add_qt_dep designer) )
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5

--- a/kde-apps/poxml/poxml-15.12.1.ebuild
+++ b/kde-apps/poxml/poxml-15.12.1.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE=""
 
 DEPEND="
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/poxml/poxml-15.12.49.9999.ebuild
+++ b/kde-apps/poxml/poxml-15.12.49.9999.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/poxml/poxml-9999.ebuild
+++ b/kde-apps/poxml/poxml-9999.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	sys-devel/gettext
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/print-manager/print-manager-15.12.1.ebuild
+++ b/kde-apps/print-manager/print-manager-15.12.1.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-print/cups
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/print-manager/print-manager-15.12.49.9999.ebuild
+++ b/kde-apps/print-manager/print-manager-15.12.49.9999.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-print/cups
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/print-manager/print-manager-9999.ebuild
+++ b/kde-apps/print-manager/print-manager-9999.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	net-print/cups
 "
 RDEPEND="${DEPEND}

--- a/kde-apps/pykde5/pykde5-9999.ebuild
+++ b/kde-apps/pykde5/pykde5-9999.ebuild
@@ -28,9 +28,9 @@ RDEPEND="${PYTHON_DEPS}
 	$(add_frameworks_dep sonnet)
 	dev-python/PyQt5[${PYTHON_USEDEP},gui,widgets]
 	>=dev-python/sip-4.16.2:=[${PYTHON_USEDEP}]
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 
 DEPEND="${RDEPEND}

--- a/kde-apps/rocs/rocs-15.08.3.ebuild
+++ b/kde-apps/rocs/rocs-15.08.3.ebuild
@@ -28,15 +28,15 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5[scripttools]
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript 'scripttools')
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49

--- a/kde-apps/rocs/rocs-15.12.1.ebuild
+++ b/kde-apps/rocs/rocs-15.12.1.ebuild
@@ -29,15 +29,15 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5[scripttools]
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript 'scripttools')
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49

--- a/kde-apps/rocs/rocs-15.12.49.9999.ebuild
+++ b/kde-apps/rocs/rocs-15.12.49.9999.ebuild
@@ -29,15 +29,15 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5[scripttools]
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript 'scripttools')
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49

--- a/kde-apps/rocs/rocs-9999.ebuild
+++ b/kde-apps/rocs/rocs-9999.ebuild
@@ -29,15 +29,15 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/grantlee:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5[scripttools]
-	dev-qt/qtsvg:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript 'scripttools')
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	$(add_qt_dep qtxmlpatterns)
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49

--- a/kde-apps/spectacle/spectacle-15.12.1.ebuild
+++ b/kde-apps/spectacle/spectacle-15.12.1.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep libkscreen)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	x11-libs/xcb-util
 	x11-libs/xcb-util-cursor

--- a/kde-apps/spectacle/spectacle-15.12.49.9999.ebuild
+++ b/kde-apps/spectacle/spectacle-15.12.49.9999.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep libkscreen)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	x11-libs/xcb-util
 	x11-libs/xcb-util-cursor

--- a/kde-apps/spectacle/spectacle-9999.ebuild
+++ b/kde-apps/spectacle/spectacle-9999.ebuild
@@ -24,11 +24,11 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep libkscreen)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	x11-libs/xcb-util
 	x11-libs/xcb-util-cursor

--- a/kde-apps/step/step-15.08.3.ebuild
+++ b/kde-apps/step/step-15.08.3.ebuild
@@ -31,13 +31,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	=dev-cpp/eigen-3.2*:3
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )

--- a/kde-apps/step/step-15.12.1.ebuild
+++ b/kde-apps/step/step-15.12.1.ebuild
@@ -31,13 +31,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	=dev-cpp/eigen-3.2*:3
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )

--- a/kde-apps/step/step-15.12.49.9999.ebuild
+++ b/kde-apps/step/step-15.12.49.9999.ebuild
@@ -31,13 +31,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	=dev-cpp/eigen-3.2*:3
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )

--- a/kde-apps/step/step-9999.ebuild
+++ b/kde-apps/step/step-9999.ebuild
@@ -31,13 +31,13 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	=dev-cpp/eigen-3.2*:3
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtopengl)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )

--- a/kde-apps/svgpart/svgpart-5.9999.ebuild
+++ b/kde-apps/svgpart/svgpart-5.9999.ebuild
@@ -15,9 +15,9 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-apps/syndication/syndication-15.12.1.ebuild
+++ b/kde-apps/syndication/syndication-15.12.1.ebuild
@@ -17,6 +17,6 @@ RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/syndication/syndication-15.12.49.9999.ebuild
+++ b/kde-apps/syndication/syndication-15.12.49.9999.ebuild
@@ -17,6 +17,6 @@ RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/syndication/syndication-9999.ebuild
+++ b/kde-apps/syndication/syndication-9999.ebuild
@@ -17,6 +17,6 @@ RDEPEND="
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-apps/templateparser/templateparser-15.12.1.ebuild
+++ b/kde-apps/templateparser/templateparser-15.12.1.ebuild
@@ -33,10 +33,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep messageviewer)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/templateparser/templateparser-15.12.49.9999.ebuild
+++ b/kde-apps/templateparser/templateparser-15.12.49.9999.ebuild
@@ -33,10 +33,10 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep messagecore)
 	$(add_kdeapps_dep messageviewer)
 	$(add_kdeapps_dep pimcommon)
-	dev-qt/designer:5
-	dev-qt/qtgui:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-apps/thumbnailers/thumbnailers-15.12.1.ebuild
+++ b/kde-apps/thumbnailers/thumbnailers-15.12.1.ebuild
@@ -15,6 +15,6 @@ DEPEND="
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/thumbnailers/thumbnailers-15.12.49.9999.ebuild
+++ b/kde-apps/thumbnailers/thumbnailers-15.12.49.9999.ebuild
@@ -15,6 +15,6 @@ DEPEND="
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/thumbnailers/thumbnailers-9999.ebuild
+++ b/kde-apps/thumbnailers/thumbnailers-9999.ebuild
@@ -15,6 +15,6 @@ DEPEND="
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/umbrello/umbrello-15.12.1.ebuild
+++ b/kde-apps/umbrello/umbrello-15.12.1.ebuild
@@ -33,11 +33,11 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/libxml2
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/umbrello/umbrello-15.12.49.9999.ebuild
+++ b/kde-apps/umbrello/umbrello-15.12.49.9999.ebuild
@@ -33,11 +33,11 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/libxml2
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/umbrello/umbrello-9999.ebuild
+++ b/kde-apps/umbrello/umbrello-9999.ebuild
@@ -33,11 +33,11 @@ RDEPEND="
 	$(add_frameworks_dep kxmlgui)
 	dev-libs/libxml2
 	dev-libs/libxslt
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-apps/zeroconf-ioslave/zeroconf-ioslave-5.9999.ebuild
+++ b/kde-apps/zeroconf-ioslave/zeroconf-ioslave-5.9999.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	$(add_frameworks_dep kdnssd)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtdbus:5
+	$(add_qt_dep qtdbus)
 "
 
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/attica/attica-9999.ebuild
+++ b/kde-frameworks/attica/attica-9999.ebuild
@@ -12,6 +12,6 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/baloo/baloo-9999.ebuild
+++ b/kde-frameworks/baloo/baloo-9999.ebuild
@@ -22,10 +22,10 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep solid)
 	>=dev-db/lmdb-0.9.17
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/baloo:4[-minimal(-)]

--- a/kde-frameworks/bluez-qt/bluez-qt-9999.ebuild
+++ b/kde-frameworks/bluez-qt/bluez-qt-9999.ebuild
@@ -12,9 +12,9 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtnetwork)
 "
 RDEPEND="${DEPEND}
 	!kde-plasma/bluez-qt

--- a/kde-frameworks/extra-cmake-modules/extra-cmake-modules-9999.ebuild
+++ b/kde-frameworks/extra-cmake-modules/extra-cmake-modules-9999.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	)
 "
 RDEPEND="
-	dev-qt/qtcore:5
+	$(add_qt_dep qtcore)
 "
 
 python_check_deps() {

--- a/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
+++ b/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
@@ -25,12 +25,12 @@ RDEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
+	$(add_qt_dep qtdbus)
 	dev-qt/qtgui:5=
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtwidgets)
 	media-fonts/noto
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 		x11-libs/libXcursor
 	)

--- a/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
+++ b/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_qt_dep qtdbus)
-	dev-qt/qtgui:5=
+	$(add_qt_dep qtgui '' '' '5=')
 	$(add_qt_dep qtwidgets)
 	media-fonts/noto
 	X? (

--- a/kde-frameworks/kactivities/kactivities-9999.ebuild
+++ b/kde-frameworks/kactivities/kactivities-9999.ebuild
@@ -25,11 +25,11 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
 	!<kde-base/kactivities-4.13.3-r1:4[-minimal(-)]
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kauth/kauth-9999.ebuild
+++ b/kde-frameworks/kauth/kauth-9999.ebuild
@@ -14,13 +14,13 @@ IUSE="nls +policykit"
 
 RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	policykit? ( || ( $(add_frameworks_dep polkit-qt) sys-auth/polkit-qt[qt5] ) )
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 PDEPEND="policykit? ( kde-plasma/polkit-kde-agent )"
 

--- a/kde-frameworks/kbookmarks/kbookmarks-9999.ebuild
+++ b/kde-frameworks/kbookmarks/kbookmarks-9999.ebuild
@@ -19,12 +19,12 @@ RDEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
 	$(add_frameworks_dep kconfigwidgets)
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "

--- a/kde-frameworks/kcmutils/kcmutils-9999.ebuild
+++ b/kde-frameworks/kcmutils/kcmutils-9999.ebuild
@@ -24,9 +24,9 @@ RDEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kcodecs/kcodecs-9999.ebuild
+++ b/kde-frameworks/kcodecs/kcodecs-9999.ebuild
@@ -11,4 +11,4 @@ LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS=""
 IUSE="nls"
 
-DEPEND="nls? ( dev-qt/linguist-tools:5 )"
+DEPEND="nls? ( $(add_qt_dep linguist-tools) )"

--- a/kde-frameworks/kcompletion/kcompletion-9999.ebuild
+++ b/kde-frameworks/kcompletion/kcompletion-9999.ebuild
@@ -14,9 +14,9 @@ IUSE="nls"
 RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "

--- a/kde-frameworks/kconfig/kconfig-9999.ebuild
+++ b/kde-frameworks/kconfig/kconfig-9999.ebuild
@@ -13,12 +13,12 @@ KEYWORDS=""
 IUSE="nls"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
-	test? ( dev-qt/qtconcurrent:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
+	test? ( $(add_qt_dep qtconcurrent) )
 "
 
 # bug 560086

--- a/kde-frameworks/kconfigwidgets/kconfigwidgets-9999.ebuild
+++ b/kde-frameworks/kconfigwidgets/kconfigwidgets-9999.ebuild
@@ -20,9 +20,9 @@ RDEPEND="
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	!<kde-frameworks/kdelibs4support-5.3.0:5
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kcoreaddons/kcoreaddons-9999.ebuild
+++ b/kde-frameworks/kcoreaddons/kcoreaddons-9999.ebuild
@@ -12,13 +12,13 @@ KEYWORDS=""
 IUSE="fam nls"
 
 RDEPEND="
-	dev-qt/qtcore:5[icu]
+	$(add_qt_dep qtcore 'icu')
 	fam? ( virtual/fam )
 	!<kde-frameworks/kservice-5.2.0:5
 "
 DEPEND="${RDEPEND}
 	x11-misc/shared-mime-info
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 
 src_configure() {

--- a/kde-frameworks/kcrash/kcrash-9999.ebuild
+++ b/kde-frameworks/kcrash/kcrash-9999.ebuild
@@ -18,15 +18,15 @@ RESTRICT="test"
 RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
-	test? ( dev-qt/qtwidgets:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
+	test? ( $(add_qt_dep qtwidgets) )
 	X? ( x11-proto/xproto )
 "
 

--- a/kde-frameworks/kdbusaddons/kdbusaddons-9999.ebuild
+++ b/kde-frameworks/kdbusaddons/kdbusaddons-9999.ebuild
@@ -13,11 +13,11 @@ KEYWORDS=""
 IUSE="nls X"
 
 RDEPEND="
-	dev-qt/qtdbus:5
-	X? ( dev-qt/qtx11extras:5 )
+	$(add_qt_dep qtdbus)
+	X? ( $(add_qt_dep qtx11extras) )
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 
 src_configure() {

--- a/kde-frameworks/kdeclarative/kdeclarative-9999.ebuild
+++ b/kde-frameworks/kdeclarative/kdeclarative-9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	media-libs/libepoxy
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kded/kded-9999.ebuild
+++ b/kde-frameworks/kded/kded-9999.ebuild
@@ -19,9 +19,9 @@ RDEPEND="
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kinit)
 	$(add_frameworks_dep kservice)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	man? ( $(add_frameworks_dep kdoctools) )

--- a/kde-frameworks/kdelibs4support/kdelibs4support-9999.ebuild
+++ b/kde-frameworks/kdelibs4support/kdelibs4support-9999.ebuild
@@ -41,16 +41,16 @@ COMMON_DEPEND="
 	$(add_frameworks_dep solid)
 	app-text/docbook-xml-dtd:4.2
 	dev-libs/openssl:0
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5[ssl]
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qttest:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork 'ssl')
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qttest)
+	$(add_qt_dep qtwidgets)
 	virtual/libintl
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libICE
 		x11-libs/libSM
 		x11-libs/libX11
@@ -61,15 +61,15 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kemoticons)
 	$(add_frameworks_dep kinit)
 	$(add_frameworks_dep kitemmodels)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	!<kde-apps/kcontrol-15.08.0[handbook]
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kdoctools)
 	dev-lang/perl
 	dev-perl/URI
-	dev-qt/designer:5
-	test? ( dev-qt/qtconcurrent:5 )
+	$(add_qt_dep designer)
+	test? ( $(add_qt_dep qtconcurrent) )
 	X? ( x11-proto/xproto )
 "
 

--- a/kde-frameworks/kdesignerplugin/kdesignerplugin-9999.ebuild
+++ b/kde-frameworks/kdesignerplugin/kdesignerplugin-9999.ebuild
@@ -16,7 +16,7 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	designer? (
-		dev-qt/designer:5
+		$(add_qt_dep designer)
 		$(add_frameworks_dep kcompletion)
 		$(add_frameworks_dep kconfigwidgets)
 		$(add_frameworks_dep kiconthemes)
@@ -29,14 +29,14 @@ RDEPEND="
 		$(add_frameworks_dep sonnet)
 	)
 	webkit? (
-		dev-qt/designer:5
-		dev-qt/qtgui:5
+		$(add_qt_dep designer)
+		$(add_qt_dep qtgui)
 		$(add_frameworks_dep kdewebkit)
 	)
 "
 DEPEND="${RDEPEND}
 	$(add_frameworks_dep kdoctools)
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 
 src_configure() {

--- a/kde-frameworks/kdewebkit/kdewebkit-9999.ebuild
+++ b/kde-frameworks/kdewebkit/kdewebkit-9999.ebuild
@@ -20,11 +20,11 @@ RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwallet)
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 "

--- a/kde-frameworks/kdnssd/kdnssd-9999.ebuild
+++ b/kde-frameworks/kdnssd/kdnssd-9999.ebuild
@@ -12,14 +12,14 @@ KEYWORDS=""
 IUSE="nls zeroconf"
 
 RDEPEND="
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtnetwork)
 	zeroconf? (
-		dev-qt/qtdbus:5
+		$(add_qt_dep qtdbus)
 		net-dns/avahi[mdnsresponder-compat]
 	)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 
 src_configure() {

--- a/kde-frameworks/kemoticons/kemoticons-9999.ebuild
+++ b/kde-frameworks/kemoticons/kemoticons-9999.ebuild
@@ -17,8 +17,8 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kservice)
-	dev-qt/qtgui:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
@@ -14,7 +14,7 @@ IUSE="epub exif ffmpeg libav pdf taglib"
 DEPEND="
 	$(add_frameworks_dep karchive)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	epub? ( app-text/ebook-tools )
 	exif? ( media-gfx/exiv2:= )
 	ffmpeg? (

--- a/kde-frameworks/kglobalaccel/kglobalaccel-9999.ebuild
+++ b/kde-frameworks/kglobalaccel/kglobalaccel-9999.ebuild
@@ -18,14 +18,14 @@ RDEPEND="
 	$(add_frameworks_dep kcrash)
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kwindowsystem X)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	x11-libs/xcb-util-keysyms
 	!<kde-plasma/plasma-workspace-5.2.0-r2
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "

--- a/kde-frameworks/kguiaddons/kguiaddons-9999.ebuild
+++ b/kde-frameworks/kguiaddons/kguiaddons-9999.ebuild
@@ -13,8 +13,8 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/khtml/khtml-9999.ebuild
+++ b/kde-frameworks/khtml/khtml-9999.ebuild
@@ -34,26 +34,26 @@ RDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5[ssl]
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork 'ssl')
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	media-libs/giflib:=
 	media-libs/libpng:0=
 	media-libs/phonon[qt5]
 	sys-libs/zlib
 	virtual/jpeg:0
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "
 DEPEND="${RDEPEND}
 	dev-lang/perl
 	dev-libs/openssl:0
-	test? ( dev-qt/qtx11extras:5 )
+	test? ( $(add_qt_dep qtx11extras) )
 	X? ( x11-proto/xproto )
 "
 

--- a/kde-frameworks/ki18n/ki18n-9999.ebuild
+++ b/kde-frameworks/ki18n/ki18n-9999.ebuild
@@ -12,10 +12,10 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtscript:5
+	$(add_qt_dep qtscript)
 	sys-devel/gettext
 	virtual/libintl
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtconcurrent:5 )
+	test? ( $(add_qt_dep qtconcurrent) )
 "

--- a/kde-frameworks/kiconthemes/kiconthemes-9999.ebuild
+++ b/kde-frameworks/kiconthemes/kiconthemes-9999.ebuild
@@ -19,9 +19,9 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kidletime/kidletime-9999.ebuild
+++ b/kde-frameworks/kidletime/kidletime-9999.ebuild
@@ -13,10 +13,10 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 	x11-libs/libXScrnSaver
 	x11-libs/libXext

--- a/kde-frameworks/kimageformats/kimageformats-9999.ebuild
+++ b/kde-frameworks/kimageformats/kimageformats-9999.ebuild
@@ -13,8 +13,8 @@ KEYWORDS=""
 IUSE="eps openexr"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	eps? ( dev-qt/qtprintsupport:5 )
+	$(add_qt_dep qtgui)
+	eps? ( $(add_qt_dep qtprintsupport) )
 	openexr? (
 		media-libs/ilmbase:=
 		media-libs/openexr:=

--- a/kde-frameworks/kinit/kinit-9999.ebuild
+++ b/kde-frameworks/kinit/kinit-9999.ebuild
@@ -20,8 +20,8 @@ RDEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 	x11-libs/libX11
 	x11-libs/libxcb
 	caps? ( sys-libs/libcap )

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -33,12 +33,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5[ssl]
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork 'ssl')
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	dev-libs/libxml2
 	dev-libs/libxslt
 	acl? (
@@ -47,10 +47,10 @@ COMMON_DEPEND="
 	)
 	kerberos? ( virtual/krb5 )
 	kwallet? ( $(add_frameworks_dep kwallet) )
-	X? ( dev-qt/qtx11extras:5 )
+	X? ( $(add_qt_dep qtx11extras) )
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep qtconcurrent)
 	handbook? ( $(add_frameworks_dep kdoctools) )
 	test? ( sys-libs/zlib )
 	X? (

--- a/kde-frameworks/kitemmodels/kitemmodels-9999.ebuild
+++ b/kde-frameworks/kitemmodels/kitemmodels-9999.ebuild
@@ -12,4 +12,4 @@ LICENSE="LGPL-2+"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="test? ( dev-qt/qtwidgets:5 )"
+DEPEND="test? ( $(add_qt_dep qtwidgets) )"

--- a/kde-frameworks/kitemviews/kitemviews-9999.ebuild
+++ b/kde-frameworks/kitemviews/kitemviews-9999.ebuild
@@ -13,9 +13,9 @@ KEYWORDS=""
 IUSE="nls"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "

--- a/kde-frameworks/kjobwidgets/kjobwidgets-9999.ebuild
+++ b/kde-frameworks/kjobwidgets/kjobwidgets-9999.ebuild
@@ -14,13 +14,13 @@ IUSE="nls X"
 RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	X? ( dev-qt/qtx11extras:5 )
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	X? ( $(add_qt_dep qtx11extras) )
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 	X? (
 		x11-libs/libX11
 		x11-proto/xproto

--- a/kde-frameworks/kjsembed/kjsembed-9999.ebuild
+++ b/kde-frameworks/kjsembed/kjsembed-9999.ebuild
@@ -15,12 +15,12 @@ IUSE=""
 RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kjs)
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
 	$(add_frameworks_dep kdoctools)
-	dev-qt/designer:5
+	$(add_qt_dep designer)
 "

--- a/kde-frameworks/kmediaplayer/kmediaplayer-9999.ebuild
+++ b/kde-frameworks/kmediaplayer/kmediaplayer-9999.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/knewstuff/knewstuff-9999.ebuild
+++ b/kde-frameworks/knewstuff/knewstuff-9999.ebuild
@@ -26,8 +26,8 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/knotifications/knotifications-9999.ebuild
+++ b/kde-frameworks/knotifications/knotifications-9999.ebuild
@@ -17,20 +17,20 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/phonon[qt5]
 	dbus? ( dev-libs/libdbusmenu-qt[qt5] )
-	speech? ( dev-qt/qtspeech:5 )
+	speech? ( $(add_qt_dep qtspeech) )
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 		x11-libs/libXtst
 	)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 	X? ( x11-proto/xproto )
 "
 

--- a/kde-frameworks/knotifyconfig/knotifyconfig-9999.ebuild
+++ b/kde-frameworks/knotifyconfig/knotifyconfig-9999.ebuild
@@ -17,9 +17,9 @@ RDEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	phonon? ( media-libs/phonon[qt5] )
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kparts/kparts-9999.ebuild
+++ b/kde-frameworks/kparts/kparts-9999.ebuild
@@ -22,9 +22,9 @@ RDEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
 	$(add_frameworks_dep ktextwidgets)

--- a/kde-frameworks/kpeople/kpeople-9999.ebuild
+++ b/kde-frameworks/kpeople/kpeople-9999.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!net-libs/kpeople:5

--- a/kde-frameworks/kplotting/kplotting-9999.ebuild
+++ b/kde-frameworks/kplotting/kplotting-9999.ebuild
@@ -13,7 +13,7 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kross/kross-9999.ebuild
+++ b/kde-frameworks/kross/kross-9999.ebuild
@@ -21,12 +21,12 @@ RDEPEND="
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtgui:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
 	$(add_frameworks_dep kdoctools)
-	dev-qt/designer:5
+	$(add_qt_dep designer)
 "

--- a/kde-frameworks/krunner/krunner-9999.ebuild
+++ b/kde-frameworks/krunner/krunner-9999.ebuild
@@ -21,8 +21,8 @@ RDEPEND="
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
 	$(add_frameworks_dep threadweaver)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kservice/kservice-9999.ebuild
+++ b/kde-frameworks/kservice/kservice-9999.ebuild
@@ -17,12 +17,12 @@ RDEPEND="
 	$(add_frameworks_dep kcrash)
 	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtdbus:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}
 	man? ( $(add_frameworks_dep kdoctools) )
-	test? ( dev-qt/qtconcurrent:5 )
+	test? ( $(add_qt_dep qtconcurrent) )
 "
 
 # requires running kde environment

--- a/kde-frameworks/ktexteditor/ktexteditor-9999.ebuild
+++ b/kde-frameworks/ktexteditor/ktexteditor-9999.ebuild
@@ -30,15 +30,15 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	git? ( dev-libs/libgit2:= )
 "
 DEPEND="${RDEPEND}
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtxmlpatterns)
 	test? ( $(add_frameworks_dep kservice) )
 "
 

--- a/kde-frameworks/ktextwidgets/ktextwidgets-9999.ebuild
+++ b/kde-frameworks/ktextwidgets/ktextwidgets-9999.ebuild
@@ -23,9 +23,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	speech? ( dev-qt/qtspeech:5 )
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	speech? ( $(add_qt_dep qtspeech) )
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kunitconversion/kunitconversion-9999.ebuild
+++ b/kde-frameworks/kunitconversion/kunitconversion-9999.ebuild
@@ -13,7 +13,7 @@ IUSE=""
 
 RDEPEND="
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtnetwork:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtxml)
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kwallet/kwallet-9999.ebuild
+++ b/kde-frameworks/kwallet/kwallet-9999.ebuild
@@ -22,9 +22,9 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	dev-libs/libgcrypt:0=
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	gpg? (
 		$(add_kdeapps_dep gpgmepp)
 		app-crypt/gpgme

--- a/kde-frameworks/kwidgetsaddons/kwidgetsaddons-9999.ebuild
+++ b/kde-frameworks/kwidgetsaddons/kwidgetsaddons-9999.ebuild
@@ -13,10 +13,10 @@ KEYWORDS=""
 IUSE="nls"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
-	test? ( dev-qt/designer:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
+	test? ( $(add_qt_dep designer) )
 "

--- a/kde-frameworks/kwindowsystem/kwindowsystem-9999.ebuild
+++ b/kde-frameworks/kwindowsystem/kwindowsystem-9999.ebuild
@@ -13,10 +13,10 @@ KEYWORDS=""
 IUSE="nls X"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 		x11-libs/libXfixes
 		x11-libs/libxcb
@@ -24,7 +24,7 @@ RDEPEND="
 	)
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 	X? ( x11-proto/xproto )
 "
 

--- a/kde-frameworks/kxmlgui/kxmlgui-9999.ebuild
+++ b/kde-frameworks/kxmlgui/kxmlgui-9999.ebuild
@@ -23,12 +23,12 @@ RDEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5[ssl]
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork 'ssl')
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	attica? ( $(add_frameworks_dep attica) )
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kxmlrpcclient/kxmlrpcclient-9999.ebuild
+++ b/kde-frameworks/kxmlrpcclient/kxmlrpcclient-9999.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtxml:5
+	$(add_qt_dep qtxml)
 	!<kde-plasma/plasma-workspace-5.2.95
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/modemmanager-qt/modemmanager-qt-9999.ebuild
+++ b/kde-frameworks/modemmanager-qt/modemmanager-qt-9999.ebuild
@@ -12,8 +12,8 @@ KEYWORDS=""
 IUSE=""
 
 RDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtxml)
 	net-misc/modemmanager
 	!kde-plasma/libmm-qt
 "

--- a/kde-frameworks/networkmanager-qt/networkmanager-qt-9999.ebuild
+++ b/kde-frameworks/networkmanager-qt/networkmanager-qt-9999.ebuild
@@ -12,8 +12,8 @@ KEYWORDS=""
 IUSE="teamd"
 
 RDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtnetwork:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtnetwork)
 	|| (
 		>=net-misc/networkmanager-0.9.10.0[consolekit,teamd=]
 		>=net-misc/networkmanager-0.9.10.0[systemd,teamd=]

--- a/kde-frameworks/oxygen-icons/oxygen-icons-9999.ebuild
+++ b/kde-frameworks/oxygen-icons/oxygen-icons-9999.ebuild
@@ -18,6 +18,6 @@ IUSE=""
 
 DEPEND="
 	$(add_frameworks_dep extra-cmake-modules)
-	test? ( dev-qt/qttest:5 )
+	test? ( $(add_qt_dep qttest) )
 "
 RDEPEND="!kde-frameworks/oxygen-icons:4"

--- a/kde-frameworks/plasma/plasma-9999.ebuild
+++ b/kde-frameworks/plasma/plasma-9999.ebuild
@@ -30,26 +30,26 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=]
-	dev-qt/qtquickcontrols:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=')
+	$(add_qt_dep qtquickcontrols)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	egl? ( media-libs/mesa[egl] )
 	!gles2? ( virtual/opengl )
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 		x11-libs/libxcb
 	)
 "
 DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep kdoctools)
-	dev-qt/qtquick1:5
+	$(add_qt_dep qtquick1)
 	X? ( x11-proto/xproto )
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-frameworks/polkit-qt/polkit-qt-9999.ebuild
+++ b/kde-frameworks/polkit-qt/polkit-qt-9999.ebuild
@@ -16,12 +16,12 @@ IUSE="examples"
 
 DEPEND="
 	dev-libs/glib:2
-	dev-qt/qtcore:5
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtcore)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	>=sys-auth/polkit-0.103
-	examples? ( dev-qt/qtxml:5 )
+	examples? ( $(add_qt_dep qtxml) )
 "
 RDEPEND="${DEPEND}
 	!sys-auth/polkit-qt[qt5]

--- a/kde-frameworks/solid/solid-9999.ebuild
+++ b/kde-frameworks/solid/solid-9999.ebuild
@@ -13,16 +13,16 @@ KEYWORDS=""
 IUSE="nls"
 
 RDEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sys-fs/udisks:2
 	virtual/udev
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
-	test? ( dev-qt/qtconcurrent:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
+	test? ( $(add_qt_dep qtconcurrent) )
 "
 pkg_postinst() {
 	kde5_pkg_postinst

--- a/kde-frameworks/sonnet/sonnet-9999.ebuild
+++ b/kde-frameworks/sonnet/sonnet-9999.ebuild
@@ -12,13 +12,13 @@ KEYWORDS=""
 IUSE="aspell +hunspell nls"
 
 RDEPEND="
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	aspell? ( app-text/aspell )
 	hunspell? ( app-text/hunspell )
 "
 DEPEND="${RDEPEND}
-	nls? ( dev-qt/linguist-tools:5 )
+	nls? ( $(add_qt_dep linguist-tools) )
 "
 
 src_configure() {

--- a/kde-misc/akonadi-phabricator-resource/akonadi-phabricator-resource-9999.ebuild
+++ b/kde-misc/akonadi-phabricator-resource/akonadi-phabricator-resource-9999.ebuild
@@ -17,12 +17,12 @@ IUSE=""
 DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kio)
+	$(add_kdeapps_dep akonadi)
 	$(add_kdeapps_dep kasync)
 	$(add_kdeapps_dep kcalcore)
-	|| ( $(add_kdeapps_dep kdepimlibs) $(add_kdeapps_dep libakonadi) )
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
 	dev-libs/libxslt
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
 "
 RDEPEND="${DEPEND}"

--- a/kde-misc/colord-kde/colord-kde-9999.ebuild
+++ b/kde-misc/colord-kde/colord-kde-9999.ebuild
@@ -29,9 +29,9 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
 	media-libs/lcms:2
-	dev-qt/qtdbus:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	x11-libs/libX11
 "

--- a/kde-misc/kdeconnect/kdeconnect-0.9-r1.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-0.9-r1.ebuild
@@ -30,12 +30,12 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	>=app-crypt/qca-2.1.0:2[qt5,openssl]
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libfakekey
 	x11-libs/libX11
 	x11-libs/libXtst

--- a/kde-misc/kdeconnect/kdeconnect-0.9g.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-0.9g.ebuild
@@ -30,12 +30,12 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	>=app-crypt/qca-2.1.0:2[qt5,openssl]
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libfakekey
 	x11-libs/libX11
 	x11-libs/libXtst

--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -28,13 +28,13 @@ DEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	>=app-crypt/qca-2.1.0:2[qt5,openssl]
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
 	x11-libs/libfakekey
 	x11-libs/libX11
 	x11-libs/libXtst

--- a/kde-misc/kimtoy/kimtoy-9999.ebuild
+++ b/kde-misc/kimtoy/kimtoy-9999.ebuild
@@ -34,10 +34,10 @@ COMMON_DEPEND="
 	dev-libs/glib:2
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:= )
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	media-libs/libpng:0=[apng]
 	x11-libs/libX11
 	scim? (

--- a/kde-misc/kolor-manager/kolor-manager-9999.ebuild
+++ b/kde-misc/kolor-manager/kolor-manager-9999.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtwidgets)
 	media-gfx/synnefo[qt5]
 	=media-libs/oyranos-9999
 	media-libs/libXcm

--- a/kde-misc/krusader/krusader-9999.ebuild
+++ b/kde-misc/krusader/krusader-9999.ebuild
@@ -36,11 +36,11 @@ CDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	sys-apps/attr
 	sys-libs/zlib
 "

--- a/kde-misc/kwebkitpart/kwebkitpart-9999.ebuild
+++ b/kde-misc/kwebkitpart/kwebkitpart-9999.ebuild
@@ -29,12 +29,12 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebkit:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwebkit)
+	$(add_qt_dep qtwidgets)
 "
 
 RDEPEND="${DEPEND}

--- a/kde-misc/massif-visualizer/massif-visualizer-9999.ebuild
+++ b/kde-misc/massif-visualizer/massif-visualizer-9999.ebuild
@@ -26,13 +26,13 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep kdiagram)
-	dev-qt/qtgui:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/qtxmlpatterns:5
+	$(add_qt_dep qtxmlpatterns)
 	x11-misc/shared-mime-info
 "
 RDEPEND="${COMMON_DEPEND}"

--- a/kde-misc/openofficeorg-thumbnail/openofficeorg-thumbnail-1.0.0-r500.ebuild
+++ b/kde-misc/openofficeorg-thumbnail/openofficeorg-thumbnail-1.0.0-r500.ebuild
@@ -19,7 +19,7 @@ IUSE=""
 DEPEND="
 	$(add_frameworks_dep karchive)
 	$(add_frameworks_dep kio)
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-misc/plasma-applet-weather-widget/plasma-applet-weather-widget-1.6.1.ebuild
+++ b/kde-misc/plasma-applet-weather-widget/plasma-applet-weather-widget-1.6.1.ebuild
@@ -21,7 +21,7 @@ IUSE=""
 
 DEPEND="
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdeclarative:5
+	$(add_qt_dep qtdeclarative)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-misc/plasma-applet-weather-widget/plasma-applet-weather-widget-9999.ebuild
+++ b/kde-misc/plasma-applet-weather-widget/plasma-applet-weather-widget-9999.ebuild
@@ -21,7 +21,7 @@ IUSE=""
 
 DEPEND="
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdeclarative:5
+	$(add_qt_dep qtdeclarative)
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-misc/rsibreak/rsibreak-9999.ebuild
+++ b/kde-misc/rsibreak/rsibreak-9999.ebuild
@@ -31,9 +31,9 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	sys-devel/gettext

--- a/kde-misc/skanlite/skanlite-9999.ebuild
+++ b/kde-misc/skanlite/skanlite-9999.ebuild
@@ -22,8 +22,8 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep libksane)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-libs/libpng:0=
 "
 RDEPEND="${DEPEND}

--- a/kde-misc/systemd-kcm/systemd-kcm-9999.ebuild
+++ b/kde-misc/systemd-kcm/systemd-kcm-9999.ebuild
@@ -23,9 +23,9 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	>=dev-libs/boost-1.45
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	sys-apps/systemd
 "
 RDEPEND="${DEPEND}

--- a/kde-misc/wacomtablet/wacomtablet-9999.ebuild
+++ b/kde-misc/wacomtablet/wacomtablet-9999.ebuild
@@ -29,11 +29,11 @@ CDEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	>=x11-drivers/xf86-input-wacom-0.20.0
 	x11-libs/libX11
 	x11-libs/libXi

--- a/kde-misc/yakuake/yakuake-9999.ebuild
+++ b/kde-misc/yakuake/yakuake-9999.ebuild
@@ -34,10 +34,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep konsole)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 "
 RDEPEND="${DEPEND}

--- a/kde-misc/zanshin/zanshin-9999.ebuild
+++ b/kde-misc/zanshin/zanshin-9999.ebuild
@@ -42,11 +42,11 @@ RDEPEND="
 	$(add_kdeapps_dep kldap)
 	$(add_kdeapps_dep kmime)
 	dev-libs/boost
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${RDEPEND}
 	!kde-misc/zanshin:4

--- a/kde-plasma/bluedevil/bluedevil-5.5.49.9999.ebuild
+++ b/kde-plasma/bluedevil/bluedevil-5.5.49.9999.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info

--- a/kde-plasma/bluedevil/bluedevil-9999.ebuild
+++ b/kde-plasma/bluedevil/bluedevil-9999.ebuild
@@ -25,10 +25,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info

--- a/kde-plasma/breeze/breeze-5.5.49.9999.ebuild
+++ b/kde-plasma/breeze/breeze-5.5.49.9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
 	$(add_plasma_dep kdecoration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	qt4? (
 		kde-base/kdelibs:4

--- a/kde-plasma/breeze/breeze-9999.ebuild
+++ b/kde-plasma/breeze/breeze-9999.ebuild
@@ -23,10 +23,10 @@ DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep plasma)
 	$(add_plasma_dep kdecoration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	qt4? (
 		kde-base/kdelibs:4

--- a/kde-plasma/kde-cli-tools/kde-cli-tools-5.5.49.9999.ebuild
+++ b/kde-plasma/kde-cli-tools/kde-cli-tools-5.5.49.9999.ebuild
@@ -26,14 +26,14 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	kdesu? ( $(add_frameworks_dep kdesu) )
 	X? (
 		$(add_frameworks_dep kdelibs4support)
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "

--- a/kde-plasma/kde-cli-tools/kde-cli-tools-9999.ebuild
+++ b/kde-plasma/kde-cli-tools/kde-cli-tools-9999.ebuild
@@ -26,14 +26,14 @@ DEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
 	kdesu? ( $(add_frameworks_dep kdesu) )
 	X? (
 		$(add_frameworks_dep kdelibs4support)
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 	)
 "

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-5.5.49.9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-5.5.49.9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/glib:2
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	x11-libs/gtk+:2
 	gtk3? ( x11-libs/gtk+:3 )
 "

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
@@ -25,8 +25,8 @@ DEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/glib:2
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	x11-libs/gtk+:2
 	gtk3? ( x11-libs/gtk+:3 )
 "

--- a/kde-plasma/kdeplasma-addons/kdeplasma-addons-5.5.49.9999.ebuild
+++ b/kde-plasma/kdeplasma-addons/kdeplasma-addons-5.5.49.9999.ebuild
@@ -35,15 +35,15 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	ibus? (
 		app-i18n/ibus
 		dev-libs/glib:2
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 		x11-libs/xcb-util-keysyms
 	)

--- a/kde-plasma/kdeplasma-addons/kdeplasma-addons-9999.ebuild
+++ b/kde-plasma/kdeplasma-addons/kdeplasma-addons-9999.ebuild
@@ -35,15 +35,15 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	ibus? (
 		app-i18n/ibus
 		dev-libs/glib:2
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libxcb
 		x11-libs/xcb-util-keysyms
 	)

--- a/kde-plasma/kgamma/kgamma-5.5.49.9999.ebuild
+++ b/kde-plasma/kgamma/kgamma-5.5.49.9999.ebuild
@@ -18,9 +18,9 @@ RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 	x11-libs/libXxf86vm
 "

--- a/kde-plasma/kgamma/kgamma-9999.ebuild
+++ b/kde-plasma/kgamma/kgamma-9999.ebuild
@@ -18,8 +18,9 @@ RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 	x11-libs/libXxf86vm
 "

--- a/kde-plasma/khelpcenter/khelpcenter-5.5.49.9999.ebuild
+++ b/kde-plasma/khelpcenter/khelpcenter-5.5.49.9999.ebuild
@@ -31,10 +31,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)

--- a/kde-plasma/khelpcenter/khelpcenter-9999.ebuild
+++ b/kde-plasma/khelpcenter/khelpcenter-9999.ebuild
@@ -31,10 +31,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)

--- a/kde-plasma/khotkeys/khotkeys-5.5.49.9999.ebuild
+++ b/kde-plasma/khotkeys/khotkeys-5.5.49.9999.ebuild
@@ -27,10 +27,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-plasma/khotkeys/khotkeys-9999.ebuild
+++ b/kde-plasma/khotkeys/khotkeys-9999.ebuild
@@ -27,10 +27,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 "
 RDEPEND="${COMMON_DEPEND}

--- a/kde-plasma/kinfocenter/kinfocenter-5.5.49.9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.5.49.9999.ebuild
@@ -32,12 +32,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[opengl(+)]
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'opengl(+)')
+	$(add_qt_dep qtwidgets)
 	gles? (
-		dev-qt/qtgui:5[gles2]
+		$(add_qt_dep qtgui 'gles2')
 		|| (
 			media-libs/mesa[egl,gles1]
 			media-libs/mesa[egl,gles2]

--- a/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
@@ -32,12 +32,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[opengl(+)]
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'opengl(+)')
+	$(add_qt_dep qtwidgets)
 	gles? (
-		dev-qt/qtgui:5[gles2]
+		$(add_qt_dep qtgui 'gles2')
 		|| (
 			media-libs/mesa[egl,gles1]
 			media-libs/mesa[egl,gles2]

--- a/kde-plasma/kmenuedit/kmenuedit-5.5.49.9999.ebuild
+++ b/kde-plasma/kmenuedit/kmenuedit-5.5.49.9999.ebuild
@@ -26,10 +26,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	hotkeys? ( $(add_plasma_dep khotkeys) )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kmenuedit/kmenuedit-9999.ebuild
+++ b/kde-plasma/kmenuedit/kmenuedit-9999.ebuild
@@ -26,10 +26,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	hotkeys? ( $(add_plasma_dep khotkeys) )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kscreen/kscreen-5.5.49.9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-5.5.49.9999.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
-	dev-qt/qtgraphicaleffects:5
+	$(add_qt_dep qtgraphicaleffects)
 	!kde-misc/kscreen
 "

--- a/kde-plasma/kscreen/kscreen-9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-9999.ebuild
@@ -22,13 +22,13 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
-	dev-qt/qtgraphicaleffects:5
+	$(add_qt_dep qtgraphicaleffects)
 	!kde-misc/kscreen
 "

--- a/kde-plasma/kscreenlocker/kscreenlocker-5.5.49.9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-5.5.49.9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_TEST="forceoptional"
-QT_MINIMAL="5.5.0"
 VIRTUALX_REQUIRED="test"
 inherit kde5 pam
 
@@ -30,13 +29,13 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep plasma)
 	$(add_plasma_dep kwayland)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	dev-libs/wayland
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
 	x11-libs/libX11
 	x11-libs/libXi
 	x11-libs/libxcb

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_TEST="forceoptional"
-QT_MINIMAL="5.5.0"
 VIRTUALX_REQUIRED="test"
 inherit kde5 pam
 
@@ -29,13 +28,13 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
 	$(add_plasma_dep kwayland)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	dev-libs/wayland
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
 	x11-libs/libX11
 	x11-libs/libXi
 	x11-libs/libxcb

--- a/kde-plasma/ksshaskpass/ksshaskpass-5.5.49.9999.ebuild
+++ b/kde-plasma/ksshaskpass/ksshaskpass-5.5.49.9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="
 	${DEPEND}

--- a/kde-plasma/ksshaskpass/ksshaskpass-9999.ebuild
+++ b/kde-plasma/ksshaskpass/ksshaskpass-9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="
 	${DEPEND}

--- a/kde-plasma/ksysguard/ksysguard-5.5.49.9999.ebuild
+++ b/kde-plasma/ksysguard/ksysguard-5.5.49.9999.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	lm_sensors? ( sys-apps/lm_sensors )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/ksysguard/ksysguard-9999.ebuild
+++ b/kde-plasma/ksysguard/ksysguard-9999.ebuild
@@ -29,10 +29,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 	lm_sensors? ( sys-apps/lm_sensors )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kwayland-integration/kwayland-integration-5.5.49.9999.ebuild
+++ b/kde-plasma/kwayland-integration/kwayland-integration-5.5.49.9999.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	$(add_frameworks_dep kidletime)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_plasma_dep kwayland)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/kwayland-integration/kwayland-integration-9999.ebuild
+++ b/kde-plasma/kwayland-integration/kwayland-integration-9999.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	$(add_frameworks_dep kidletime)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_plasma_dep kwayland)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/kwayland/kwayland-5.5.49.9999.ebuild
+++ b/kde-plasma/kwayland/kwayland-5.5.49.9999.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 
 DEPEND="
 	>=dev-libs/wayland-1.7.0
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	media-libs/mesa[egl]
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/kwayland/kwayland-9999.ebuild
+++ b/kde-plasma/kwayland/kwayland-9999.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 
 DEPEND="
 	>=dev-libs/wayland-1.7.0
-	dev-qt/qtgui:5
+	$(add_qt_dep qtgui)
 	media-libs/mesa[egl]
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/kwin/kwin-5.5.49.9999.ebuild
+++ b/kde-plasma/kwin/kwin-5.5.49.9999.ebuild
@@ -43,12 +43,12 @@ COMMON_DEPEND="
 	$(add_plasma_dep kwayland)
 	>=dev-libs/libinput-0.10
 	>=dev-libs/wayland-1.2
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=,opengl(+)]
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=,opengl(+)')
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
@@ -68,16 +68,16 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
 	multimedia? (
 		|| (
-			dev-qt/qtmultimedia:5[gstreamer,qml]
-			dev-qt/qtmultimedia:5[gstreamer010,qml]
+			$(add_qt_dep qtmultimedia 'gstreamer,qml')
+			$(add_qt_dep qtmultimedia 'gstreamer010,qml')
 		)
 	)
 	!kde-base/kwin:4
 	!kde-base/systemsettings:4
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/designer:5
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtconcurrent)
 	x11-proto/xproto
 	test? (	x11-libs/xcb-util-wm )
 "

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -43,12 +43,12 @@ COMMON_DEPEND="
 	$(add_plasma_dep kwayland)
 	>=dev-libs/libinput-0.10
 	>=dev-libs/wayland-1.2
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5[gles2=,opengl(+)]
-	dev-qt/qtscript:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=,opengl(+)')
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
@@ -68,16 +68,16 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
 	multimedia? (
 		|| (
-			dev-qt/qtmultimedia:5[gstreamer,qml]
-			dev-qt/qtmultimedia:5[gstreamer010,qml]
+			$(add_qt_dep qtmultimedia 'gstreamer,qml')
+			$(add_qt_dep qtmultimedia 'gstreamer010,qml')
 		)
 	)
 	!kde-base/kwin:4
 	!kde-base/systemsettings:4
 "
 DEPEND="${COMMON_DEPEND}
-	dev-qt/designer:5
-	dev-qt/qtconcurrent:5
+	$(add_qt_dep designer)
+	$(add_qt_dep qtconcurrent)
 	x11-proto/xproto
 	test? (	x11-libs/xcb-util-wm )
 "

--- a/kde-plasma/kwrited/kwrited-5.5.49.9999.ebuild
+++ b/kde-plasma/kwrited/kwrited-5.5.49.9999.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kpty)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/kwrited:4

--- a/kde-plasma/kwrited/kwrited-9999.ebuild
+++ b/kde-plasma/kwrited/kwrited-9999.ebuild
@@ -16,8 +16,8 @@ DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kpty)
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-base/kwrited:4

--- a/kde-plasma/libkscreen/libkscreen-5.5.49.9999.ebuild
+++ b/kde-plasma/libkscreen/libkscreen-5.5.49.9999.ebuild
@@ -13,9 +13,9 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/libkscreen/libkscreen-9999.ebuild
+++ b/kde-plasma/libkscreen/libkscreen-9999.ebuild
@@ -14,9 +14,9 @@ IUSE="X"
 
 DEPEND="
 	$(add_plasma_dep kwayland)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtx11extras)
 	X? ( x11-libs/libxcb )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/libksysguard/libksysguard-5.5.49.9999.ebuild
+++ b/kde-plasma/libksysguard/libksysguard-5.5.49.9999.ebuild
@@ -22,14 +22,14 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	sys-libs/zlib
-	detailedmemory? ( dev-qt/qtwebkit:5 )
+	detailedmemory? ( $(add_qt_dep qtwebkit) )
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 		x11-libs/libXres
 	)

--- a/kde-plasma/libksysguard/libksysguard-9999.ebuild
+++ b/kde-plasma/libksysguard/libksysguard-9999.ebuild
@@ -22,14 +22,14 @@ COMMON_DEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	sys-libs/zlib
-	detailedmemory? ( dev-qt/qtwebkit:5 )
+	detailedmemory? ( $(add_qt_dep qtwebkit) )
 	X? (
-		dev-qt/qtx11extras:5
+		$(add_qt_dep qtx11extras)
 		x11-libs/libX11
 		x11-libs/libXres
 	)

--- a/kde-plasma/milou/milou-5.5.49.9999.ebuild
+++ b/kde-plasma/milou/milou-5.5.49.9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep krunner)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-misc/milou:4

--- a/kde-plasma/milou/milou-9999.ebuild
+++ b/kde-plasma/milou/milou-9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep krunner)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
 	!kde-misc/milou:4

--- a/kde-plasma/oxygen/oxygen-5.5.49.9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-5.5.49.9999.ebuild
@@ -23,10 +23,10 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_plasma_dep kdecoration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	!kde-base/kdebase-cursors:4
 	!kde-base/oxygen:4

--- a/kde-plasma/oxygen/oxygen-9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-9999.ebuild
@@ -23,10 +23,10 @@ RDEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_plasma_dep kdecoration)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libxcb
 	!kde-base/kdebase-cursors:4
 	!kde-base/oxygen:4

--- a/kde-plasma/plasma-desktop/plasma-desktop-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-5.5.49.9999.ebuild
@@ -54,17 +54,17 @@ COMMON_DEPEND="
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
 	$(add_frameworks_dep sonnet)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	x11-libs/libX11
 	x11-libs/libXcursor
@@ -89,7 +89,7 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep breeze)
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep oxygen)
-	dev-qt/qtgraphicaleffects:5
+	$(add_qt_dep qtgraphicaleffects)
 	sys-apps/accountsservice
 	x11-apps/setxkbmap
 	legacy-systray? (

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -54,17 +54,17 @@ COMMON_DEPEND="
 	$(add_frameworks_dep sonnet)
 	$(add_plasma_dep kwin)
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtsvg)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	x11-libs/libX11
 	x11-libs/libXcursor
@@ -89,7 +89,7 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep breeze)
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep oxygen)
-	dev-qt/qtgraphicaleffects:5
+	$(add_qt_dep qtgraphicaleffects)
 	sys-apps/accountsservice
 	x11-apps/setxkbmap
 	legacy-systray? (

--- a/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
@@ -27,10 +27,10 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep kwayland)
-	dev-qt/qtdbus:5
+	$(add_qt_dep qtdbus)
 	dev-qt/qtgui:5=
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libXcursor
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 FRAMEWORKS_MINIMAL="5.17.0"
-QT_MINIMAL="5.5.0"
 VIRTUALX_REQUIRED="test"
 inherit kde5
 
@@ -28,7 +27,7 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep kwayland)
 	$(add_qt_dep qtdbus)
-	dev-qt/qtgui:5=
+	$(add_qt_dep qtgui '' '' '5=')
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtx11extras)
 	x11-libs/libXcursor

--- a/kde-plasma/plasma-mediacenter/plasma-mediacenter-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-mediacenter/plasma-mediacenter-5.5.49.9999.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtxml)
 	media-libs/taglib
 	semantic-desktop? (
 		$(add_frameworks_dep baloo)
@@ -34,7 +34,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtmultimedia:5[qml]
+	$(add_qt_dep qtmultimedia 'qml')
 	!media-video/plasma-mediacenter
 "
 

--- a/kde-plasma/plasma-mediacenter/plasma-mediacenter-9999.ebuild
+++ b/kde-plasma/plasma-mediacenter/plasma-mediacenter-9999.ebuild
@@ -21,11 +21,11 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtxml)
 	media-libs/taglib
 	semantic-desktop? (
 		$(add_frameworks_dep baloo)
@@ -34,7 +34,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtmultimedia:5[qml]
+	$(add_qt_dep qtmultimedia 'qml')
 	!media-video/plasma-mediacenter
 "
 

--- a/kde-plasma/plasma-nm/plasma-nm-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-5.5.49.9999.ebuild
@@ -33,19 +33,19 @@ DEPEND="
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
 	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	>=net-misc/networkmanager-0.9.10.0[teamd=]
 	modemmanager? (
 		$(add_frameworks_dep modemmanager-qt)
-		dev-qt/qtxml:5
+		$(add_qt_dep qtxml)
 		net-misc/mobile-broadband-provider-info
 	)
 	openconnect? (
-		dev-qt/qtxml:5
+		$(add_qt_dep qtxml)
 		net-misc/networkmanager-openconnect
 		net-misc/openconnect:=
 	)

--- a/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
@@ -33,19 +33,19 @@ DEPEND="
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
 	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtwidgets)
 	>=net-misc/networkmanager-0.9.10.0[teamd=]
 	modemmanager? (
 		$(add_frameworks_dep modemmanager-qt)
-		dev-qt/qtxml:5
+		$(add_qt_dep qtxml)
 		net-misc/mobile-broadband-provider-info
 	)
 	openconnect? (
-		dev-qt/qtxml:5
+		$(add_qt_dep qtxml)
 		net-misc/networkmanager-openconnect
 		net-misc/openconnect:=
 	)

--- a/kde-plasma/plasma-pa/plasma-pa-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-5.5.49.9999.ebuild
@@ -17,10 +17,10 @@ DEPEND="
 	$(add_frameworks_dep kglobalaccel)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-sound/pulseaudio
 "
 

--- a/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
@@ -17,10 +17,10 @@ DEPEND="
 	$(add_frameworks_dep kglobalaccel)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	media-sound/pulseaudio
 "
 

--- a/kde-plasma/plasma-sdk/plasma-sdk-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-5.5.49.9999.ebuild
@@ -27,11 +27,11 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	!dev-util/plasmate

--- a/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
@@ -27,11 +27,11 @@ DEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep plasma)
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
 "
 RDEPEND="${DEPEND}
 	!dev-util/plasmate

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.5.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.5.49.9999.ebuild
@@ -7,7 +7,6 @@ EAPI=6
 KDE_HANDBOOK="true"
 KDE_PUNT_BOGUS_DEPS="true"
 KDE_TEST="true"
-QT_MINIMAL="5.5.0"
 VIRTUALX_REQUIRED="test"
 inherit kde5 multilib qmake-utils
 
@@ -60,16 +59,16 @@ COMMON_DEPEND="
 	$(add_plasma_dep kwin)
 	$(add_plasma_dep libkscreen)
 	$(add_plasma_dep libksysguard)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5[jpeg]
-	dev-qt/qtnetwork:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui 'jpeg')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	sys-libs/zlib
 	x11-libs/libICE
@@ -93,10 +92,10 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep ksysguard)
 	$(add_plasma_dep milou)
-	dev-qt/qdbus:5
-	dev-qt/qtgraphicaleffects:5
-	dev-qt/qtpaths:5
-	dev-qt/qtquickcontrols:5[widgets]
+	$(add_qt_dep qdbus)
+	$(add_qt_dep qtgraphicaleffects)
+	$(add_qt_dep qtpaths)
+	$(add_qt_dep qtquickcontrols 'widgets')
 	x11-apps/mkfontdir
 	x11-apps/xmessage
 	x11-apps/xprop

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -7,7 +7,6 @@ EAPI=6
 KDE_HANDBOOK="true"
 KDE_PUNT_BOGUS_DEPS="true"
 KDE_TEST="true"
-QT_MINIMAL="5.5.0"
 VIRTUALX_REQUIRED="test"
 inherit kde5 multilib qmake-utils
 
@@ -60,16 +59,16 @@ COMMON_DEPEND="
 	$(add_plasma_dep kwin)
 	$(add_plasma_dep libkscreen)
 	$(add_plasma_dep libksysguard)
-	dev-qt/qtconcurrent:5
-	dev-qt/qtdbus:5
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5[jpeg]
-	dev-qt/qtnetwork:5
-	dev-qt/qtscript:5
-	dev-qt/qtsql:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui 'jpeg')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
 	media-libs/phonon[qt5]
 	sys-libs/zlib
 	x11-libs/libICE
@@ -93,10 +92,10 @@ RDEPEND="${COMMON_DEPEND}
 	$(add_plasma_dep kde-cli-tools)
 	$(add_plasma_dep ksysguard)
 	$(add_plasma_dep milou)
-	dev-qt/qdbus:5
-	dev-qt/qtgraphicaleffects:5
-	dev-qt/qtpaths:5
-	dev-qt/qtquickcontrols:5[widgets]
+	$(add_qt_dep qdbus)
+	$(add_qt_dep qtgraphicaleffects)
+	$(add_qt_dep qtpaths)
+	$(add_qt_dep qtquickcontrols 'widgets')
 	x11-apps/mkfontdir
 	x11-apps/xmessage
 	x11-apps/xprop

--- a/kde-plasma/polkit-kde-agent/polkit-kde-agent-5.5.49.9999.ebuild
+++ b/kde-plasma/polkit-kde-agent/polkit-kde-agent-5.5.49.9999.ebuild
@@ -21,9 +21,9 @@ DEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	|| ( $(add_frameworks_dep polkit-qt) >=sys-auth/polkit-qt-0.112.0[qt5] )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/polkit-kde-agent/polkit-kde-agent-9999.ebuild
+++ b/kde-plasma/polkit-kde-agent/polkit-kde-agent-9999.ebuild
@@ -20,9 +20,9 @@ DEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	|| ( $(add_frameworks_dep polkit-qt) >=sys-auth/polkit-qt-0.112.0[qt5] )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/powerdevil/powerdevil-5.5.49.9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-5.5.49.9999.ebuild
@@ -34,10 +34,10 @@ DEPEND="
 	$(add_plasma_dep kwayland)
 	$(add_plasma_dep libkscreen)
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	virtual/libudev:=
 	x11-libs/libxcb
 "

--- a/kde-plasma/powerdevil/powerdevil-9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-9999.ebuild
@@ -34,10 +34,10 @@ DEPEND="
 	$(add_plasma_dep kwayland)
 	$(add_plasma_dep libkscreen)
 	$(add_plasma_dep plasma-workspace)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	virtual/libudev:=
 	x11-libs/libxcb
 "

--- a/kde-plasma/sddm-kcm/sddm-kcm-5.5.49.9999.ebuild
+++ b/kde-plasma/sddm-kcm/sddm-kcm-5.5.49.9999.ebuild
@@ -20,10 +20,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 	x11-libs/libXcursor
 "

--- a/kde-plasma/sddm-kcm/sddm-kcm-9999.ebuild
+++ b/kde-plasma/sddm-kcm/sddm-kcm-9999.ebuild
@@ -20,10 +20,10 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kio)
-	dev-qt/qtdeclarative:5[widgets]
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
 	x11-libs/libX11
 	x11-libs/libXcursor
 "

--- a/kde-plasma/systemsettings/systemsettings-5.5.49.9999.ebuild
+++ b/kde-plasma/systemsettings/systemsettings-5.5.49.9999.ebuild
@@ -27,9 +27,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	classic? ( $(add_frameworks_dep khtml) )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/systemsettings/systemsettings-9999.ebuild
+++ b/kde-plasma/systemsettings/systemsettings-9999.ebuild
@@ -27,9 +27,9 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 	classic? ( $(add_frameworks_dep khtml) )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/user-manager/user-manager-5.5.49.9999.ebuild
+++ b/kde-plasma/user-manager/user-manager-5.5.49.9999.ebuild
@@ -19,8 +19,8 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/libpwquality
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/user-manager/user-manager-9999.ebuild
+++ b/kde-plasma/user-manager/user-manager-9999.ebuild
@@ -19,8 +19,8 @@ DEPEND="
 	$(add_frameworks_dep kio)
 	$(add_frameworks_dep kwidgetsaddons)
 	dev-libs/libpwquality
-	dev-qt/qtdbus:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
I guess it's not a new idea. ;)

We can't expect portage to properly resolve Qt version dependencies by just setting >=dev-qt/qt{core,test}-${QT_MINIMAL} in eclass and rely on dev-qt/*'s own version blockers for the rest.

This also enables global QT_MINIMAL settings if multiple Plasma versions are around that might be better off with different Qt versions.

In the end will also solve https://bugs.gentoo.org/show_bug.cgi?id=565764

For now I've converted ebuilds where QT_MINIMAL had already been in use.