### PR TITLE
kde-apps/kget: kf5_port->frameworks, fix DEPENDs and build options

### DIFF
--- a/kde-apps/kget/kget-16.08.49.9999.ebuild
+++ b/kde-apps/kget/kget-16.08.49.9999.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 KDE_HANDBOOK="optional"
 inherit kde4-base
 
-DESCRIPTION="An advanced download manager by KDE"
+DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
 IUSE="debug bittorrent gpg mms sqlite"

--- a/kde-apps/kget/kget-5.9999.ebuild
+++ b/kde-apps/kget/kget-5.9999.ebuild
@@ -4,22 +4,19 @@
 
 EAPI=6
 
-KDE_HANDBOOK="true"
-EGIT_BRANCH="kf5_port"
+KDE_HANDBOOK="forceoptional"
+KDE_TEST="forceoptional"
+EGIT_BRANCH="frameworks"
 inherit kde5
 
-DESCRIPTION="An advanced download manager by KDE"
+DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
-IUSE="gpg mms sqlite"
+IUSE="bittorrent gpg mms sqlite"
 
-# TODO: not yet ported
-# 	bittorrent? ( 
-# 		app-crypt/qca:2
-# 		net-libs/libktorrent
-# 	)
 RDEPEND="
 	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
@@ -28,31 +25,39 @@ RDEPEND="
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kiconthemes)
 	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemviews)
 	$(add_frameworks_dep knotifications)
 	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep kparts)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktextwidgets)
 	$(add_frameworks_dep kwallet)
 	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep solid)
 	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
 	$(add_qt_dep qtnetwork)
 	$(add_qt_dep qtsql)
-	$(add_qt_dep qttest)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
-	gpg? ( $(add_kdeapps_dep gpgmepp) )
+	app-crypt/qca:2[qt5]
+	bittorrent? ( net-libs/libktorrent:5 )
+	gpg? ( app-crypt/gpgme[qt5] )
 	mms? ( media-libs/libmms )
 	sqlite? ( dev-db/sqlite:3 )
 "
-
 DEPEND="${RDEPEND}
 	dev-libs/boost
 "
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_QGpgme=$(usex gpg)
-		-DWITH_LibMms=$(usex mms)
-		-DWITH_Sqlite=$(usex sqlite)
+		$(cmake-utils_use_find_package bittorrent KF5Torrent)
+		$(cmake-utils_use_find_package gpg Gpgmepp)
+		$(cmake-utils_use_find_package mms LibMms)
+		$(cmake-utils_use_find_package sqlite Sqlite)
 	)
 
 	kde5_src_configure

--- a/kde-apps/kget/kget-9999.ebuild
+++ b/kde-apps/kget/kget-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 KDE_HANDBOOK="optional"
 inherit kde4-base
 
-DESCRIPTION="An advanced download manager by KDE"
+DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
 IUSE="debug bittorrent gpg mms sqlite"


### PR DESCRIPTION
Force handbook and tests optional
Improve DESCRIPTION

Package-Manager: portage-2.3.0