### PR TITLE
Eclass changes/fixes

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -142,33 +142,6 @@ fi
 case ${KDE_AUTODEPS} in
 	false)	;;
 	*)
-		if [[ ${KDE_BUILD_TYPE} = live ]]; then
-			case ${CATEGORY} in
-				kde-frameworks)
-					: ${FRAMEWORKS_MINIMAL:=9999}
-				;;
-				kde-plasma)
-
-					: ${FRAMEWORKS_MINIMAL:=9999}
-				;;
-				*) ;;
-			esac
-		fi
-
-		if [[ ${CATEGORY} = kde-plasma && ${FRAMEWORKS_MINIMAL} != 9999 ]]; then
-			if ! [[ $(get_version_component_range 2) -le 8 && $(get_version_component_range 3) -lt 50 ]]; then
-				: ${FRAMEWORKS_MINIMAL:=5.27.0}
-			fi
-		fi
-
-		if [[ ${CATEGORY} = kde-apps ]]; then
-			local vcr2=$((10#$(get_version_component_range 2)))
-			if ! [[ $(get_version_component_range 1) -le 16 && ${vcr2} -lt 9 ]]; then
-				: ${FRAMEWORKS_MINIMAL:=5.28.0}
-			fi
-			unset vcr2
-		fi
-
 		DEPEND+=" $(add_frameworks_dep extra-cmake-modules)"
 		RDEPEND+=" >=kde-frameworks/kf-env-3"
 		COMMONDEPEND+=" $(add_qt_dep qtcore)"


### PR DESCRIPTION
FRAMEWORKS_MINIMAL was always set by kde5-functions.eclass, making the assignments as done with KDE_AUTODEPS since 040cef12f24e64267d5c60bd0b2fbcc5a3280cec a no-op. Since that re-introduces 5.28.0 minimum for KDE Applications 16.12, adding also KDEBASE=kdepim to be able to fix deps for PIM only.

This PR moves assignment of the various KDE related *_MINIMAL variables from ``kde5-functions.eclass`` to ``kde5.eclass`` if ``KDE_AUTODEPS=true``. Effectively no change for the vast majority of ebuilds using kde5.eclass.