### PR TITLE
kde-apps/kdepimlibs: fix compilation of kdepimlibs-4.14.11_pre20160211

### DIFF
--- a/kde-apps/kdepimlibs/files/kdepimlibs-4.14.11-boostincludes.patch
+++ b/kde-apps/kdepimlibs/files/kdepimlibs-4.14.11-boostincludes.patch
@@ -2,8 +2,8 @@ Make sure that the Boost headers are actually found, since they are
 referenced in the kdepimlibs headers. 
 Patch by Alex Turbov, see https://bugs.kde.org/show_bug.cgi?id=306323
 
---- KdepimLibsConfig.cmake.in.org	2012-08-13 12:46:24.000000000 +0400
-+++ KdepimLibsConfig.cmake.in	2012-09-06 08:53:53.000000000 +0400
+--- a/KdepimLibsConfig.cmake.in.org	2012-08-13 12:46:24.000000000 +0400
++++ b/KdepimLibsConfig.cmake.in	2012-09-06 08:53:53.000000000 +0400
 @@ -15,7 +15,7 @@
  set(KDEPIMLIBS_DBUS_INTERFACES_DIR "@KDEPIMLIBS_DBUS_INTERFACES_DIR@")
  set(KDEPIMLIBS_DBUS_SERVICES_DIR   "@KDEPIMLIBS_DBUS_SERVICES_DIR@")

--- a/kde-apps/kdepimlibs/kdepimlibs-4.14.11_pre20160211.ebuild
+++ b/kde-apps/kdepimlibs/kdepimlibs-4.14.11_pre20160211.ebuild
@@ -41,7 +41,7 @@ RDEPEND="${DEPEND}
 	!kde-misc/akonadi-social-utils
 "
 
-PATCHES=( "${FILESDIR}/${PN}-4.9.1-boostincludes.patch" )
+PATCHES=( "${FILESDIR}/${PN}-4.14.11-boostincludes.patch" )
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
- converted the patch to be easily digestible by eapply (EAPI 6)
- revbumped kdepimlibs