### PR TITLE
kde-apps/{kldap,libksieve}: fix use_if_iuse usage

### DIFF
--- a/kde-apps/kldap/kldap-18.08.49.9999.ebuild
+++ b/kde-apps/kldap/kldap-18.08.49.9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="${DEPEND}
 src_prepare() {
 	kde5_src_prepare
 
-	if ! use_if_iuse handbook ; then
+	if ! use handbook ; then
 		sed -e "/add_subdirectory(doc)/I s/^/#DONOTCOMPILE /" \
 			-i kioslave/CMakeLists.txt || die "failed to comment add_subdirectory(doc)"
 	fi

--- a/kde-apps/kldap/kldap-9999.ebuild
+++ b/kde-apps/kldap/kldap-9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="${DEPEND}
 src_prepare() {
 	kde5_src_prepare
 
-	if ! use_if_iuse handbook ; then
+	if ! use handbook ; then
 		sed -e "/add_subdirectory(doc)/I s/^/#DONOTCOMPILE /" \
 			-i kioslave/CMakeLists.txt || die "failed to comment add_subdirectory(doc)"
 	fi

--- a/kde-apps/libksieve/libksieve-18.08.49.9999.ebuild
+++ b/kde-apps/libksieve/libksieve-18.08.49.9999.ebuild
@@ -53,7 +53,7 @@ RESTRICT+=" test"
 src_prepare() {
 	kde5_src_prepare
 
-	if ! use_if_iuse handbook ; then
+	if ! use handbook ; then
 		sed -e "/add_subdirectory(doc)/I s/^/#DONOTCOMPILE /" \
 			-i kioslave/CMakeLists.txt || die "failed to comment add_subdirectory(doc)"
 	fi

--- a/kde-apps/libksieve/libksieve-9999.ebuild
+++ b/kde-apps/libksieve/libksieve-9999.ebuild
@@ -53,7 +53,7 @@ RESTRICT+=" test"
 src_prepare() {
 	kde5_src_prepare
 
-	if ! use_if_iuse handbook ; then
+	if ! use handbook ; then
 		sed -e "/add_subdirectory(doc)/I s/^/#DONOTCOMPILE /" \
 			-i kioslave/CMakeLists.txt || die "failed to comment add_subdirectory(doc)"
 	fi


### PR DESCRIPTION
Hi,

Both packages (kldap, libksieve) using the function ```use_if_iuse``` from the ```eutils``` eclass but doesn't inherit it. This PR fixes that.

please review.