### PR TITLE
kde-apps/konqueror: Remove kde-base/kactivities dependency

### DIFF
--- a/kde-apps/konqueror/files/konqueror-16.08.0-kactivities.patch
+++ b/kde-apps/konqueror/files/konqueror-16.08.0-kactivities.patch
@@ -1,0 +1,15 @@
+Make sure KActivities headers aren't used either if disabled.
+
+--- a/dolphin/src/CMakeLists.txt	2016-08-24 22:25:42.603345565 +0200
++++ b/dolphin/src/CMakeLists.txt	2016-08-24 22:27:39.921317927 +0200
+@@ -27,7 +27,9 @@
+ macro_bool_to_01(X11_Xrender_FOUND HAVE_XRENDER)
+ configure_file(config-X11.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-X11.h )
+ 
+-include_directories( ${KACTIVITIES_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} )
++if (KActivities_FOUND)
++  include_directories( ${KACTIVITIES_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} )
++endif (KActivities_FOUND)
+ 
+ if(HAVE_BALOO)
+   include_directories(${BALOO_INCLUDE_DIR} ${BALOO_WIDGETS_INCLUDE_DIR} ${KFILEMETADATA_INCLUDE_DIR})

--- a/kde-apps/konqueror/konqueror-16.08.0-r1.ebuild
+++ b/kde-apps/konqueror/konqueror-16.08.0-r1.ebuild
@@ -21,7 +21,6 @@ RESTRICT="test"
 DEPEND="
 	$(add_kdeapps_dep libkonq)
 	filemanager? (
-		$(add_kdebase_dep kactivities '' 4.13)
 		media-libs/phonon[qt4]
 		x11-libs/libXrender
 	)
@@ -52,6 +51,8 @@ KMEXTRACTONLY="
 	lib/konq/
 "
 
+PATCHES=( "${FILESDIR}/${PN}-16.08.0-kactivities.patch" )
+
 src_prepare() {
 	[[ ${CHOST} == *-solaris* ]] && append-ldflags -lmalloc
 
@@ -78,6 +79,7 @@ src_configure() {
 			-DWITH_Baloo=OFF
 			-DWITH_BalooWidgets=OFF
 			-DWITH_KFileMetaData=OFF
+			-DCMAKE_DISABLE_FIND_PACKAGE_KActivities=ON
 		)
 	fi
 

--- a/kde-apps/konqueror/konqueror-16.08.49.9999.ebuild
+++ b/kde-apps/konqueror/konqueror-16.08.49.9999.ebuild
@@ -21,7 +21,6 @@ RESTRICT="test"
 DEPEND="
 	$(add_kdeapps_dep libkonq)
 	filemanager? (
-		$(add_kdebase_dep kactivities '' 4.13)
 		media-libs/phonon[qt4]
 		x11-libs/libXrender
 	)
@@ -52,6 +51,8 @@ KMEXTRACTONLY="
 	lib/konq/
 "
 
+PATCHES=( "${FILESDIR}/${PN}-16.08.0-kactivities.patch" )
+
 src_prepare() {
 	[[ ${CHOST} == *-solaris* ]] && append-ldflags -lmalloc
 
@@ -78,6 +79,7 @@ src_configure() {
 			-DWITH_Baloo=OFF
 			-DWITH_BalooWidgets=OFF
 			-DWITH_KFileMetaData=OFF
+			-DCMAKE_DISABLE_FIND_PACKAGE_KActivities=ON
 		)
 	fi
 


### PR DESCRIPTION
Most remaining rdeps on ``kde-base/kactivities`` are optional:
```
app-office/calligra-2.9.11 (kde ? >=kde-base/kactivities-4.4:4[aqua=])
kde-apps/konqueror-16.04.3-r1 (filemanager ? >=kde-base/kactivities-4.13:4[aqua=])
kde-apps/okular-15.12.3 (kde ? >=kde-base/kactivities-4.13.3:4[aqua=])
kde-apps/okular-16.04.3 (kde ? >=kde-base/kactivities-4.13.3:4[aqua=])
kde-apps/okular-16.08.0 (kde ? >=kde-base/kactivities-4.13.3:4[aqua=])
kde-apps/okular-16.08.49.9999 (kde ? >=kde-base/kactivities-4.13.3:4[aqua=])
kde-apps/okular-9999 (kde ? >=kde-base/kactivities-4.13.3:4[aqua=])
www-client/rekonq-2.4.2-r1 (kde ? >=kde-base/kactivities-4.13.1:4[aqua=])
```
That leaves the following non-optional rdeps:
```
kde-apps/plasma-runtime-15.12.3 (>=kde-base/kactivities-4.13:4[aqua=])
kde-apps/plasma-runtime-16.04.3 (>=kde-base/kactivities-4.13:4[aqua=])
kde-misc/plasmoid-workflow-0.4.1 (>=kde-base/kactivities-4.4:4[aqua=])
```
...of which only kde-apps/plasma-runtime matters after Plasma-4 removal because it has rdeps itself, but its use was already made optional via USE=webkit in >=16.04.3 meta packages so could be dropped without much effort.