### PR TITLE
Mask =kde-apps/kdepimlibs-4.14.11* for POP3 breakage

### DIFF
--- a/Documentation/package.mask/kdepim-4.7
+++ b/Documentation/package.mask/kdepim-4.7
@@ -12,6 +12,7 @@
 >=kde-apps/kdepim-strigi-analyzer-4.5.50
 >=kde-apps/kdepim-runtime-4.5.50
 >=kde-apps/kdepim-wizards-4.5.50
+>=kde-apps/kdepimlibs-4.14.11_pre20160211
 >=kde-apps/kjots-4.5.50
 >=kde-apps/kleopatra-4.5.50
 >=kde-apps/kmail-4.5.50


### PR DESCRIPTION
Incompatible commit:
https://quickgit.kde.org/?p=kdepimlibs.git&a=commit&h=544410c905ce0ed2d40b33a50dcbb0796d6c91cd

Anyone attempting to remove this mask would need to backport this commit
from kdepim-runtime (nonexistent in KDE PIM 4.4):
https://quickgit.kde.org/?p=kdepim-runtime.git&a=commitdiff&h=d0958cb91c32c72127305e684a70e0d416ff6aa3