### PR TITLE
kde-plasma/kwayland-server: add ~ppc64 keyword

### DIFF
--- a/kde-plasma/kwayland-server/kwayland-server-5.18.90.ebuild
+++ b/kde-plasma/kwayland-server/kwayland-server-5.18.90.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://invent.kde.org/plasma/kwayland-server"
 
 LICENSE="LGPL-2.1"
 SLOT="5"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~ppc64"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>