### PR TITLE
kde-apps/ktp-l10n: Add blocker on <kde-apps/kde-l10n-16.08.0

### DIFF
--- a/app-cdr/k3b/k3b-9999.ebuild
+++ b/app-cdr/k3b/k3b-9999.ebuild
@@ -8,7 +8,7 @@ KDE_HANDBOOK="forceoptional"
 KDE_TEST="true"
 inherit kde5
 
-DESCRIPTION="Full-featured CD/DVD/Blu-ray burning and ripping application based on KDE Frameworks"
+DESCRIPTION="Full-featured burning and ripping application based on KDE Frameworks"
 HOMEPAGE="http://www.k3b.org/"
 
 LICENSE="GPL-2 FDL-1.2"

--- a/kde-apps/kdepim-l10n/kdepim-l10n-16.08.0.ebuild
+++ b/kde-apps/kdepim-l10n/kdepim-l10n-16.08.0.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde-l10n-15.08.0-r1
+	!<kde-apps/kde-l10n-16.04.3
 	!<kde-apps/kde4-l10n-4.14.3-r1
 "
 

--- a/kde-apps/ktp-l10n/ktp-l10n-16.08.0.ebuild
+++ b/kde-apps/ktp-l10n/ktp-l10n-16.08.0.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde-l10n-15.08.0-r1
+	!<kde-apps/kde-l10n-16.04.3
 	!kde-apps/ktp-accounts-kcm:4
 	!kde-apps/ktp-approver:4
 	!kde-apps/ktp-auth-handler:4


### PR DESCRIPTION
There are a number of files that changed packages between 16.04 and 16.08.
Add a blocker to get the update to work correctly.

Package-Manager: portage-2.2.28