### PR TITLE
plasma-nm needs new enough QCA due to -DQT_NO_KEYWORDS

### DIFF
--- a/kde-plasma/plasma-nm/plasma-nm-5.5.95.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-5.5.95.ebuild
@@ -32,7 +32,7 @@ DEPEND="
 	$(add_frameworks_dep networkmanager-qt 'teamd=')
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
-	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
+	>=app-crypt/qca-2.1.1:2[qt5]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)

--- a/kde-plasma/plasma-nm/plasma-nm-5.6.49.9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-5.6.49.9999.ebuild
@@ -32,7 +32,7 @@ DEPEND="
 	$(add_frameworks_dep networkmanager-qt 'teamd=')
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
-	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
+	>=app-crypt/qca-2.1.1:2[qt5]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)

--- a/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
@@ -32,7 +32,7 @@ DEPEND="
 	$(add_frameworks_dep networkmanager-qt 'teamd=')
 	$(add_frameworks_dep plasma)
 	$(add_frameworks_dep solid)
-	>=app-crypt/qca-2.1.0.3-r1:2[qt5]
+	>=app-crypt/qca-2.1.1:2[qt5]
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtdeclarative)
 	$(add_qt_dep qtgui)


### PR DESCRIPTION
plasma-nm started building with -DQT_NO_KEYWORDS which removes Qt's
"signals" and "slots" keywords, leaving only Q_SIGNALS and Q_SLOTS in
place. This has happened in plasma-nm's commit 705d0f2f.

QCA got fixed to not require the signals/slots "keywords" in 66b9754,
which is only part of the v2.1.1 git tag.

I have no idea how the QCA tarballs are genrated of course because some
tags are apparently missing form that repo...