### PR TITLE
kde-apps/kdecore-meta: Re-add ported baseapps

### DIFF
--- a/kde-apps/kdecore-meta/kdecore-meta-16.12.49.9999.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-16.12.49.9999.ebuild
@@ -14,6 +14,10 @@ IUSE="+handbook nls"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
+	$(add_kdeapps_dep kdialog)
+	$(add_kdeapps_dep keditbookmarks)
+	$(add_kdeapps_dep kfind)
+	$(add_kdeapps_dep konqueror)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )

--- a/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-9999.ebuild
@@ -14,6 +14,10 @@ IUSE="+handbook nls"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
+	$(add_kdeapps_dep kdialog)
+	$(add_kdeapps_dep keditbookmarks)
+	$(add_kdeapps_dep kfind)
+	$(add_kdeapps_dep konqueror)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
 	handbook? ( $(add_kdeapps_dep khelpcenter) )


### PR DESCRIPTION
Historically, these were part of kdebase-meta.

Package-Manager: portage-2.3.0