### PR TITLE
kde-apps/konqueror: Add missing DEPEND

### DIFF
--- a/kde-apps/konqueror/konqueror-9999.ebuild
+++ b/kde-apps/konqueror/konqueror-9999.ebuild
@@ -47,6 +47,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)
+	$(add_qt_dep qtwebengine 'widgets')
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
 	sys-libs/zlib


### PR DESCRIPTION
Upstream commit: 179e924e31113caf36293d494f07a51fc790ade1

Package-Manager: portage-2.3.0