### PR TITLE
kde-apps/kget: Drop USE=gpg

### DIFF
--- a/kde-apps/kget/kget-16.11.90.ebuild
+++ b/kde-apps/kget/kget-16.11.90.ebuild
@@ -10,13 +10,12 @@ inherit kde4-base
 DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="debug bittorrent gpg mms sqlite"
+IUSE="debug bittorrent mms sqlite"
 
 RDEPEND="
 	$(add_kdeapps_dep libkonq)
 	app-crypt/qca:2[qt4]
 	bittorrent? ( >=net-libs/libktorrent-1.0.3:4 )
-	gpg? ( || ( $(add_kdeapps_dep gpgmepp) $(add_kdeapps_dep kdepimlibs) ) )
 	mms? ( media-libs/libmms )
 	sqlite? ( dev-db/sqlite:3 )
 "
@@ -29,8 +28,8 @@ src_configure() {
 		-DWITH_KDE4Workspace=OFF
 		-DWITH_NepomukCore=OFF
 		-DWITH_NepomukWidgets=OFF
+		-DWITH_QGpgme=OFF
 		-DWITH_KTorrent=$(usex bittorrent)
-		-DWITH_QGpgme=$(usex gpg)
 		-DWITH_LibMms=$(usex mms)
 		-DWITH_Sqlite=$(usex sqlite)
 	)

--- a/kde-apps/kget/kget-16.12.49.9999.ebuild
+++ b/kde-apps/kget/kget-16.12.49.9999.ebuild
@@ -10,13 +10,12 @@ inherit kde4-base
 DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
-IUSE="debug bittorrent gpg mms sqlite"
+IUSE="debug bittorrent mms sqlite"
 
 RDEPEND="
 	$(add_kdeapps_dep libkonq)
 	app-crypt/qca:2[qt4]
 	bittorrent? ( >=net-libs/libktorrent-1.0.3:4 )
-	gpg? ( || ( $(add_kdeapps_dep gpgmepp) $(add_kdeapps_dep kdepimlibs) ) )
 	mms? ( media-libs/libmms )
 	sqlite? ( dev-db/sqlite:3 )
 "
@@ -29,8 +28,8 @@ src_configure() {
 		-DWITH_KDE4Workspace=OFF
 		-DWITH_NepomukCore=OFF
 		-DWITH_NepomukWidgets=OFF
+		-DWITH_QGpgme=OFF
 		-DWITH_KTorrent=$(usex bittorrent)
-		-DWITH_QGpgme=$(usex gpg)
 		-DWITH_LibMms=$(usex mms)
 		-DWITH_Sqlite=$(usex sqlite)
 	)

--- a/kde-apps/kget/kget-9999.ebuild
+++ b/kde-apps/kget/kget-9999.ebuild
@@ -10,13 +10,12 @@ inherit kde4-base
 DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://www.kde.org/applications/internet/kget/"
 KEYWORDS=""
-IUSE="debug bittorrent gpg mms sqlite"
+IUSE="debug bittorrent mms sqlite"
 
 RDEPEND="
 	$(add_kdeapps_dep libkonq)
 	app-crypt/qca:2[qt4]
 	bittorrent? ( >=net-libs/libktorrent-1.0.3:4 )
-	gpg? ( || ( $(add_kdeapps_dep gpgmepp) $(add_kdeapps_dep kdepimlibs) ) )
 	mms? ( media-libs/libmms )
 	sqlite? ( dev-db/sqlite:3 )
 "
@@ -29,8 +28,8 @@ src_configure() {
 		-DWITH_KDE4Workspace=OFF
 		-DWITH_NepomukCore=OFF
 		-DWITH_NepomukWidgets=OFF
+		-DWITH_QGpgme=OFF
 		-DWITH_KTorrent=$(usex bittorrent)
-		-DWITH_QGpgme=$(usex gpg)
 		-DWITH_LibMms=$(usex mms)
 		-DWITH_Sqlite=$(usex sqlite)
 	)

--- a/kde-apps/kget/metadata.xml
+++ b/kde-apps/kget/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="bittorrent">Enable bittorrent transfer plugin through <pkg>net-libs/libktorrent</pkg></flag>
-		<flag name="gpg">Enable signature verification by QGpgME via <pkg>kde-apps/gpgmepp</pkg> or <pkg>kde-apps/kdepimlibs</pkg></flag>
+		<flag name="gpg">Enable signature verification by GpgME++ via <pkg>app-crypt/gpgme</pkg></flag>
 		<flag name="mms">Enable MMS (Microsoft Media Server) plugin through <pkg>media-libs/libmms</pkg></flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
It conflicts with >=app-crypt/gpgme-1.7.0 and KDE PIM 5.

Package-Manager: portage-2.3.0