### PR TITLE
kde-apps/{kleopatra,libkleo}: Fix DEPENDs

### DIFF
--- a/kde-apps/kleopatra/kleopatra-9999.ebuild
+++ b/kde-apps/kleopatra/kleopatra-9999.ebuild
@@ -18,7 +18,7 @@ KEYWORDS=""
 IUSE=""
 
 # drop qtgui subslot operator when QT_MINIMAL >= 5.7.0
-COMMON_DEPEND="
+DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kcodecs)
 	$(add_frameworks_dep kconfig)
@@ -29,6 +29,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_kdeapps_dep gpgmepp)
@@ -39,17 +40,11 @@ COMMON_DEPEND="
 	$(add_qt_dep qtnetwork)
 	$(add_qt_dep qtprintsupport)
 	$(add_qt_dep qtwidgets)
-	>=app-crypt/gpgme-1.3.2
 	dev-libs/boost:=
 	dev-libs/libassuan
 	dev-libs/libgpg-error
 "
-DEPEND="${COMMON_DEPEND}
-	sys-devel/gettext
-"
-RDEPEND="${COMMON_DEPEND}
-	!kde-apps/kdepim[kdepim_features_kleopatra]
-	!<kde-apps/kdepim-15.12.2-r1
+RDEPEND="${DEPEND}
 	>=app-crypt/gnupg-2.1
 	app-crypt/paperkey
 "

--- a/kde-apps/libkleo/libkleo-9999.ebuild
+++ b/kde-apps/libkleo/libkleo-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2+"
 KEYWORDS=""
 IUSE=""
 
-COMMON_DEPEND="
+RDEPEND="
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kcoreaddons)
@@ -24,16 +24,12 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_kdeapps_dep gpgmepp)
 	$(add_kdeapps_dep kmime)
-	$(add_kdeapps_dep pimcommon)
+	$(add_kdeapps_dep kpimtextedit)
 	$(add_qt_dep designer)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
 "
-DEPEND="${COMMON_DEPEND}
+DEPEND="${RDEPEND}
 	dev-libs/boost
-"
-RDEPEND="${COMMON_DEPEND}
-	!<kde-apps/kdepim-15.08.50:5
-	!kde-apps/kdepim-common-libs:4
 "


### PR DESCRIPTION
~~kwatchgnupg makes knotifications and ktextwidgets optional~~

Drop unused dependency app-crypt/gpgme
commit 7dfe5e49299d02a7539047f8459c4c75ae803eec

Package-Manager: portage-2.2.28