### PR TITLE
kde-apps/kde4-l10n: Fix latest file collision

### DIFF
--- a/kde-apps/kde4-l10n/files/kde4-l10n-16.07.80-remove-dirs
+++ b/kde-apps/kde4-l10n/files/kde4-l10n-16.07.80-remove-dirs
@@ -14,6 +14,7 @@ docs/kdegraphics gwenview
 docs/kdegraphics kruler
 docs/kdesdk umbrello
 docs/kdeutils kwalletmanager
+docs/kdeutils/kcontrol blockdevices
 scripts kdeedu
 # Plasma 5
 docs kde-workspace


### PR DESCRIPTION
Gentoo-bug: 589836

Package-Manager: portage-2.2.28