### PR TITLE
kde-plasma/user-manager: Fix DEPENDs

### DIFF
--- a/kde-plasma/user-manager/user-manager-9999.ebuild
+++ b/kde-plasma/user-manager/user-manager-9999.ebuild
@@ -11,9 +11,10 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)


### PR DESCRIPTION
Upstream commit 4aafaf4e5fea538978f088709ced441a9cd3671e

Package-Manager: portage-2.3.0