### PR TITLE
sets: Update KDE Multimedia 19.12 set to fix typo

### DIFF
--- a/sets/kdemultimedia-19.12
+++ b/sets/kdemultimedia-19.12
@@ -5,7 +5,7 @@
 <kde-apps/k3b-19.12.50
 <kde-apps/kamoso-19.12.50
 <kde-apps/kdemultimedia-meta-19.12.50
-<kde-apps/kden19.12-19.12.50
+<kde-apps/kdenlive-19.12.50
 <kde-apps/kmix-19.12.50
 <kde-apps/kwave-19.12.50
 <kde-apps/libkcddb-19.12.50


### PR DESCRIPTION
Looks like live was replaced with 19.12 in this name.

Signed-off-by: M. David Bennett <mdavidbennett@syntheticworks.com>