### PR TITLE
kde-apps/minuet: Add dependency on media-sound/fluidsynth

### DIFF
--- a/kde-apps/minuet/minuet-16.07.80.ebuild
+++ b/kde-apps/minuet/minuet-16.07.80.ebuild
@@ -27,6 +27,7 @@ COMMON_DEPEND="
 	$(add_qt_dep qtwidgets)
 	media-libs/alsa-lib
 	>=media-sound/drumstick-1.0.1
+	media-sound/fluidsynth
 "
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig

--- a/kde-apps/minuet/minuet-16.08.49.9999.ebuild
+++ b/kde-apps/minuet/minuet-16.08.49.9999.ebuild
@@ -27,6 +27,7 @@ COMMON_DEPEND="
 	$(add_qt_dep qtwidgets)
 	media-libs/alsa-lib
 	>=media-sound/drumstick-1.0.1
+	media-sound/fluidsynth
 "
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig

--- a/kde-apps/minuet/minuet-9999.ebuild
+++ b/kde-apps/minuet/minuet-9999.ebuild
@@ -27,6 +27,7 @@ COMMON_DEPEND="
 	$(add_qt_dep qtwidgets)
 	media-libs/alsa-lib
 	>=media-sound/drumstick-1.0.1
+	media-sound/fluidsynth
 "
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig


### PR DESCRIPTION
Package-Manager: portage-2.2.28

Build will fail otherwise:
```
-- Checking for module 'drumstick-alsa>=1.0.1'
--   Found drumstick-alsa, version 1.0.2
-- Checking for module 'drumstick-file>=1.0.1'
--   Found drumstick-file, version 1.0.2
-- Checking for module 'fluidsynth>=1.1.6'
--   
CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:424 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:597 (_pkg_check_modules_internal)
  src/plugins/CMakeLists.txt:37 (pkg_check_modules
```
I don't know whether this is also required for older releases.