### PR TITLE
kde-apps: Push down *l10n deps into all meta packages to improve L10N coverage

### DIFF
--- a/eclass/kde5-functions.eclass
+++ b/eclass/kde5-functions.eclass
@@ -50,7 +50,7 @@ esac
 if [[ ${KMNAME-${PN}} = kdevelop ]]; then
 	KDEBASE=kdevelop
 elif [[ ${KMNAME} = kde-l10n || ${PN} = kde-l10n ]]; then
-	[[ ${PV} != 15.12.3 ]] && KDEBASE=kdel10n
+	KDEBASE=kdel10n
 fi
 
 debug-print "${ECLASS}: ${KDEBASE} ebuild recognized"

--- a/kde-apps/kde-apps-meta/kde-apps-meta-16.08.0.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-16.08.0.ebuild
@@ -8,9 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS="~amd64 ~x86"
-IUSE="accessibility nls pim sdk"
-
-[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+IUSE="accessibility pim sdk"
 
 RDEPEND="
 	$(add_kdeapps_dep kate)
@@ -23,10 +21,6 @@ RDEPEND="
 	$(add_kdeapps_dep kdenetwork-meta)
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
-	nls? (
-		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
-		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
-	)
 	pim? ( kde-apps/kdepim-meta:* )
 	sdk? (
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kde-apps-meta/kde-apps-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-16.08.49.9999.ebuild
@@ -8,9 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS=""
-IUSE="accessibility nls pim sdk"
-
-[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+IUSE="accessibility pim sdk"
 
 RDEPEND="
 	$(add_kdeapps_dep kate)
@@ -23,10 +21,6 @@ RDEPEND="
 	$(add_kdeapps_dep kdenetwork-meta)
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
-	nls? (
-		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
-		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
-	)
 	pim? ( kde-apps/kdepim-meta:* )
 	sdk? (
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-9999.ebuild
@@ -8,9 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Meta package for the KDE Applications collection"
 KEYWORDS=""
-IUSE="accessibility nls pim sdk"
-
-[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+IUSE="accessibility pim sdk"
 
 RDEPEND="
 	$(add_kdeapps_dep kate)
@@ -23,10 +21,6 @@ RDEPEND="
 	$(add_kdeapps_dep kdenetwork-meta)
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
-	nls? (
-		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
-		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
-	)
 	pim? ( kde-apps/kdepim-meta:* )
 	sdk? (
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-16.08.0.ebuild
+++ b/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-16.08.0.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdeaccessibility - merge this to pull in all kdeaccessiblity-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep jovie)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kmag)
 	$(add_kdeapps_dep kmousetool)
 	$(add_kdeapps_dep kmouth)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-16.08.49.9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdeaccessibility - merge this to pull in all kdeaccessiblity-derived packages"
 KEYWORDS=""
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep jovie)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kmag)
 	$(add_kdeapps_dep kmousetool)
 	$(add_kdeapps_dep kmouth)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-9999.ebuild
+++ b/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdeaccessibility - merge this to pull in all kdeaccessiblity-derived packages"
 KEYWORDS=""
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep jovie)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kmag)
 	$(add_kdeapps_dep kmousetool)
 	$(add_kdeapps_dep kmouth)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-16.08.0.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-16.08.0.ebuild
@@ -8,11 +8,14 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE="+cron"
+IUSE="+cron nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kuser)
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
 	cron? ( $(add_kdeapps_dep kcron) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-16.08.49.9999.ebuild
@@ -8,11 +8,14 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-derived packages"
 KEYWORDS=""
-IUSE="+cron"
+IUSE="+cron nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kuser)
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
 	cron? ( $(add_kdeapps_dep kcron) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdeadmin-meta/kdeadmin-meta-9999.ebuild
+++ b/kde-apps/kdeadmin-meta/kdeadmin-meta-9999.ebuild
@@ -8,11 +8,14 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE administration tools - merge this to pull in all kdeadmin-derived packages"
 KEYWORDS=""
-IUSE="+cron"
+IUSE="+cron nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kuser)
 RDEPEND="
 	$(add_kdeapps_dep ksystemlog)
 	cron? ( $(add_kdeapps_dep kcron) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdecore-meta/kdecore-meta-16.08.0.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-16.08.0.ebuild
@@ -8,12 +8,15 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdecore - merge this to pull in the most basic applications"
 KEYWORDS="~amd64 ~x86"
-IUSE="+handbook minimal"
+IUSE="+handbook minimal nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta '' 16.04.3) )
 "

--- a/kde-apps/kdecore-meta/kdecore-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-16.08.49.9999.ebuild
@@ -8,12 +8,15 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdecore - merge this to pull in the most basic applications"
 KEYWORDS=""
-IUSE="+handbook minimal"
+IUSE="+handbook minimal nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta '' 16.04.3) )
 "

--- a/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
@@ -8,12 +8,15 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdecore - merge this to pull in the most basic applications"
 KEYWORDS=""
-IUSE="+handbook minimal"
+IUSE="+handbook minimal nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )
+	nls? ( $(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL}) )
 	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta '' 16.04.3) )
 "

--- a/kde-apps/kdeedu-meta/kdeedu-meta-16.08.0.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-16.08.0.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS="~amd64 ~x86"
-IUSE="+webkit"
+IUSE="nls +webkit"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -36,6 +38,10 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	webkit? (
 		$(add_kdeapps_dep kqtquickcharts)
 		$(add_kdeapps_dep ktouch)

--- a/kde-apps/kdeedu-meta/kdeedu-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-16.08.49.9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS=""
-IUSE="+webkit"
+IUSE="nls +webkit"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -36,6 +38,10 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	webkit? (
 		$(add_kdeapps_dep kqtquickcharts)
 		$(add_kdeapps_dep ktouch)

--- a/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS=""
-IUSE="+webkit"
+IUSE="nls +webkit"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -36,6 +38,10 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	webkit? (
 		$(add_kdeapps_dep kqtquickcharts)
 		$(add_kdeapps_dep ktouch)

--- a/kde-apps/kdegames-meta/kdegames-meta-16.08.0.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-16.08.0.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
 HOMEPAGE="https://games.kde.org/"
 KEYWORDS="~amd64 ~x86"
-IUSE="opengl python"
+IUSE="nls opengl python"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep bomber)
@@ -50,6 +52,10 @@ RDEPEND="
 	$(add_kdeapps_dep lskat)
 	$(add_kdeapps_dep palapeli)
 	$(add_kdeapps_dep picmi)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	opengl? (
 		$(add_kdeapps_dep ksudoku)
 		$(add_kdeapps_dep kubrick)

--- a/kde-apps/kdegames-meta/kdegames-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-16.08.49.9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
 HOMEPAGE="https://games.kde.org/"
 KEYWORDS=""
-IUSE="opengl python"
+IUSE="nls opengl python"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep bomber)
@@ -50,6 +52,10 @@ RDEPEND="
 	$(add_kdeapps_dep lskat)
 	$(add_kdeapps_dep palapeli)
 	$(add_kdeapps_dep picmi)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	opengl? (
 		$(add_kdeapps_dep ksudoku)
 		$(add_kdeapps_dep kubrick)

--- a/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
 HOMEPAGE="https://games.kde.org/"
 KEYWORDS=""
-IUSE="opengl python"
+IUSE="nls opengl python"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep bomber)
@@ -50,6 +52,10 @@ RDEPEND="
 	$(add_kdeapps_dep lskat)
 	$(add_kdeapps_dep palapeli)
 	$(add_kdeapps_dep picmi)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	opengl? (
 		$(add_kdeapps_dep ksudoku)
 		$(add_kdeapps_dep kubrick)

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-16.08.0.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-16.08.0.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegraphics - merge this to pull in all kdegraphics-derived packages"
 HOMEPAGE="https://www.kde.org/applications/graphics/"
 KEYWORDS="~amd64 ~x86"
-IUSE="scanner"
+IUSE="nls scanner"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep gwenview)
@@ -25,6 +27,10 @@ RDEPEND="
 	$(add_kdeapps_dep spectacle)
 	$(add_kdeapps_dep svgpart)
 	$(add_kdeapps_dep thumbnailers)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	scanner? (
 		$(add_kdeapps_dep ksaneplugin)
 		$(add_kdeapps_dep libksane)

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-16.08.49.9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegraphics - merge this to pull in all kdegraphics-derived packages"
 HOMEPAGE="https://www.kde.org/applications/graphics/"
 KEYWORDS=""
-IUSE="scanner"
+IUSE="nls scanner"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep gwenview)
@@ -25,6 +27,10 @@ RDEPEND="
 	$(add_kdeapps_dep spectacle)
 	$(add_kdeapps_dep svgpart)
 	$(add_kdeapps_dep thumbnailers)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	scanner? (
 		$(add_kdeapps_dep ksaneplugin)
 		$(add_kdeapps_dep libksane)

--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdegraphics - merge this to pull in all kdegraphics-derived packages"
 HOMEPAGE="https://www.kde.org/applications/graphics/"
 KEYWORDS=""
-IUSE="scanner"
+IUSE="nls scanner"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep gwenview)
@@ -25,6 +27,10 @@ RDEPEND="
 	$(add_kdeapps_dep spectacle)
 	$(add_kdeapps_dep svgpart)
 	$(add_kdeapps_dep thumbnailers)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	scanner? (
 		$(add_kdeapps_dep ksaneplugin)
 		$(add_kdeapps_dep libksane)

--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.08.0.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.08.0.ebuild
@@ -12,7 +12,9 @@ HOMEPAGE="
 	https://multimedia.kde.org/
 "
 KEYWORDS="~amd64 ~x86"
-IUSE="+ffmpeg"
+IUSE="+ffmpeg nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep audiocd-kio)
@@ -24,4 +26,8 @@ RDEPEND="
 	$(add_kdeapps_dep libkcddb)
 	$(add_kdeapps_dep libkcompactdisc)
 	ffmpeg? ( $(add_kdeapps_dep ffmpegthumbs) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.08.49.9999.ebuild
@@ -12,7 +12,9 @@ HOMEPAGE="
 	https://multimedia.kde.org/
 "
 KEYWORDS=""
-IUSE="+ffmpeg"
+IUSE="+ffmpeg nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep audiocd-kio)
@@ -24,4 +26,8 @@ RDEPEND="
 	$(add_kdeapps_dep libkcddb)
 	$(add_kdeapps_dep libkcompactdisc)
 	ffmpeg? ( $(add_kdeapps_dep ffmpegthumbs) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-9999.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-9999.ebuild
@@ -12,7 +12,9 @@ HOMEPAGE="
 	https://multimedia.kde.org/
 "
 KEYWORDS=""
-IUSE="+ffmpeg"
+IUSE="+ffmpeg nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep audiocd-kio)
@@ -24,4 +26,8 @@ RDEPEND="
 	$(add_kdeapps_dep libkcddb)
 	$(add_kdeapps_dep libkcompactdisc)
 	ffmpeg? ( $(add_kdeapps_dep ffmpegthumbs) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-16.08.0.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-16.08.0.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE="ppp +telepathy"
+IUSE="nls ppp +telepathy"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
@@ -16,6 +18,10 @@ RDEPEND="
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
 	$(add_kdeapps_dep zeroconf-ioslave)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	ppp? ( $(add_kdeapps_dep kppp) )
 	telepathy? ( $(add_kdeapps_dep plasma-telepathy-meta) )
 	!telepathy? ( $(add_kdeapps_dep kopete) )

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-16.08.49.9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS=""
-IUSE="ppp +telepathy"
+IUSE="nls ppp +telepathy"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
@@ -16,6 +18,10 @@ RDEPEND="
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
 	$(add_kdeapps_dep zeroconf-ioslave)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	ppp? ( $(add_kdeapps_dep kppp) )
 	telepathy? ( $(add_kdeapps_dep plasma-telepathy-meta) )
 	!telepathy? ( $(add_kdeapps_dep kopete) )

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-9999.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
 KEYWORDS=""
-IUSE="ppp +telepathy"
+IUSE="nls ppp +telepathy"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep kdenetwork-filesharing)
@@ -16,6 +18,10 @@ RDEPEND="
 	$(add_kdeapps_dep krdc)
 	$(add_kdeapps_dep krfb)
 	$(add_kdeapps_dep zeroconf-ioslave)
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 	ppp? ( $(add_kdeapps_dep kppp) )
 	telepathy? ( $(add_kdeapps_dep plasma-telepathy-meta) )
 	!telepathy? ( $(add_kdeapps_dep kopete) )

--- a/kde-apps/kdepim-meta/kdepim-meta-16.08.0.ebuild
+++ b/kde-apps/kdepim-meta/kdepim-meta-16.08.0.ebuild
@@ -73,7 +73,5 @@ RDEPEND="
 	$(add_kdeapps_dep sieveeditor)
 	$(add_kdeapps_dep storageservicemanager)
 	$(add_kdeapps_dep syndication)
-	nls? (
-		$(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL})
-	)
+	nls? ( $(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdepim-meta/kdepim-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdepim-meta/kdepim-meta-16.08.49.9999.ebuild
@@ -73,7 +73,5 @@ RDEPEND="
 	$(add_kdeapps_dep sieveeditor)
 	$(add_kdeapps_dep storageservicemanager)
 	$(add_kdeapps_dep syndication)
-	nls? (
-		$(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL})
-	)
+	nls? ( $(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdepim-meta/kdepim-meta-9999.ebuild
+++ b/kde-apps/kdepim-meta/kdepim-meta-9999.ebuild
@@ -72,7 +72,5 @@ RDEPEND="
 	$(add_kdeapps_dep sieveeditor)
 	$(add_kdeapps_dep storageservicemanager)
 	$(add_kdeapps_dep syndication)
-	nls? (
-		$(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL})
-	)
+	nls? ( $(add_kdeapps_dep kdepim-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdesdk-meta/kdesdk-meta-16.08.0.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-16.08.0.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE SDK - merge this to pull in all kdesdk-derived packages"
 HOMEPAGE="https://www.kde.org/applications/development"
 KEYWORDS="~amd64 ~x86"
-IUSE="cvs"
+IUSE="cvs nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin-plugins)
@@ -27,4 +29,8 @@ RDEPEND="
 	$(add_kdeapps_dep kross-interpreters)
 	$(add_kdeapps_dep umbrello)
 	cvs? ( $(add_kdeapps_dep cervisia) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdesdk-meta/kdesdk-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-16.08.49.9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE SDK - merge this to pull in all kdesdk-derived packages"
 HOMEPAGE="https://www.kde.org/applications/development"
 KEYWORDS=""
-IUSE="cvs"
+IUSE="cvs nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin-plugins)
@@ -27,4 +29,8 @@ RDEPEND="
 	$(add_kdeapps_dep kross-interpreters)
 	$(add_kdeapps_dep umbrello)
 	cvs? ( $(add_kdeapps_dep cervisia) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdesdk-meta/kdesdk-meta-9999.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE SDK - merge this to pull in all kdesdk-derived packages"
 HOMEPAGE="https://www.kde.org/applications/development"
 KEYWORDS=""
-IUSE="cvs"
+IUSE="cvs nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin-plugins)
@@ -27,4 +29,8 @@ RDEPEND="
 	$(add_kdeapps_dep kross-interpreters)
 	$(add_kdeapps_dep umbrello)
 	cvs? ( $(add_kdeapps_dep cervisia) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdeutils-meta/kdeutils-meta-16.08.0.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-16.08.0.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdeutils - merge this to pull in all kdeutils-derived packages"
 HOMEPAGE="https://www.kde.org/applications/utilities https://utils.kde.org"
 KEYWORDS="~amd64 ~x86"
-IUSE="cups floppy lirc"
+IUSE="cups floppy lirc nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kgpg)
@@ -27,4 +29,8 @@ RDEPEND="
 	cups? ( $(add_kdeapps_dep print-manager) )
 	floppy? ( $(add_kdeapps_dep kfloppy) )
 	lirc? ( $(add_kdeapps_dep kremotecontrol) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdeutils-meta/kdeutils-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-16.08.49.9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdeutils - merge this to pull in all kdeutils-derived packages"
 HOMEPAGE="https://www.kde.org/applications/utilities https://utils.kde.org"
 KEYWORDS=""
-IUSE="cups floppy lirc"
+IUSE="cups floppy lirc nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kgpg)
@@ -27,4 +29,8 @@ RDEPEND="
 	cups? ( $(add_kdeapps_dep print-manager) )
 	floppy? ( $(add_kdeapps_dep kfloppy) )
 	lirc? ( $(add_kdeapps_dep kremotecontrol) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
@@ -9,7 +9,9 @@ inherit kde5-meta-pkg
 DESCRIPTION="kdeutils - merge this to pull in all kdeutils-derived packages"
 HOMEPAGE="https://www.kde.org/applications/utilities https://utils.kde.org"
 KEYWORDS=""
-IUSE="cups floppy lirc"
+IUSE="cups floppy lirc nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep kgpg)
@@ -27,4 +29,8 @@ RDEPEND="
 	cups? ( $(add_kdeapps_dep print-manager) )
 	floppy? ( $(add_kdeapps_dep kfloppy) )
 	lirc? ( $(add_kdeapps_dep kremotecontrol) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL})
+	)
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-16.08.0.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-16.08.0.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep klinkstatus)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
 	$(add_kdeapps_dep kommander)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-16.08.49.9999.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-16.08.49.9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS=""
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep klinkstatus)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
 	$(add_kdeapps_dep kommander)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "

--- a/kde-apps/kdewebdev-meta/kdewebdev-meta-9999.ebuild
+++ b/kde-apps/kdewebdev-meta/kdewebdev-meta-9999.ebuild
@@ -8,7 +8,9 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="KDE WebDev - merge this to pull in all kdewebdev-derived packages"
 KEYWORDS=""
-IUSE=""
+IUSE="nls"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 # FIXME: Add back when ported
 # $(add_kdeapps_dep klinkstatus)
@@ -16,4 +18,5 @@ RDEPEND="
 	$(add_kdeapps_dep kfilereplace)
 	$(add_kdeapps_dep kimagemapeditor)
 	$(add_kdeapps_dep kommander)
+	nls? ( $(add_kdeapps_dep kde4-l10n '' ${L10N_MINIMAL}) )
 "


### PR DESCRIPTION
An array of ${PN} which lists kde-apps/ L10N packages to add to RDEPEND.
Currently known L10N packages: kde-l10n, kde4-l10n, kdepim-l10n, ktp-l10n
If non-empty, add nls to IUSE to control these dependencies.

EDIT: Not sure about that one yet.