### PR TITLE
kde-apps/kdepim-addons: Fix src_prepare

### DIFF
--- a/kde-apps/kdepim-addons/kdepim-addons-16.04.49.9999.ebuild
+++ b/kde-apps/kdepim-addons/kdepim-addons-16.04.49.9999.ebuild
@@ -68,7 +68,7 @@ src_prepare() {
 	kde5_src_prepare
 
 	for pim_ft in ${PIM_FTS}; do
-		use kdepim_features_${pim_ft} || comment_add_subdirectory ${pim_ft}
+		use kdepim_features_${pim_ft} || cmake_comment_add_subdirectory ${pim_ft}
 	done
 }
 


### PR DESCRIPTION
kde-apps/kdepim-addons-9999: Changed "comment_add_subdirectory" to "cmake_comment_add_subdirectory"; to match EAPI 6.