### PR TITLE
kde-frameworks/kwayland: qtgui dependency needs USE="egl"

### DIFF
--- a/kde-frameworks/kwayland/kwayland-9999.ebuild
+++ b/kde-frameworks/kwayland/kwayland-9999.ebuild
@@ -16,12 +16,12 @@ IUSE=""
 
 DEPEND="
 	$(add_qt_dep qtconcurrent)
-	$(add_qt_dep qtgui)
+	$(add_qt_dep qtgui 'egl')
 	>=dev-libs/wayland-1.7.0
 	media-libs/mesa[egl]
 "
 RDEPEND="${DEPEND}
-	$(add_qt_dep qtwayland)
+	$(add_qt_dep qtwayland 'egl')
 	!kde-plasma/kwayland
 "
 


### PR DESCRIPTION
Otherwise starting any kind of Plasma Wayland session (full, nested)
will fail with the error message:

`Failed to load client buffer integration: wayland-egl`

Package-Manager: portage-2.3.0
