### PR TITLE
kde-apps/kdepasswd: Drop KDE_HANDBOOK

### DIFF
--- a/kde-apps/kdepasswd/kdepasswd-9999.ebuild
+++ b/kde-apps/kdepasswd/kdepasswd-9999.ebuild
@@ -4,8 +4,6 @@
 
 EAPI=6
 
-KDE_DOC_DIR="docs"
-KDE_HANDBOOK="forceoptional"
 KMNAME="kde-baseapps"
 inherit kde5
 


### PR DESCRIPTION
Upstream commit 5874a978e0857768dcecc2b3b3da7413f6cdea34

Package-Manager: portage-2.2.28