### PR TITLE
sys-libs/kpmcore: Update dependencies

### DIFF
--- a/sys-libs/kpmcore/kpmcore-9999.ebuild
+++ b/sys-libs/kpmcore/kpmcore-9999.ebuild
@@ -17,15 +17,15 @@ SLOT="5/8"
 IUSE=""
 
 RDEPEND="
+	$(add_frameworks_dep kauth)
 	$(add_frameworks_dep kcoreaddons)
 	$(add_frameworks_dep ki18n)
 	$(add_frameworks_dep kwidgetsaddons)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)
 	$(add_qt_dep qtwidgets)
-	dev-libs/libatasmart
-	>=sys-apps/util-linux-2.30
-	>=sys-block/parted-3
+	|| ( app-crypt/qca[botan] app-crypt/qca[ssl] )
+	>=sys-apps/util-linux-2.32
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig


### PR DESCRIPTION
libatasmart was in principle replaced with smartmontools 6.7 (-9999 for now) but it is optional runtime dependency, so not included. Similarly for fatresize...