### PR TITLE
kde5.eclass: Take care of empty po directory shipped by upstream

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -545,7 +545,7 @@ EOF
 				if [[ -e CMakeLists.txt ]] ; then
 					cmake_comment_add_subdirectory ${lang}
 				fi
-			elif ! has ${lang/.po/} ${LINGUAS} ; then
+			elif [[ -f ${lang} ]] && ! has ${lang/.po/} ${LINGUAS} ; then
 				if [[ ${lang} != CMakeLists.txt && ${lang} != ${PN}.pot ]] ; then
 					rm ${lang} || die
 				fi


### PR DESCRIPTION
Uncovered by dev-libs/kreport-3.0.0.