### PR TITLE
kde-apps/dolphin: Fix ebuild for EAPI 6

### DIFF
--- a/kde-apps/dolphin/dolphin-15.12.49.9999.ebuild
+++ b/kde-apps/dolphin/dolphin-15.12.49.9999.ebuild
@@ -66,9 +66,8 @@ RESTRICT="test"
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_with semantic-desktop KF5Baloo)
-		$(cmake-utils_use_with semantic-desktop KF5BalooWidgets)
-		$(cmake-utils_use_with semantic-desktop KF5FileMetaData)
+		-DWITH_KF5Baloo=$(usex semantic-desktop)
+		-DWITH_KF5BalooWidgets=$(usex semantic-desktop)
 	)
 
 	kde5_src_configure

--- a/kde-apps/dolphin/dolphin-9999.ebuild
+++ b/kde-apps/dolphin/dolphin-9999.ebuild
@@ -67,9 +67,8 @@ RESTRICT="test"
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_with semantic-desktop KF5Baloo)
-		$(cmake-utils_use_with semantic-desktop KF5BalooWidgets)
-		$(cmake-utils_use_with semantic-desktop KF5FileMetaData)
+		-DWITH_KF5Baloo=$(usex semantic-desktop)
+		-DWITH_KF5BalooWidgets=$(usex semantic-desktop)
 	)
 
 	kde5_src_configure


### PR DESCRIPTION
Package-Manager: portage-2.2.27