### PR TITLE
kde-apps/konsole: Set KDE_HANDBOOK to optional, fix DEPENDs

### DIFF
--- a/kde-apps/konsole/konsole-16.07.90.ebuild
+++ b/kde-apps/konsole/konsole-16.07.90.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-KDE_HANDBOOK="forceoptional"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 VIRTUALX_REQUIRED="test"
 inherit kde5
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep ki18n)

--- a/kde-apps/konsole/konsole-16.08.49.9999.ebuild
+++ b/kde-apps/konsole/konsole-16.08.49.9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-KDE_HANDBOOK="forceoptional"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 VIRTUALX_REQUIRED="test"
 inherit kde5
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep ki18n)

--- a/kde-apps/konsole/konsole-9999.ebuild
+++ b/kde-apps/konsole/konsole-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-KDE_HANDBOOK="forceoptional"
+KDE_HANDBOOK="optional"
 KDE_TEST="true"
 VIRTUALX_REQUIRED="test"
 inherit kde5
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdbusaddons)
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep ki18n)


### PR DESCRIPTION
Ported away from kdelibs4support in upstream commit
27dec8d02f705c77eef45a2533bed203eec9454f

Package-Manager: portage-2.2.28