### PR TITLE
kde5.eclass: Remove obsolete KDE_PUNT_BOGUS_DEPS handling

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -109,13 +109,6 @@ if [[ ${KDEBASE} = kdel10n ]]; then
 	fi
 fi
 
-# @ECLASS-VARIABLE: KDE_PUNT_BOGUS_DEPS
-# @DESCRIPTION:
-# If set to "false", do nothing.
-# For any other value, do black magic to make hardcoded-but-optional dependencies
-# optional again. An upstream solution is preferable and this is a last resort.
-: ${KDE_PUNT_BOGUS_DEPS:=false}
-
 # @ECLASS-VARIABLE: KDE_SELINUX_MODULE
 # @DESCRIPTION:
 # If set to "none", do nothing.
@@ -555,18 +548,6 @@ EOF
 	if [[ ${CATEGORY} = kde-frameworks ]] && [[ ${PN} != extra-cmake-modules ]]; then
 		cmake_comment_add_subdirectory tests
 	fi
-
-	case ${KDE_PUNT_BOGUS_DEPS} in
-		false)	;;
-		*)
-			if ! use_if_iuse test ; then
-				punt_bogus_dep Qt5 Test
-			fi
-			if ! use_if_iuse handbook ; then
-				punt_bogus_dep KF5 DocTools
-			fi
-			;;
-	esac
 
 	# only build unit tests when required
 	if ! use_if_iuse test ; then

--- a/kde-apps/ktnef/ktnef-16.07.90.ebuild
+++ b/kde-apps/ktnef/ktnef-16.07.90.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_HANDBOOK="forceoptional"
-KDE_PUNT_BOGUS_DEPS="true"
 KMNAME="kdepim"
 inherit kde5
 

--- a/kde-apps/ktnef/ktnef-16.08.49.9999.ebuild
+++ b/kde-apps/ktnef/ktnef-16.08.49.9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_HANDBOOK="forceoptional"
-KDE_PUNT_BOGUS_DEPS="true"
 KMNAME="kdepim"
 inherit kde5
 

--- a/kde-apps/ktnef/ktnef-9999.ebuild
+++ b/kde-apps/ktnef/ktnef-9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_HANDBOOK="forceoptional"
-KDE_PUNT_BOGUS_DEPS="true"
 KMNAME="kdepim"
 inherit kde5
 

--- a/kde-apps/libkmahjongg/libkmahjongg-16.07.90.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-16.07.90.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_BLOCK_SLOT4="false"
-KDE_PUNT_BOGUS_DEPS="true"
 inherit kde5
 
 DESCRIPTION="Mahjongg library based on Qt/KDE Frameworks"
@@ -24,3 +23,8 @@ DEPEND="
 	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}"
+
+src_prepare(){
+	punt_bogus_dep Qt5 Test
+	kde5_src_prepare
+}

--- a/kde-apps/libkmahjongg/libkmahjongg-16.08.49.9999.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-16.08.49.9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_BLOCK_SLOT4="false"
-KDE_PUNT_BOGUS_DEPS="true"
 inherit kde5
 
 DESCRIPTION="Mahjongg library based on Qt/KDE Frameworks"

--- a/kde-apps/libkmahjongg/libkmahjongg-9999.ebuild
+++ b/kde-apps/libkmahjongg/libkmahjongg-9999.ebuild
@@ -5,7 +5,6 @@
 EAPI=6
 
 KDE_BLOCK_SLOT4="false"
-KDE_PUNT_BOGUS_DEPS="true"
 inherit kde5
 
 DESCRIPTION="Mahjongg library based on Qt/KDE Frameworks"


### PR DESCRIPTION
(bogus Qt5Test punted upstream in libkmahjongg post-16.07.90)