### PR TITLE
kde-apps/kdeedu-meta: Add USE=webkit for indirect qtwebkit:4 rdeps

### DIFF
--- a/kde-apps/kdeedu-meta/kdeedu-meta-16.07.90.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-16.07.90.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="+webkit"
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -27,9 +27,7 @@ RDEPEND="
 	$(add_kdeapps_dep kiten)
 	$(add_kdeapps_dep klettres)
 	$(add_kdeapps_dep kmplot)
-	$(add_kdeapps_dep kqtquickcharts)
 	$(add_kdeapps_dep kstars)
-	$(add_kdeapps_dep ktouch)
 	$(add_kdeapps_dep kturtle)
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkeduvocdocument)
@@ -38,4 +36,8 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	webkit? (
+		$(add_kdeapps_dep kqtquickcharts)
+		$(add_kdeapps_dep ktouch)
+	)
 "

--- a/kde-apps/kdeedu-meta/kdeedu-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-16.08.49.9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS=""
-IUSE=""
+IUSE="+webkit"
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -27,9 +27,7 @@ RDEPEND="
 	$(add_kdeapps_dep kiten)
 	$(add_kdeapps_dep klettres)
 	$(add_kdeapps_dep kmplot)
-	$(add_kdeapps_dep kqtquickcharts)
 	$(add_kdeapps_dep kstars)
-	$(add_kdeapps_dep ktouch)
 	$(add_kdeapps_dep kturtle)
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkeduvocdocument)
@@ -38,4 +36,8 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	webkit? (
+		$(add_kdeapps_dep kqtquickcharts)
+		$(add_kdeapps_dep ktouch)
+	)
 "

--- a/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS=""
-IUSE=""
+IUSE="+webkit"
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -27,9 +27,7 @@ RDEPEND="
 	$(add_kdeapps_dep kiten)
 	$(add_kdeapps_dep klettres)
 	$(add_kdeapps_dep kmplot)
-	$(add_kdeapps_dep kqtquickcharts)
 	$(add_kdeapps_dep kstars)
-	$(add_kdeapps_dep ktouch)
 	$(add_kdeapps_dep kturtle)
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkeduvocdocument)
@@ -38,4 +36,8 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	webkit? (
+		$(add_kdeapps_dep kqtquickcharts)
+		$(add_kdeapps_dep ktouch)
+	)
 "

--- a/kde-apps/ktouch/ktouch-16.07.90.ebuild
+++ b/kde-apps/ktouch/ktouch-16.07.90.ebuild
@@ -8,7 +8,7 @@ KDE_HANDBOOK="optional"
 inherit kde4-base
 
 DESCRIPTION="Program that helps to learn and practice touch typing"
-HOMEPAGE="https://edu.kde.org/applications/miscellaneous/ktouch"
+HOMEPAGE="https://www.kde.org/applications/education/ktouch/"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="debug"
 

--- a/kde-apps/ktouch/ktouch-16.08.49.9999.ebuild
+++ b/kde-apps/ktouch/ktouch-16.08.49.9999.ebuild
@@ -8,7 +8,7 @@ KDE_HANDBOOK="optional"
 inherit kde4-base
 
 DESCRIPTION="Program that helps to learn and practice touch typing"
-HOMEPAGE="https://edu.kde.org/applications/miscellaneous/ktouch"
+HOMEPAGE="https://www.kde.org/applications/education/ktouch/"
 KEYWORDS=""
 IUSE="debug"
 

--- a/kde-apps/ktouch/ktouch-5.9999.ebuild
+++ b/kde-apps/ktouch/ktouch-5.9999.ebuild
@@ -9,7 +9,7 @@ EGIT_BRANCH="frameworks"
 inherit kde5
 
 DESCRIPTION="Program that helps to learn and practice touch typing"
-HOMEPAGE="https://edu.kde.org/applications/miscellaneous/ktouch"
+HOMEPAGE="https://www.kde.org/applications/education/ktouch/"
 KEYWORDS=""
 IUSE=""
 

--- a/kde-apps/ktouch/ktouch-9999.ebuild
+++ b/kde-apps/ktouch/ktouch-9999.ebuild
@@ -8,7 +8,7 @@ KDE_HANDBOOK="optional"
 inherit kde4-base
 
 DESCRIPTION="Program that helps to learn and practice touch typing"
-HOMEPAGE="https://edu.kde.org/applications/miscellaneous/ktouch"
+HOMEPAGE="https://www.kde.org/applications/education/ktouch/"
 KEYWORDS=""
 IUSE="debug"
 


### PR DESCRIPTION
These depend on plasma-runtime which in turn depends on qtwebkit:4.