### PR TITLE
kde-frameworks/kfilemetadata, kde-plasma/kwin: Fix DEPENDs

### DIFF
--- a/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
@@ -10,8 +10,7 @@ DESCRIPTION="Library for extracting file metadata"
 KEYWORDS=""
 IUSE="epub exif ffmpeg libav pdf taglib"
 
-# TODO: mobi? ( $(add_plasma_dep kdegraphics-mobipocket) ) NOTE: not integrated upstream
-DEPEND="
+RDEPEND="
 	$(add_frameworks_dep karchive)
 	$(add_frameworks_dep ki18n)
 	$(add_qt_dep qtxml)
@@ -24,7 +23,9 @@ DEPEND="
 	pdf? ( app-text/poppler[qt5] )
 	taglib? ( media-libs/taglib )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	kernel_linux? ( sys-apps/attr )
+"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/kwin/kwin-5.7.49.9999.ebuild
+++ b/kde-plasma/kwin/kwin-5.7.49.9999.ebuild
@@ -88,7 +88,7 @@ DEPEND="${COMMON_DEPEND}
 	test? (	x11-libs/xcb-util-wm )
 "
 
-RESTRICT="test"
+RESTRICT+=" test"
 
 src_prepare() {
 	kde5_src_prepare

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -64,7 +64,7 @@ COMMON_DEPEND="
 	x11-libs/libXi
 	x11-libs/libdrm
 	>=x11-libs/libxcb-1.10
-	>=x11-libs/libxkbcommon-0.4.1
+	>=x11-libs/libxkbcommon-0.5.0
 	x11-libs/xcb-util-cursor
 	x11-libs/xcb-util-image
 	x11-libs/xcb-util-keysyms
@@ -88,7 +88,7 @@ DEPEND="${COMMON_DEPEND}
 	test? (	x11-libs/xcb-util-wm )
 "
 
-RESTRICT="test"
+RESTRICT+=" test"
 
 src_prepare() {
 	kde5_src_prepare


### PR DESCRIPTION
Upstream commit 163001ddac913ca565b52ec2fc96cd56e9ea31d4

Clean up comment. mobipocket can always be added back if it ever gets
re-added upstream.

Package-Manager: portage-2.2.28