### PR TITLE
kde-plasma/kinfocenter: Drop USE="nfs,samba", add pkg_postinst messages

### DIFF
--- a/kde-plasma/kinfocenter/kinfocenter-5.7.49.9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.7.49.9999.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A utility that provides information about a computer system"
 HOMEPAGE="https://www.kde.org/applications/system/kinfocenter/"
 SRC_URI+=" https://www.gentoo.org/assets/img/logo/gentoo-3d-small.png -> glogo-small.png"
 KEYWORDS=""
-IUSE="egl gles2 ieee1394 nfs +opengl +pci samba wayland"
+IUSE="egl gles2 ieee1394 +opengl +pci wayland"
 
 REQUIRED_USE="egl? ( || ( gles2 opengl ) )"
 
@@ -50,8 +50,6 @@ DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep plasma)
 "
 RDEPEND="${COMMON_DEPEND}
-	nfs? ( net-fs/nfs-utils )
-	samba? ( net-fs/samba[server(+)] )
 	$(add_plasma_dep kde-cli-tools)
 	!kde-base/kcontrol:4
 	!kde-base/kinfocenter:4
@@ -79,4 +77,13 @@ src_install() {
 
 	insinto /usr/share/${PN}
 	doins "${DISTDIR}"/glogo-small.png
+}
+
+pkg_postinst() {
+	if ! has_version "net-fs/nfs-utils"; then
+		einfo "Installing net-fs/nfs-utils will enable the NFS information module."
+	fi
+	if ! has_version "net-fs/samba" || ! has_version "net-fs/samba[server]"; then
+		einfo "Installing net-fs/samba[server(+)] will enable the Samba status information module."
+	fi
 }

--- a/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A utility that provides information about a computer system"
 HOMEPAGE="https://www.kde.org/applications/system/kinfocenter/"
 SRC_URI+=" https://www.gentoo.org/assets/img/logo/gentoo-3d-small.png -> glogo-small.png"
 KEYWORDS=""
-IUSE="egl gles2 ieee1394 nfs +opengl +pci samba wayland"
+IUSE="egl gles2 ieee1394 +opengl +pci wayland"
 
 REQUIRED_USE="egl? ( || ( gles2 opengl ) )"
 
@@ -50,8 +50,6 @@ DEPEND="${COMMON_DEPEND}
 	$(add_frameworks_dep plasma)
 "
 RDEPEND="${COMMON_DEPEND}
-	nfs? ( net-fs/nfs-utils )
-	samba? ( net-fs/samba[server(+)] )
 	$(add_plasma_dep kde-cli-tools)
 	!kde-base/kcontrol:4
 	!kde-base/kinfocenter:4
@@ -79,4 +77,13 @@ src_install() {
 
 	insinto /usr/share/${PN}
 	doins "${DISTDIR}"/glogo-small.png
+}
+
+pkg_postinst() {
+	if ! has_version "net-fs/nfs-utils"; then
+		einfo "Installing net-fs/nfs-utils will enable the NFS information module."
+	fi
+	if ! has_version "net-fs/samba" || ! has_version "net-fs/samba[server]"; then
+		einfo "Installing net-fs/samba[server(+)] will enable the Samba status information module."
+	fi
 }

--- a/kde-plasma/kinfocenter/metadata.xml
+++ b/kde-plasma/kinfocenter/metadata.xml
@@ -8,8 +8,6 @@
 	<use>
 		<flag name="egl">Retrieve information about OpenGL via EGL</flag>
 		<flag name="gles2">Show OpenGL ES information in kinfocenter</flag>
-		<flag name="nfs">Show information about NFS mounts, shares and log entries</flag>
 		<flag name="pci">Show advanced PCI information</flag>
-		<flag name="samba">Show information about Samba mounts, shares and log entries</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Having seen some optional runtime deps in plasma-desktop and systemsettings, I thought why not put them in a separate package to avoid needless rebuilds.

For minimal interruptions this is done by
* keeping the old USE flags in 5.7.0 intact to gently enforce them in the new package (autounmask works)
* removing the USE flags in 9999 when for next version autounmask will have done its magic

In kde-plasma/kinfocenter the (imo) useless flags were just replaced with postinst messages.