### PR TITLE
kde-misc/kolor-manager: Drop unused DEPEND

### DIFF
--- a/kde-misc/kolor-manager/kolor-manager-9999.ebuild
+++ b/kde-misc/kolor-manager/kolor-manager-9999.ebuild
@@ -16,7 +16,6 @@ IUSE=""
 DEPEND="
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
 	$(add_frameworks_dep ki18n)
 	$(add_qt_dep qtwidgets)
 	media-gfx/synnefo


### PR DESCRIPTION
Package-Manager: portage-2.3.0