### PR TITLE
kde-apps/kaddressbook: Add missing dep on kde-apps/mailcommon

### DIFF
--- a/kde-apps/kaddressbook/kaddressbook-9999.ebuild
+++ b/kde-apps/kaddressbook/kaddressbook-9999.ebuild
@@ -43,6 +43,7 @@ COMMON_DEPEND="
 	$(add_kdeapps_dep kontactinterface)
 	$(add_kdeapps_dep libgravatar)
 	$(add_kdeapps_dep libkdepim)
+	$(add_kdeapps_dep mailcommon)
 	$(add_kdeapps_dep pimcommon)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)


### PR DESCRIPTION
Will otherwise fail building `kde-apps/kaddressbook` like this:

```
-- Found PythonInterp: /usr/bin/python (found version "3.4.4")                                                                       
-- Boost version: 1.56.0                                                                                                             
CMake Error at CMakeLists.txt:64 (find_package):                                                                                     
  Could not find a package configuration file provided by "KF5MailCommon"                                                            
  (requested version 5.2.80) with any of the following names:                                                                        
                                                                                                                                     
    KF5MailCommonConfig.cmake                                                                                                        
    kf5mailcommon-config.cmake                                                                                                       
                                                                                                                                     
  Add the installation prefix of "KF5MailCommon" to CMAKE_PREFIX_PATH or set                                                         
  "KF5MailCommon_DIR" to a directory containing one of the above files.  If                                                          
  "KF5MailCommon" provides a separate development package or SDK, be sure it                                                         
  has been installed.     
```