### PR TITLE
Add missing dependency on kde-frameworks/syntax-highlighting

### DIFF
--- a/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-9999.ebuild
@@ -28,6 +28,7 @@ DEPEND="
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_frameworks_dep syntax-highlighting)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtwidgets)
 	dev-libs/grantlee:5

--- a/kde-apps/messagelib/messagelib-9999.ebuild
+++ b/kde-apps/messagelib/messagelib-9999.ebuild
@@ -36,6 +36,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep kwindowsystem)
 	$(add_frameworks_dep kxmlgui)
 	$(add_frameworks_dep sonnet)
+	$(add_frameworks_dep syntax-highlighting)
 	$(add_kdeapps_dep akonadi)
 	$(add_kdeapps_dep akonadi-mime)
 	$(add_kdeapps_dep akonadi-notes)


### PR DESCRIPTION
Builds of `kde-apps/kpimtextedit-9999` and `kde-apps/messagelib-9999` fail otherwise like this:

```
CMake Error at CMakeLists.txt:71 (find_package):                                                                                     
  Could not find a package configuration file provided by                                                                            
  "KF5SyntaxHighlighting" (requested version 5.28.0) with any of the                                                                 
  following names:                                                                                                                   
                                                                                                                                     
    KF5SyntaxHighlightingConfig.cmake                                                                                                
    kf5syntaxhighlighting-config.cmake                                                                                               
                                                                                                                                     
  Add the installation prefix of "KF5SyntaxHighlighting" to CMAKE_PREFIX_PATH                                                        
  or set "KF5SyntaxHighlighting_DIR" to a directory containing one of the                                                            
  above files.  If "KF5SyntaxHighlighting" provides a separate development                                                           
  package or SDK, be sure it has been installed. 
```