### PR TITLE
kde-apps/okular: Raise DEPEND to >=app-text/poppler-0.50.0

### DIFF
--- a/kde-apps/okular/okular-9999.ebuild
+++ b/kde-apps/okular/okular-9999.ebuild
@@ -47,7 +47,7 @@ DEPEND="
 		virtual/jpeg:0
 	)
 	mobi? ( $(add_kdeapps_dep kdegraphics-mobipocket) )
-	pdf? ( app-text/poppler[qt5,-exceptions(-)] )
+	pdf? ( >=app-text/poppler-0.50.0[qt5,-exceptions(-)] )
 	postscript? ( app-text/libspectre )
 	speech? ( $(add_qt_dep qtspeech) )
 	tiff? ( media-libs/tiff:0 )


### PR DESCRIPTION
okular already ifdefs support for latest poppler version, rather than
add another subslot operator, just raise the minimum version.

Upstream commit 2868e3e5ca802dd4decfdeb1dded82394a4c34b6

Package-Manager: portage-2.3.0