### PR TITLE
games-board/knights: fix LICENSE, add SELinux module, add USE=speech

### DIFF
--- a/games-board/knights/knights-9999.ebuild
+++ b/games-board/knights/knights-9999.ebuild
@@ -6,14 +6,15 @@ EAPI=6
 
 KDE_GCC_MINIMAL="4.9"
 KDE_HANDBOOK="forceoptional"
+KDE_SELINUX_MODULE="games"
 inherit kde5
 
 DESCRIPTION="Simple chess board for KDE"
 HOMEPAGE="http://kde-apps.org/content/show.php/Knights?content=122046"
 
-LICENSE="GPL-3"
+LICENSE="GPL-2+"
 KEYWORDS=""
-IUSE=""
+IUSE="speech"
 
 DEPEND="
 	$(add_frameworks_dep kcompletion)
@@ -35,6 +36,7 @@ DEPEND="
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtnetwork)
+	speech? ( $(add_qt_dep qtspeech) )
 	$(add_qt_dep qtsvg)
 	$(add_qt_dep qtwidgets)
 "

--- a/games-board/knights/metadata.xml
+++ b/games-board/knights/metadata.xml
@@ -9,4 +9,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<use>
+		<flag name="speech">Enable text-to-speech support</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
* License is GPL-2+ as noted [in upstream source files](https://cgit.kde.org/knights.git/tree/src/board.cpp) and its [AppData XML manifest](https://cgit.kde.org/knights.git/tree/src/org.kde.knights.appdata.xml#n5).

* Package was missing KDE_SELINUX_MODULE="games" as other KDE Games packages have

* Upstream supports QtSpeech for speaking opponent moves

Package-Manager: portage-2.3.1