### PR TITLE
Include media-libs/eglexternalplatform for testing

### DIFF
--- a/media-libs/eglexternalplatform/eglexternalplatform-9999.ebuild
+++ b/media-libs/eglexternalplatform/eglexternalplatform-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2019 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit
+
+if [[ ${PV} == "9999" ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/NVIDIA/eglexternalplatform.git"
+fi
+
+DESCRIPTION="The EGL External Platform interface"
+HOMEPAGE="https://github.com/NVIDIA/eglexternalplatform"
+
+LICENSE="MIT"
+SLOT="0"
+
+IUSE="examples"
+
+src_install() {
+	einstalldocs
+
+	doheader -r interface/.
+	insinto /usr/$(get_libdir)/pkgconfig/
+	doins eglexternalplatform.pc
+
+	if use examples; then
+		docinto samples
+		dodoc samples/*.c
+	fi
+}

--- a/media-libs/eglexternalplatform/metadata.xml
+++ b/media-libs/eglexternalplatform/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">NVIDIA/eglexternalplatform</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
A patch for initial implementation of an eglstream DRM backend for the proprietary Nvidia driver has been accepted upstream.  One of the build requirements, from [D18570](https://phabricator.kde.org/D18570):

> Ensure EGL external platform support is installed https://github.com/NVIDIA/eglexternalplatform


This PR adds that header library for testing.

Package-Manager: Portage-2.3.65, Repoman-2.3.12