### PR TITLE
kde-plasma/kactivitymanagerd: Workaround file collision

### DIFF
--- a/kde-plasma/breeze-gtk/breeze-gtk-5.6.0-r1.ebuild
+++ b/kde-plasma/breeze-gtk/breeze-gtk-5.6.0-r1.ebuild
@@ -11,3 +11,5 @@ HOMEPAGE="https://projects.kde.org/projects/kde/workspace/breeze-gtk"
 LICENSE="LGPL-2.1+"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""
+
+PATCHES=( "${FILESDIR}/${P}-dark.patch" )

--- a/kde-plasma/breeze-gtk/files/breeze-gtk-5.6.0-dark.patch
+++ b/kde-plasma/breeze-gtk/files/breeze-gtk-5.6.0-dark.patch
@@ -1,0 +1,26 @@
+From: Sebastian Kügler <sebas@kde.org>
+Date: Wed, 23 Mar 2016 11:16:48 +0000
+Subject: Fix installation of breeze-dark
+X-Git-Url: http://quickgit.kde.org/?p=breeze-gtk.git&a=commitdiff&h=1a547a83dc1bb1c4a0e6d61df747b0426c53531a
+---
+Fix installation of breeze-dark
+
+This regession is introduced in this commit:
+https://quickgit.kde.org/?p=breeze-gtk.git&a=commit&h=673f3e18af95ff2c4af0a999fd1ed00176e05516
+
+Patch-by: Gustavo Alvarez
+REVIEW:127465
+---
+
+
+--- a/Breeze-dark-gtk/CMakeLists.txt
++++ b/Breeze-dark-gtk/CMakeLists.txt
+@@ -1,5 +1,5 @@
+-install(DIRECTORY gtk-2.0 DESTINATION ${KDE_INSTALL_FULL_DATAROOTDIR}/themes/
++install(DIRECTORY gtk-2.0 DESTINATION ${KDE_INSTALL_FULL_DATAROOTDIR}/themes/Breeze-Dark
+     ${directory_EXCLUDES})
+-install(DIRECTORY gtk-3.0 DESTINATION ${KDE_INSTALL_FULL_DATAROOTDIR}/themes/
++install(DIRECTORY gtk-3.0 DESTINATION ${KDE_INSTALL_FULL_DATAROOTDIR}/themes/Breeze-Dark
+     ${directory_EXCLUDES})
+ 
+

--- a/kde-plasma/kactivitymanagerd/kactivitymanagerd-5.6.0-r1.ebuild
+++ b/kde-plasma/kactivitymanagerd/kactivitymanagerd-5.6.0-r1.ebuild
@@ -32,3 +32,9 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.54
 "
+
+src_install() {
+	kde5_src_install
+	# File collisions with kde-plasma/plasma-desktop...
+	rm -r ${ED}usr/share/locale || die
+}

--- a/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
@@ -46,8 +46,6 @@ RDEPEND="${DEPEND}
 	!dev-util/plasmate
 "
 
-PATCHES=( "${FILESDIR}/${PN}-5.5.5-dependencies.patch" ) # RR pending
-
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_find_package plasmate KDevPlatform)


### PR DESCRIPTION
Conflict exists with kde-plasma/plasma-desktop-5.6.0

Package-Manager: portage-2.2.27