### PR TITLE
media-sound/amarok: remove unused eclass

### DIFF
--- a/media-sound/amarok/amarok-9999.ebuild
+++ b/media-sound/amarok/amarok-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 KDE_HANDBOOK="true"
-inherit flag-o-matic kde5 pax-utils
+inherit kde5 pax-utils
 
 DESCRIPTION="Advanced audio player based on KDE frameworks"
 HOMEPAGE="https://amarok.kde.org/"


### PR DESCRIPTION
Hi,

As far as i can see ```flag-o-matic``` isn't used by this ebuild. Guess we can remove the inherit?
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>