### PR TITLE
kde5-functions.eclass: Improve punt_bogus_dep

### DIFF
--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -279,7 +279,7 @@ punt_bogus_dep() {
 	sed -e "${first},${last}s/${dep}//" -i CMakeLists.txt || die
 
 	if [[ ${length} = 1 ]] ; then
-		sed -e "/find_package\s*(\s*${prefix}\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${KF5_VERSION}\)\)\+\s*)/Is/^/# removed by kde5-functions.eclass - /" -i CMakeLists.txt || die
+		sed -e "/find_package\s*(\s*${prefix}\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# removed by kde5-functions.eclass - /" -i CMakeLists.txt || die
 	fi
 }
 


### PR DESCRIPTION
The variable holding the min version requirement can be named anything.
This should catch most cases, most importantly Qt5 modules.

Fixes akonadi-9999 at least.