### PR TITLE
kde-misc/krusader: Add USE=kde for kde-apps/kio-extras, add elog msgs

### DIFF
--- a/kde-misc/krusader/krusader-9999.ebuild
+++ b/kde-misc/krusader/krusader-9999.ebuild
@@ -7,13 +7,13 @@ EAPI=6
 KDE_HANDBOOK="forceoptional"
 inherit kde5
 
-DESCRIPTION="An advanced twin-panel (commander-style) file-manager with many extras"
+DESCRIPTION="Advanced twin-panel (commander-style) file-manager with many extras"
 HOMEPAGE="https://krusader.org/"
 [[ ${KDE_BUILD_TYPE} = release ]] && SRC_URI="mirror://kde/stable/${PN}/${PV}/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 KEYWORDS=""
-IUSE=""
+IUSE="kde"
 
 DEPEND="
 	$(add_frameworks_dep karchive)
@@ -47,5 +47,25 @@ DEPEND="
 	sys-libs/zlib
 "
 RDEPEND="${DEPEND}
+	kde? ( $(add_kdeapps_dep kio-extras) )
 	!kde-misc/krusader:4
 "
+
+pkg_postinst() {
+	kde5_pkg_postinst
+
+	if ! use kde && ! has_version kde-apps/kio-extras:${SLOT} ; then
+		elog "Install without USE=kde means missing thumbnails and protocol support (fish, nfs, sftp etc.)!"
+	fi
+
+	if ! has_version kde-apps/thumbnailers:${SLOT} ||
+			! has_version kde-apps/ffmpegthumbs:${SLOT} ; then
+		elog "For PDF/PS, RAW and video thumbnails support, install:"
+		elog "   kde-apps/thumbnailers:${SLOT}"
+		elog "   kde-apps/ffmpegthumbs:${SLOT}"
+	fi
+
+	if ! has_version kde-apps/keditbookmarks:${SLOT} ; then
+		elog "For bookmarks support, install kde-apps/keditbookmarks:${SLOT}"
+	fi
+}


### PR DESCRIPTION
Keep kio-extras optional but warn about what is going to be missing.
Add elog info about optional thumbnails support.

Gentoo-bug: 602046

Package-Manager: portage-2.3.0