### PR TITLE
[WIP] kde-apps/kopete: Add kf5 version

### DIFF
--- a/kde-apps/kopete/kopete-5.9999.ebuild
+++ b/kde-apps/kopete/kopete-5.9999.ebuild
@@ -1,0 +1,183 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+EGIT_BRANCH="kf5"
+KDE_HANDBOOK="forceoptional"
+KDE_TEST="forceoptional"
+inherit kde5
+
+DESCRIPTION="Multi-protocol IM client based on KDE Frameworks"
+HOMEPAGE="https://kopete.kde.org https://www.kde.org/applications/internet/kopete"
+KEYWORDS=""
+IUSE="ssl v4l"
+
+# tests hang, last checked for 4.2.96
+RESTRICT+=" test"
+
+# Available plugins
+#
+#	addbookmarks: NO DEPS
+#	alias: NO DEPS (disabled upstream)
+#	autoreplace: NO DEPS
+#	contactnotes: NO DEPS
+#	highlight: NO DEPS
+#	history: NO DEPS
+#	latex: virtual/latex as RDEPEND
+#	nowlistening: NO DEPS
+#	otr: libotr
+#	pipes: NO DEPS
+#	privacy: NO DEPS
+#	statistics: dev-db/sqlite:3
+#	texteffect: NO DEPS
+#	translator: NO DEPS
+#	urlpicpreview: NO DEPS
+#	webpresence: libxml2 libxslt
+# NOTE: By default we enable all plugins that don't have any dependencies
+PLUGINS="+addbookmarks +autoreplace +contactnotes +highlight latex
+otr +privacy +statistics +texteffect
++urlpicpreview webpresence"
+
+# DISABLED in kf5 until fixed: +history +nowlistening +pipes +translator
+
+# Available protocols
+#
+#	gadu: net-libs/libgadu @since 4.3
+#	groupwise: app-crypt/qca:2
+#	irc: NO DEPS, probably will fail so inform user about it
+#	xmpp: net-dns/libidn app-crypt/qca:2 ENABLED BY DEFAULT NETWORK
+#	jingle: media-libs/speex net-libs/ortp DISABLED BY UPSTREAM
+#	meanwhile: net-libs/meanwhile
+#	oscar: NO DEPS
+#   telepathy: net-libs/decibel
+#   testbed: NO DEPS
+#	winpopup: NO DEPS (we're adding samba as RDEPEND so it works)
+#	yahoo: media-libs/jasper
+#	zeroconf (bonjour): NO DEPS
+PROTOCOLS="gadu groupwise jingle meanwhile oscar
+testbed winpopup +xmpp yahoo zeroconf"
+
+# DISABLED in kf5 until fixed: skype sms
+
+# disabled protocols
+#   telepathy: net-libs/decibel
+#   irc: NO DEPS
+#   msn: net-libs/libmsn
+#	qq: NO DEPS
+
+IUSE="${IUSE} ${PLUGINS} ${PROTOCOLS}"
+
+# 	media-libs/qimageblitz
+COMMONDEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kemoticons)
+	$(add_frameworks_dep khtml)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep kparts)
+	$(add_kdeapps_dep kcontacts)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	dev-libs/libpcre
+	media-libs/phonon[qt5]
+	x11-libs/libX11
+	x11-libs/libXScrnSaver
+	gadu? ( >=net-libs/libgadu-1.8.0[threads] )
+	groupwise? ( app-crypt/qca:2[qt5] )
+	jingle? (
+		dev-libs/expat
+		dev-libs/openssl:0
+		>=media-libs/mediastreamer-2.3.0
+		media-libs/speex
+		net-libs/libsrtp
+		net-libs/ortp:=
+	)
+	meanwhile? ( net-libs/meanwhile )
+	otr? ( >=net-libs/libotr-4.0.0 )
+	statistics? ( dev-db/sqlite:3 )
+	v4l? ( media-libs/libv4l )
+	webpresence? (
+		dev-libs/libxml2
+		dev-libs/libxslt
+	)
+	xmpp? (
+		app-crypt/qca:2[qt5]
+		net-dns/libidn
+		sys-libs/zlib
+	)
+	yahoo? ( media-libs/jasper )
+	zeroconf? (
+		$(add_frameworks_dep kdnssd)
+		$(add_kdeapps_dep kidentitymanagement)
+	)
+"
+RDEPEND="${COMMONDEPEND}
+	latex? (
+		|| (
+			media-gfx/imagemagick
+			media-gfx/graphicsmagick[imagemagick]
+		)
+		virtual/latex-base
+	)
+	ssl? ( app-crypt/qca:2[ssl] )
+"
+# 	sms? ( app-mobilephone/smssend )
+# 	winpopup? ( net-fs/samba )
+DEPEND="${COMMONDEPEND}
+	x11-proto/scrnsaverproto
+	jingle? ( dev-libs/jsoncpp )
+"
+
+src_configure() {
+	local x x2
+	# Handle common stuff
+	local mycmakeargs=(
+		-DWITH_GOOGLETALK=$(usex jingle)
+		-DWITH_LiboRTP=$(usex jingle)
+		-DWITH_Mediastreamer=$(usex jingle)
+		-DWITH_Speex=$(usex jingle)
+		-DDISABLE_VIDEOSUPPORT=$(usex !v4l)
+	)
+	# enable protocols
+	for x in ${PROTOCOLS}; do
+		case ${x/+/} in
+			zeroconf) x2=bonjour ;;
+			xmpp) x2=jabber ;;
+			*) x2=${x/+/} ;;
+		esac
+		mycmakeargs+=( -DWITH_${x2}=$(usex ${x/+/}) )
+	done
+
+	mycmakeargs+=( -DWITH_Libmsn=OFF -DWITH_qq=OFF )
+
+	# disable in kf5 until fixed:
+	mycmakeargs+=( -DWITH_{history,nowlistening,skype,sms}=OFF )
+
+	# enable plugins
+	for x in ${PLUGINS}; do
+		mycmakeargs+=( -DWITH_${x/+/}=$(usex ${x/+/}) )
+	done
+
+	kde5_src_configure
+}
+
+pkg_postinst() {
+	kde5_pkg_postinst
+
+	if ! use ssl; then
+		if use xmpp ; then
+			if ! has_version "app-crypt/qca:2[ssl]" ; then
+				elog "In order to use ssl in xmpp you'll need to"
+				elog "install app-crypt/qca package with USE=ssl."
+			fi
+		fi
+	fi
+}


### PR DESCRIPTION
Just to put it out there - the ebuild has existed for some time, but I can't say it is doing much besides segfault at startup.

However, someone upstream just called it 'near complete' so maybe I'm just missing something.

Package-Manager: portage-2.2.27