### PR TITLE
media-gfx/digikam: Add subslot op, improve openmp check

### DIFF
--- a/kde-apps/libkface/libkface-9999.ebuild
+++ b/kde-apps/libkface/libkface-9999.ebuild
@@ -23,8 +23,6 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}-15.12.2-opencv3.1.patch" )
-
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_OPENCV3=$(has_version ">=media-libs/opencv-3" && echo yes || echo no)

--- a/media-gfx/digikam/digikam-9999.ebuild
+++ b/media-gfx/digikam/digikam-9999.ebuild
@@ -65,7 +65,7 @@ COMMON_DEPEND="
 	)
 	calendar? ( $(add_kdeapps_dep kcalcore) )
 	gphoto2? ( media-libs/libgphoto2:= )
-	jpeg2k? ( media-libs/jasper )
+	jpeg2k? ( media-libs/jasper:= )
 	kipi? ( $(add_kdeapps_dep libkipi '' '16.03.80') )
 	lensfun? ( media-libs/lensfun )
 	marble? (
@@ -107,14 +107,17 @@ RDEPEND="${COMMON_DEPEND}
 RESTRICT=test
 # bug 366505
 
-# FIXME: Unbundle libraw (libs/rawengine/libraw)
 pkg_pretend() {
-	if use openmp ; then
-		tc-has-openmp || die "Please switch to an openmp compatible compiler"
-	fi
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 	kde5_pkg_pretend
 }
 
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+	kde5_pkg_setup
+}
+
+# FIXME: Unbundle libraw (libs/rawengine/libraw)
 src_prepare() {
 	if [[ ${KDE_BUILD_TYPE} != live ]]; then
 		# prepare the translations
@@ -141,7 +144,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# LQR = only allows to choose between bundled/external
 	local mycmakeargs=(
 		-DENABLE_APPSTYLES=ON
 		-DENABLE_AKONADICONTACTSUPPORT=$(usex addressbook)


### PR DESCRIPTION
Thanks to Soap.

Package-Manager: portage-2.3.0