### PR TITLE
kde-apps/messagelib: Block conflicting kdepim-addons

### DIFF
--- a/kde-apps/messagelib/messagelib-9999.ebuild
+++ b/kde-apps/messagelib/messagelib-9999.ebuild
@@ -67,13 +67,14 @@ DEPEND="${COMMON_DEPEND}
 "
 RDEPEND="${COMMON_DEPEND}
 	!<kde-apps/kdepim-15.08.50:5
+	!<kde-apps/kdepim-addons-16.04.50:5
+	!kde-apps/kdepim-common-libs:4
+	!kde-apps/kmail:4
 	!kde-apps/messagecomposer:5
 	!kde-apps/messagecore:5
 	!kde-apps/messagelist:5
 	!kde-apps/messageviewer:5
 	!kde-apps/templateparser:5
-	!kde-apps/kdepim-common-libs:4
-	!kde-apps/kmail:4
 "
 
 # bug 579630


### PR DESCRIPTION
Upstream fix for missing headers without kdepim-addons causes
file collision with the latter, see also:

https://bugs.kde.org/show_bug.cgi?id=362100
https://quickgit.kde.org/?p=messagelib.git&a=commit&h=d3c47f200c96e04785d05af9fb086bcd5a68f251

Package-Manager: portage-2.2.27