### PR TITLE
kde5.eclass: Use "optional" parameter for KDE_TEST and KDE_HANDBOOK

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -79,6 +79,8 @@ fi
 # If set to "false", do nothing.
 # Otherwise, add "+handbook" to IUSE, add the appropriate dependency, and
 # generate and install KDE handbook.
+# If set to "optional", config with -DCMAKE_DISABLE_FIND_PACKAGE_KF5DocTools=ON
+# when USE=!handbook. In case package requires KF5KDELibs4Support, see next:
 # If set to "forceoptional", remove a KF5DocTools dependency from the root
 # CMakeLists.txt in addition to the above.
 : ${KDE_HANDBOOK:=false}
@@ -92,6 +94,8 @@ fi
 # @DESCRIPTION:
 # If set to "false", do nothing.
 # For any other value, add test to IUSE and add a dependency on dev-qt/qttest:5.
+# If set to "optional", configure with -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Test=ON
+# when USE=!test.
 # If set to "forceoptional", remove a Qt5Test dependency from the root
 # CMakeLists.txt in addition to the above.
 if [[ ${CATEGORY} = kde-frameworks ]]; then
@@ -603,6 +607,14 @@ kde5_src_configure() {
 
 	if ! use_if_iuse test ; then
 		cmakeargs+=( -DBUILD_TESTING=OFF )
+
+		if [[ ${KDE_TEST} = optional ]] ; then
+			cmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Test=ON )
+		fi
+	fi
+
+	if ! use_if_iuse handbook && [[ ${KDE_HANDBOOK} = optional ]] ; then
+		cmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_KF5DocTools=ON )
 	fi
 
 	# install mkspecs in the same directory as qt stuff

--- a/kde-apps/ark/ark-15.12.49.9999.ebuild
+++ b/kde-apps/ark/ark-15.12.49.9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=6
 
 KDE_HANDBOOK="forceoptional"
-KDE_TEST="true"
+KDE_TEST="optional"
 inherit kde5
 
 DESCRIPTION="KDE Archiving tool"
@@ -16,8 +16,8 @@ IUSE="bzip2 lzma zlib"
 
 RDEPEND="
 	$(add_frameworks_dep karchive)
-	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kcrash)
@@ -31,10 +31,10 @@ RDEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtwidgets)
+	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext
@@ -44,7 +44,6 @@ src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package bzip2 BZip2)
 		$(cmake-utils_use_find_package lzma LibLZMA)
-		$(cmake-utils_use_find_package test Qt5Test)
 		$(cmake-utils_use_find_package zlib ZLIB)
 	)
 

--- a/kde-apps/ark/ark-9999.ebuild
+++ b/kde-apps/ark/ark-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI=6
 
 KDE_HANDBOOK="forceoptional"
-KDE_TEST="true"
+KDE_TEST="optional"
 inherit kde5
 
 DESCRIPTION="KDE Archiving tool"
@@ -16,8 +16,8 @@ IUSE="bzip2 lzma zlib"
 
 RDEPEND="
 	$(add_frameworks_dep karchive)
-	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep kcrash)
@@ -31,10 +31,10 @@ RDEPEND="
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtwidgets)
+	>=app-arch/libarchive-3.0.0[bzip2?,lzma?,zlib?]
 "
 DEPEND="${RDEPEND}
 	sys-devel/gettext
@@ -44,7 +44,6 @@ src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package bzip2 BZip2)
 		$(cmake-utils_use_find_package lzma LibLZMA)
-		$(cmake-utils_use_find_package test Qt5Test)
 		$(cmake-utils_use_find_package zlib ZLIB)
 	)
 

--- a/kde-apps/kleopatra/kleopatra-9999.ebuild
+++ b/kde-apps/kleopatra/kleopatra-9999.ebuild
@@ -4,8 +4,8 @@
 
 EAPI=6
 
-KDE_HANDBOOK="true"
-KDE_TEST="true"
+KDE_HANDBOOK="optional"
+KDE_TEST="forceoptional"
 VIRTUALX_REQUIRED="test"
 inherit kde5
 

--- a/kde-apps/rocs/files/rocs-15.12.2-doctools-optional.patch
+++ b/kde-apps/rocs/files/rocs-15.12.2-doctools-optional.patch
@@ -1,0 +1,29 @@
+commit c4d77a5348fcf18aff734ccff13dcc87582a35be
+Author: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date:   Tue Mar 8 19:34:32 2016 +0100
+
+    Make KF5DocTools really optional
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cc71ba0..8e2c4e8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,7 +57,6 @@ find_package(KF5 5.15 REQUIRED COMPONENTS
+     CoreAddons
+     Crash
+     Declarative
+-    DocTools
+     I18n
+     ItemViews
+     TextEditor
+@@ -80,7 +79,9 @@ remove_definitions(-DQT_NO_KEYWORDS)
+ ecm_optional_add_subdirectory(libgraphtheory)
+ ecm_optional_add_subdirectory(src)
+ ecm_optional_add_subdirectory(icons)
+-ecm_optional_add_subdirectory(doc)
++if(KF5DocTools_FOUND)
++    ecm_optional_add_subdirectory(doc)
++endif()
+ 
+ set_package_info(Boost "Boost C++ Libraries" "http://www.boost.org")
+ feature_summary(WHAT ALL)

--- a/kde-apps/rocs/rocs-15.12.2-r1.ebuild
+++ b/kde-apps/rocs/rocs-15.12.2-r1.ebuild
@@ -2,9 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
+CMAKE_MIN_VERSION="3.0.0"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 inherit kde5
 
@@ -28,7 +29,6 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-libs/grantlee:5
 	$(add_qt_dep qtconcurrent)
 	$(add_qt_dep qtdeclarative 'widgets')
 	$(add_qt_dep qtgui)
@@ -38,6 +38,7 @@ RDEPEND="
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
 	$(add_qt_dep qtxmlpatterns)
+	dev-libs/grantlee:5
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49
@@ -45,9 +46,4 @@ DEPEND="${RDEPEND}
 
 RESTRICT=test	# 1/10 tests currently fails
 
-src_prepare() {
-	# Duplicate
-	sed -e '/^find_package.*KF5DocTools/ s/^/#/' -i CMakeLists.txt || die
-
-	kde5_src_prepare
-}
+PATCHES=( "${FILESDIR}/${PN}-15.12.2-doctools-optional.patch" )

--- a/kde-apps/rocs/rocs-15.12.49.9999.ebuild
+++ b/kde-apps/rocs/rocs-15.12.49.9999.ebuild
@@ -2,9 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
+CMAKE_MIN_VERSION="3.0.0"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 inherit kde5
 
@@ -28,7 +29,6 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-libs/grantlee:5
 	$(add_qt_dep qtconcurrent)
 	$(add_qt_dep qtdeclarative 'widgets')
 	$(add_qt_dep qtgui)
@@ -38,6 +38,7 @@ RDEPEND="
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
 	$(add_qt_dep qtxmlpatterns)
+	dev-libs/grantlee:5
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49
@@ -45,9 +46,4 @@ DEPEND="${RDEPEND}
 
 RESTRICT=test	# 1/10 tests currently fails
 
-src_prepare() {
-	# Duplicate
-	sed -e '/^find_package.*KF5DocTools/ s/^/#/' -i CMakeLists.txt || die
-
-	kde5_src_prepare
-}
+PATCHES=( "${FILESDIR}/${PN}-15.12.2-doctools-optional.patch" )

--- a/kde-apps/rocs/rocs-9999.ebuild
+++ b/kde-apps/rocs/rocs-9999.ebuild
@@ -2,9 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
+CMAKE_MIN_VERSION="3.0.0"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 inherit kde5
 
@@ -28,7 +29,6 @@ RDEPEND="
 	$(add_frameworks_dep ktexteditor)
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kxmlgui)
-	dev-libs/grantlee:5
 	$(add_qt_dep qtconcurrent)
 	$(add_qt_dep qtdeclarative 'widgets')
 	$(add_qt_dep qtgui)
@@ -38,16 +38,10 @@ RDEPEND="
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
 	$(add_qt_dep qtxmlpatterns)
+	dev-libs/grantlee:5
 "
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.49
 "
 
 RESTRICT=test	# 1/10 tests currently fails
-
-src_prepare() {
-	# Duplicate
-	sed -e '/^find_package.*KF5DocTools/ s/^/#/' -i CMakeLists.txt || die
-
-	kde5_src_prepare
-}

--- a/kde-apps/step/files/step-15.12.2-doctools.patch
+++ b/kde-apps/step/files/step-15.12.2-doctools.patch
@@ -1,0 +1,34 @@
+commit 1ba1e576e20e9008d3fd862deb7bbcca61f3e4d8
+Author: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date:   Thu Mar 10 20:10:50 2016 +0100
+
+    Remove duplicate KF5DocTools search, make it optional
+    
+    Using ecm_optional_add_subdirectory, as long as KDELibs4Support
+    makes it impossible to disable KF5DocTools.
+    
+    REVIEW: 127335
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b0dd543..9623485 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,7 +33,6 @@ find_package(KF5 REQUIRED COMPONENTS
+     NewStuff
+     Plotting
+ )
+-find_package(KF5DocTools REQUIRED)
+ find_package(Eigen3 3.2.2 REQUIRED)
+ find_package(GSL)
+ find_package(Qalculate)
+@@ -69,7 +68,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${EIGEN3_INCLUDE_DIR})
+ 
+-add_subdirectory(doc)
++if(KF5DocTools_FOUND)
++    ecm_optional_add_subdirectory(doc)
++endif()
+ add_subdirectory(stepcore)
+ add_subdirectory(step)
+ add_subdirectory(autotests)

--- a/kde-apps/step/step-15.12.49.9999.ebuild
+++ b/kde-apps/step/step-15.12.49.9999.ebuild
@@ -2,10 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
-KDE_TEST="true"
+KDE_HANDBOOK="forceoptional" # not optional until !kdelibs4support
+KDE_TEST="forceoptional"
 inherit kde5
 
 DESCRIPTION="Interactive physics simulator"
@@ -30,7 +30,6 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	=dev-cpp/eigen-3.2*:3
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtopengl)
@@ -38,29 +37,27 @@ DEPEND="
 	$(add_qt_dep qtsvg)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
+	=dev-cpp/eigen-3.2*:3
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )
 "
 RDEPEND="${DEPEND}"
 
-src_prepare() {
-	use handbook || sed -e '/^find_package.*KF5DocTools/ s/^/#/' \
-		-i CMakeLists.txt || die
+PATCHES=( "${FILESDIR}/${PN}-15.12.2-doctools.patch" )
 
-	# Duplicate
-	sed -e '/^find_package.*Qt5Test/ s/^/#/' \
-		-i autotests/CMakeLists.txt || die
+src_prepare() {
+	kde5_src_prepare
+
+	# FIXME: Drop duplicate upstream
 	sed -e '/find_package.*Xml Test/ s/^/#/' \
 		-i stepcore/CMakeLists.txt || die
-
-	kde5_src_prepare
 }
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_find_package gsl)
-		$(cmake-utils_use_find_package qalculate)
+		$(cmake-utils_use_find_package gsl GSL)
+		$(cmake-utils_use_find_package qalculate Qalculate)
 	)
 	kde5_src_configure
 }

--- a/kde-apps/step/step-9999.ebuild
+++ b/kde-apps/step/step-9999.ebuild
@@ -2,10 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
-KDE_TEST="true"
+KDE_HANDBOOK="forceoptional" # not optional until !kdelibs4support
+KDE_TEST="forceoptional"
 inherit kde5
 
 DESCRIPTION="Interactive physics simulator"
@@ -30,7 +30,6 @@ DEPEND="
 	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
-	=dev-cpp/eigen-3.2*:3
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtopengl)
@@ -38,6 +37,7 @@ DEPEND="
 	$(add_qt_dep qtsvg)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
+	=dev-cpp/eigen-3.2*:3
 	sci-libs/cln
 	gsl? ( >=sci-libs/gsl-1.9-r1 )
 	qalculate? ( >=sci-libs/libqalculate-0.9.5 )
@@ -45,22 +45,17 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 src_prepare() {
-	use handbook || sed -e '/^find_package.*KF5DocTools/ s/^/#/' \
-		-i CMakeLists.txt || die
+	kde5_src_prepare
 
-	# Duplicate
-	sed -e '/^find_package.*Qt5Test/ s/^/#/' \
-		-i autotests/CMakeLists.txt || die
+	# FIXME: Drop duplicate upstream
 	sed -e '/find_package.*Xml Test/ s/^/#/' \
 		-i stepcore/CMakeLists.txt || die
-
-	kde5_src_prepare
 }
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_find_package gsl)
-		$(cmake-utils_use_find_package qalculate)
+		$(cmake-utils_use_find_package gsl GSL)
+		$(cmake-utils_use_find_package qalculate Qalculate)
 	)
 	kde5_src_configure
 }

--- a/kde-misc/kdeconnect/kdeconnect-0.9g.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-0.9g.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-KDE_HANDBOOK="true"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 KMNAME="${PN}-kde"
 inherit kde5
@@ -29,13 +29,13 @@ DEPEND="
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
-	>=app-crypt/qca-2.1.0:2[qt5,openssl]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtnetwork)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtx11extras)
+	>=app-crypt/qca-2.1.0:2[qt5,openssl]
 	x11-libs/libfakekey
 	x11-libs/libX11
 	x11-libs/libXtst
@@ -60,7 +60,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DEXPERIMENTALAPP_ENABLED=$(usex app)
-		$(cmake-utils_use_find_package handbook KF5DocTools)
 		$(cmake-utils_use_find_package telepathy TelepathyQt5)
 		$(cmake-utils_use_find_package telepathy TelepathyQt5Service)
 		$(cmake-utils_use_find_package wayland KF5Wayland)

--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-KDE_HANDBOOK="true"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 KMNAME="${PN}-kde"
 inherit kde5
@@ -59,7 +59,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DEXPERIMENTALAPP_ENABLED=$(usex app)
-		$(cmake-utils_use_find_package handbook KF5DocTools)
 		$(cmake-utils_use_find_package telepathy TelepathyQt5)
 		$(cmake-utils_use_find_package telepathy TelepathyQt5Service)
 		$(cmake-utils_use_find_package wayland KF5Wayland)


### PR DESCRIPTION
KDE_HANDBOOK: If set to "optional", configure with -DCMAKE_DISABLE_FIND_PACKAGE_KF5DocTools=ON when USE=!handbook.

KDE_TEST: If set to "optional", configure with -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Test=ON when USE=!test.