### PR TITLE
kde-apps/okular: Depend on >=KF-5.18

### DIFF
--- a/kde-apps/okular/okular-5.9999.ebuild
+++ b/kde-apps/okular/okular-5.9999.ebuild
@@ -6,6 +6,7 @@ EAPI=5
 
 KDE_HANDBOOK="forceoptional"
 EGIT_BRANCH="frameworks"
+FRAMEWORKS_MINIMAL="5.18.0"
 inherit kde5
 
 DESCRIPTION="Universal document viewer based on KPDF"


### PR DESCRIPTION
Package-Manager: portage-2.2.26