### PR TITLE
kde-apps/calendarjanitor: Fix file collision

### DIFF
--- a/kde-apps/calendarjanitor/calendarjanitor-16.08.49.9999.ebuild
+++ b/kde-apps/calendarjanitor/calendarjanitor-16.08.49.9999.ebuild
@@ -9,7 +9,7 @@ KDE_TEST="false"
 KMNAME="kdepim"
 inherit kde5
 
-DESCRIPTION="A tool to scan calendar data for buggy instances"
+DESCRIPTION="Tool to scan calendar data for buggy instances"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
 KEYWORDS=""
 
@@ -37,5 +37,6 @@ fi
 
 src_prepare() {
 	cmake_comment_add_subdirectory konsolekalendar
+	sed -i -e "/console\.categories/ s/^/#DONT/" CMakeLists.txt || die
 	kde5_src_prepare
 }

--- a/kde-apps/calendarjanitor/calendarjanitor-9999.ebuild
+++ b/kde-apps/calendarjanitor/calendarjanitor-9999.ebuild
@@ -31,5 +31,6 @@ RDEPEND="${DEPEND}
 
 src_prepare() {
 	cmake_comment_add_subdirectory doc konsolekalendar
+	sed -i -e "/console\.categories/ s/^/#DONT/" CMakeLists.txt || die
 	kde5_src_prepare
 }


### PR DESCRIPTION
console.categories currently only has an entry for konsolekalendar.

Gentoo-bug: 593886

Package-Manager: portage-2.3.0