### PR TITLE
kde-apps/akonadi: Update MySQL 5.6 crash patch

### DIFF
--- a/kde-apps/akonadi/akonadi-9999.ebuild
+++ b/kde-apps/akonadi/akonadi-9999.ebuild
@@ -58,7 +58,7 @@ RDEPEND="${COMMON_DEPEND}
 # some akonadi tests time out, that probably needs more work as it's ~700 tests
 RESTRICT+=" test"
 
-PATCHES=( "${FILESDIR}/${PN}-16.12.0-mysql56-crash.patch" )
+PATCHES=( "${FILESDIR}/${PN}-17.03.80-mysql56-crash.patch" )
 
 pkg_setup() {
 	# Set default storage backend in order: MySQL, SQLite PostgreSQL

--- a/kde-apps/akonadi/files/akonadi-17.03.80-mysql56-crash.patch
+++ b/kde-apps/akonadi/files/akonadi-17.03.80-mysql56-crash.patch
@@ -1,0 +1,40 @@
+Gentoo-bug: 530012
+
+diff --git a/src/server/storage/dbconfigmysql.cpp b/src/server/storage/dbconfigmysql.cpp
+index 50421714d..dfae09c20 100644
+--- a/src/server/storage/dbconfigmysql.cpp
++++ b/src/server/storage/dbconfigmysql.cpp
+@@ -81,6 +81,7 @@ bool DbConfigMysql::init(QSettings &settings)
+                                          << QStringLiteral("/usr/local/sbin")
+                                          << QStringLiteral("/usr/local/libexec")
+                                          << QStringLiteral("/usr/libexec")
++                                         << QStringLiteral("/usr/share/mysql/scripts")
+                                          << QStringLiteral("/opt/mysql/libexec")
+                                          << QStringLiteral("/opt/local/lib/mysql5/bin")
+                                          << QStringLiteral("/opt/mysql/sbin");
+@@ -511,7 +512,7 @@ bool DbConfigMysql::initializeMariaDBDatabase(const QString &confFile, const QSt
+     return 0 == execute(mMysqlInstallDbPath, {
+         QStringLiteral("--defaults-file=%1").arg(confFile),
+         QStringLiteral("--force"),
+-        QStringLiteral("--basedir=%1").arg(baseDir),
++        QStringLiteral("--basedir=/usr"),
+         QStringLiteral("--datadir=%1/").arg(dataDir)
+     });
+ }
+@@ -525,6 +526,7 @@ bool DbConfigMysql::initializeMySQL5_7_6Database(const QString &confFile, const
+     return 0 == execute(mMysqldPath, {
+         QStringLiteral("--defaults-file=%1").arg(confFile),
+         QStringLiteral("--initialize"),
++        QStringLiteral("--basedir=/usr"),
+         QStringLiteral("--datadir=%1/").arg(dataDir)
+     });
+ }
+@@ -539,7 +541,7 @@ bool DbConfigMysql::initializeMySQLDatabase(const QString &confFile, const QStri
+     // Don't use --force, it has been removed in MySQL 5.7.5
+     return 0 == execute(mMysqlInstallDbPath, {
+         QStringLiteral("--defaults-file=%1").arg(confFile),
+-        QStringLiteral("--basedir=%1").arg(baseDir),
++        QStringLiteral("--basedir=/usr"),
+         QStringLiteral("--datadir=%1/").arg(dataDir)
+     });
+ }


### PR DESCRIPTION
Upstream changed the code style in [ddf0db43](https://cgit.kde.org/akonadi.git/commit/src/server/storage/dbconfigmysql.cpp?id=ddf0db4305e6cfcc8c5c91d20f4989e2903fce7a)

Package-Manager: Portage-2.3.0, Repoman-2.3.1