### PR TITLE
sys-libs/kpmcore: Drop unused DEPEND

### DIFF
--- a/sys-libs/kpmcore/kpmcore-9999.ebuild
+++ b/sys-libs/kpmcore/kpmcore-9999.ebuild
@@ -19,7 +19,6 @@ IUSE=""
 RDEPEND="
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
-	$(add_frameworks_dep kservice)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)


### PR DESCRIPTION
Upstream commit: 722ef62ebbcc539add1b324a8feca49d20db5e97