### PR TITLE
[WIP] kde-apps: Add USE=+qt4 to meta ebuilds

### DIFF
--- a/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
@@ -8,28 +8,26 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS=""
-IUSE="accessibility nls pim sdk"
+IUSE="accessibility +qt4 nls pim sdk"
 
 [[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep kate)
-	$(add_kdeapps_dep kdeadmin-meta)
-	$(add_kdeapps_dep kdecore-meta)
-	$(add_kdeapps_dep kdeedu-meta)
-	$(add_kdeapps_dep kdegames-meta)
-	$(add_kdeapps_dep kdegraphics-meta)
-	$(add_kdeapps_dep kdemultimedia-meta)
-	$(add_kdeapps_dep kdenetwork-meta)
-	$(add_kdeapps_dep kdeutils-meta)
-	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta '' 15.12.3) )
-	nls? (
-		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
-		$(add_kdeapps_dep kde4-l10n 'minimal' ${L10N_MINIMAL})
-	)
+	$(add_kdeapps_dep kdeadmin-meta 'qt4?')
+	$(add_kdeapps_dep kdecore-meta 'qt4?')
+	$(add_kdeapps_dep kdeedu-meta 'qt4?')
+	$(add_kdeapps_dep kdegames-meta 'qt4?')
+	$(add_kdeapps_dep kdegraphics-meta 'qt4?')
+	$(add_kdeapps_dep kdemultimedia-meta 'qt4?')
+	$(add_kdeapps_dep kdenetwork-meta 'qt4?')
+	$(add_kdeapps_dep kdeutils-meta 'qt4?')
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 	pim? ( $(add_kdeapps_dep kdepim-meta) )
-	sdk? (
-		$(add_kdeapps_dep kdesdk-meta)
-		$(add_kdeapps_dep kdewebdev-meta '' 15.08.3)
+	qt4? (
+		accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta '' 15.12.3) )
+		nls? ( $(add_kdeapps_dep kde4-l10n 'minimal' ${L10N_MINIMAL}) )
+		sdk? ( $(add_kdeapps_dep kdewebdev-meta '' 15.08.3) )
 	)
+	sdk? ( $(add_kdeapps_dep kdesdk-meta 'qt4?') )
 "

--- a/kde-apps/kde-apps-meta/metadata.xml
+++ b/kde-apps/kde-apps-meta/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
 		<flag name="pim">Pull in KDE PIM suite</flag>
 		<flag name="sdk">Pull in developer-specific meta-packages</flag>
 	</use>

--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-9999.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-9999.ebuild
@@ -8,10 +8,10 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-derived packages"
 KEYWORDS=""
-IUSE="+cron"
+IUSE="+cron +qt4 pim-conflict"
 
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
-	$(add_kdeapps_dep kuser)
 	cron? ( $(add_kdeapps_dep kcron) )
+	qt4? ( pim-conflict? ( $(add_kdeapps_dep kuser) ) )
 "

--- a/kde-apps/kdeadmin-meta/metadata.xml
+++ b/kde-apps/kdeadmin-meta/metadata.xml
@@ -7,5 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="cron">Installs KDE application for <pkg>virtual/cron</pkg> configuration</flag>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+		<flag name="pim-conflict">Installs KDE4-based applications conflicting with KDE PIM 5</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
@@ -8,13 +8,13 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdecore - merge this to pull in the most basic applications"
 KEYWORDS=""
-IUSE="+handbook minimal +wallpapers"
+IUSE="+handbook +qt4 +wallpapers"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )
+	qt4? ( $(add_kdeapps_dep kdebase-runtime-meta '' 15.08.3-r1) )
 	wallpapers? ( $(add_kdeapps_dep kde-wallpapers '' 15.08.3-r1) )
-	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta '' 15.08.3-r1) )
 "

--- a/kde-apps/kdecore-meta/metadata.xml
+++ b/kde-apps/kdecore-meta/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
-		<flag name="minimal">Disable install of various KDE SC 4 based packages</flag>
+		<flag name="qt4">Install KDE4-based applications</flag>
 		<flag name="wallpapers">Install the KDE wallpapers</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS=""
-IUSE=""
+IUSE="+qt4"
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -17,7 +17,6 @@ RDEPEND="
 	$(add_kdeapps_dep blinken)
 	$(add_kdeapps_dep cantor)
 	$(add_kdeapps_dep kalgebra)
-	$(add_kdeapps_dep kalzium)
 	$(add_kdeapps_dep kanagram)
 	$(add_kdeapps_dep kbruch)
 	$(add_kdeapps_dep kdeedu-data)
@@ -27,9 +26,7 @@ RDEPEND="
 	$(add_kdeapps_dep kiten)
 	$(add_kdeapps_dep klettres)
 	$(add_kdeapps_dep kmplot)
-	$(add_kdeapps_dep kqtquickcharts)
 	$(add_kdeapps_dep kstars)
-	$(add_kdeapps_dep ktouch)
 	$(add_kdeapps_dep kturtle)
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkeduvocdocument)
@@ -38,4 +35,9 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	qt4? (
+		$(add_kdeapps_dep kalzium)
+		$(add_kdeapps_dep kqtquickcharts)
+		$(add_kdeapps_dep ktouch)
+	)
 "

--- a/kde-apps/kdeedu-meta/metadata.xml
+++ b/kde-apps/kdeedu-meta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+	</use>
 </pkgmetadata>

--- a/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
 HOMEPAGE="https://games.kde.org/"
 KEYWORDS=""
-IUSE="opengl python"
+IUSE="+qt4 opengl python"
 
 RDEPEND="
 	$(add_kdeapps_dep bomber)
@@ -23,8 +23,6 @@ RDEPEND="
 	$(add_kdeapps_dep kbreakout)
 	$(add_kdeapps_dep kdiamond)
 	$(add_kdeapps_dep kfourinline)
-	$(add_kdeapps_dep kgoldrunner)
-	$(add_kdeapps_dep kigo)
 	$(add_kdeapps_dep killbots)
 	$(add_kdeapps_dep kiriki)
 	$(add_kdeapps_dep kjumpingcube)
@@ -34,25 +32,29 @@ RDEPEND="
 	$(add_kdeapps_dep kmines)
 	$(add_kdeapps_dep knavalbattle)
 	$(add_kdeapps_dep knetwalk)
-	$(add_kdeapps_dep kolf)
 	$(add_kdeapps_dep kollision)
-	$(add_kdeapps_dep konquest)
 	$(add_kdeapps_dep kpat)
-	$(add_kdeapps_dep kreversi)
 	$(add_kdeapps_dep kshisen)
-	$(add_kdeapps_dep ksirk)
-	$(add_kdeapps_dep ksnakeduel)
-	$(add_kdeapps_dep kspaceduel)
 	$(add_kdeapps_dep ksquares)
 	$(add_kdeapps_dep ktuberling)
 	$(add_kdeapps_dep libkdegames)
 	$(add_kdeapps_dep libkmahjongg)
-	$(add_kdeapps_dep lskat)
-	$(add_kdeapps_dep palapeli)
 	$(add_kdeapps_dep picmi)
-	opengl? (
-		$(add_kdeapps_dep ksudoku)
-		$(add_kdeapps_dep kubrick)
+	qt4? (
+		$(add_kdeapps_dep kgoldrunner)
+		$(add_kdeapps_dep kigo)
+		$(add_kdeapps_dep kolf)
+		$(add_kdeapps_dep konquest)
+		$(add_kdeapps_dep kreversi)
+		$(add_kdeapps_dep ksirk)
+		$(add_kdeapps_dep ksnakeduel)
+		$(add_kdeapps_dep kspaceduel)
+		$(add_kdeapps_dep lskat)
+		$(add_kdeapps_dep palapeli)
+		opengl? (
+			$(add_kdeapps_dep ksudoku)
+			$(add_kdeapps_dep kubrick)
+		)
+		python? ( $(add_kdeapps_dep kajongg) )
 	)
-	python? ( $(add_kdeapps_dep kajongg) )
 "

--- a/kde-apps/kdegames-meta/metadata.xml
+++ b/kde-apps/kdegames-meta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+	</use>
 </pkgmetadata>

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
@@ -9,24 +9,24 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegraphics - merge this to pull in all kdegraphics-derived packages"
 HOMEPAGE="https://www.kde.org/applications/graphics/"
 KEYWORDS=""
-IUSE="scanner"
+IUSE="+qt4 scanner"
 
 RDEPEND="
 	$(add_kdeapps_dep gwenview)
 	$(add_kdeapps_dep kamera)
 	$(add_kdeapps_dep kcolorchooser)
-	$(add_kdeapps_dep kdegraphics-mobipocket)
-	$(add_kdeapps_dep kolourpaint)
 	$(add_kdeapps_dep kruler)
 	$(add_kdeapps_dep libkdcraw)
 	$(add_kdeapps_dep libkexiv2)
 	$(add_kdeapps_dep libkipi)
-	$(add_kdeapps_dep okular)
 	$(add_kdeapps_dep spectacle)
-	$(add_kdeapps_dep svgpart)
 	$(add_kdeapps_dep thumbnailers)
-	scanner? (
-		$(add_kdeapps_dep ksaneplugin)
-		$(add_kdeapps_dep libksane)
+	qt4? (
+		$(add_kdeapps_dep kdegraphics-mobipocket)
+		$(add_kdeapps_dep kolourpaint)
+		$(add_kdeapps_dep okular)
+		$(add_kdeapps_dep svgpart)
+		scanner? ( $(add_kdeapps_dep ksaneplugin) )
 	)
+	scanner? ( $(add_kdeapps_dep libksane) )
 "

--- a/kde-apps/kdegraphics-meta/metadata.xml
+++ b/kde-apps/kdegraphics-meta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+	</use>
 </pkgmetadata>

--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-9999.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-9999.ebuild
@@ -12,18 +12,20 @@ HOMEPAGE="
 	https://multimedia.kde.org/
 "
 KEYWORDS=""
-IUSE="+ffmpeg"
+IUSE="+ffmpeg +qt4"
 
 # Add back whenever it is ported - no change since 4.10
 # 	mplayer? ( $(add_kdeapps_dep mplayerthumbs) )
 RDEPEND="
-	$(add_kdeapps_dep audiocd-kio)
 	$(add_kdeapps_dep dragon)
-	$(add_kdeapps_dep juk)
 	$(add_kdeapps_dep kdenlive)
 	$(add_kdeapps_dep kmix)
-	$(add_kdeapps_dep kscd)
-	$(add_kdeapps_dep libkcddb)
-	$(add_kdeapps_dep libkcompactdisc)
 	ffmpeg? ( $(add_kdeapps_dep ffmpegthumbs) )
+	qt4? (
+		$(add_kdeapps_dep audiocd-kio)
+		$(add_kdeapps_dep juk)
+		$(add_kdeapps_dep kscd)
+		$(add_kdeapps_dep libkcddb)
+		$(add_kdeapps_dep libkcompactdisc)
+	)
 "

--- a/kde-apps/kdemultimedia-meta/metadata.xml
+++ b/kde-apps/kdemultimedia-meta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+	</use>
 </pkgmetadata>

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-9999.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-9999.ebuild
@@ -8,15 +8,17 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS=""
-IUSE="ppp +telepathy"
+IUSE="ppp +qt4 +telepathy"
 
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
-	$(add_kdeapps_dep kget)
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
-	$(add_kdeapps_dep zeroconf-ioslave)
-	ppp? ( $(add_kdeapps_dep kppp) )
 	telepathy? ( $(add_kdeapps_dep plasma-telepathy-meta) )
-	!telepathy? ( $(add_kdeapps_dep kopete) )
+	!telepathy? ( qt4? ( $(add_kdeapps_dep kopete) ) )
+	qt4? (
+		$(add_kdeapps_dep kget)
+		$(add_kdeapps_dep zeroconf-ioslave)
+		ppp? ( $(add_kdeapps_dep kppp) )
+	)
 "

--- a/kde-apps/kdenetwork-meta/metadata.xml
+++ b/kde-apps/kdenetwork-meta/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
 		<flag name="ppp">Enable support for <pkg>net-dialup/ppp</pkg>.</flag>
 		<flag name="telepathy">Enable build of <pkg>kde-apps/plasma-telepathy-meta</pkg>, otherwise <pkg>kde-apps/kopete</pkg>.</flag>
 	</use>

--- a/kde-apps/kdepim-meta/kdepim-meta-9999.ebuild
+++ b/kde-apps/kdepim-meta/kdepim-meta-9999.ebuild
@@ -64,7 +64,5 @@ RDEPEND="
 	$(add_kdeapps_dep messagelib)
 	$(add_kdeapps_dep pimcommon)
 	$(add_kdeapps_dep syndication)
-	nls? (
-		$(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL})
-	)
+	nls? ( $(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdesdk-meta/kdesdk-meta-9999.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE SDK - merge this to pull in all kdesdk-derived packages"
 HOMEPAGE="https://www.kde.org/applications/development"
 KEYWORDS=""
-IUSE="cvs"
+IUSE="cvs +qt4"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin-plugins)
@@ -17,13 +17,15 @@ RDEPEND="
 	$(add_kdeapps_dep kate)
 	$(add_kdeapps_dep kcachegrind)
 	$(add_kdeapps_dep kde-dev-scripts)
-	$(add_kdeapps_dep kde-dev-utils)
-	$(add_kdeapps_dep kdesdk-kioslaves)
 	$(add_kdeapps_dep kompare)
 	$(add_kdeapps_dep libkomparediff2)
 	$(add_kdeapps_dep lokalize)
 	$(add_kdeapps_dep okteta)
 	$(add_kdeapps_dep poxml)
 	$(add_kdeapps_dep umbrello)
-	cvs? ( $(add_kdeapps_dep cervisia) )
+	qt4? (
+		$(add_kdeapps_dep kde-dev-utils)
+		$(add_kdeapps_dep kdesdk-kioslaves)
+		cvs? ( $(add_kdeapps_dep cervisia) )
+	)
 "

--- a/kde-apps/kdesdk-meta/metadata.xml
+++ b/kde-apps/kdesdk-meta/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+	</use>
 </pkgmetadata>

--- a/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdeutils - merge this to pull in all kdeutils-derived packages"
 HOMEPAGE="https://www.kde.org/applications/utilities https://utils.kde.org"
 KEYWORDS=""
-IUSE="cups floppy lirc"
+IUSE="cups floppy +qt4 lirc pim-conflict"
 
 RDEPEND="
 	$(add_kdeapps_dep ark)
@@ -17,13 +17,15 @@ RDEPEND="
 	$(add_kdeapps_dep kcalc)
 	$(add_kdeapps_dep kcharselect)
 	$(add_kdeapps_dep kdebugsettings)
-	$(add_kdeapps_dep kdf)
-	$(add_kdeapps_dep kgpg)
 	$(add_kdeapps_dep kteatime)
 	$(add_kdeapps_dep ktimer)
 	$(add_kdeapps_dep kwalletmanager)
-	$(add_kdeapps_dep sweeper)
 	cups? ( $(add_kdeapps_dep print-manager) )
 	floppy? ( $(add_kdeapps_dep kfloppy) )
-	lirc? ( $(add_kdeapps_dep kremotecontrol) )
+	qt4? (
+		$(add_kdeapps_dep kdf)
+		$(add_kdeapps_dep sweeper)
+		lirc? ( $(add_kdeapps_dep kremotecontrol) )
+		pim-conflict? ( $(add_kdeapps_dep kgpg) )
+	)
 "

--- a/kde-apps/kdeutils-meta/metadata.xml
+++ b/kde-apps/kdeutils-meta/metadata.xml
@@ -7,5 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="floppy">Install <pkg>kde-apps/kfloppy</pkg> to format and create DOS or ext2fs filesystems in a floppy.</flag>
+		<flag name="qt4">Installs KDE4-based applications</flag>
+		<flag name="pim-conflict">Installs KDE4-based applications conflicting with KDE PIM 5</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Add USE=qt4 to control install of KDE4-based applications through meta ebuilds.

USE=pim-conflict: not sure if serious...