### PR TITLE
sys-libs/kpmcore: remove kde-frameworks/kauth build time dependency.

### DIFF
--- a/sys-libs/kpmcore/kpmcore-9999.ebuild
+++ b/sys-libs/kpmcore/kpmcore-9999.ebuild
@@ -16,10 +16,7 @@ SLOT="5/10"
 KEYWORDS=""
 IUSE=""
 
-BDEPEND="
-	>=kde-frameworks/kauth-${KFMIN}:5
-	virtual/pkgconfig
-"
+BDEPEND="virtual/pkgconfig"
 DEPEND="
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtgui-${QTMIN}:5


### PR DESCRIPTION
Upstream commit: https://invent.kde.org/system/kpmcore/-/commit/68fdf2fcf2ea57850c05365efe3a1d657c90227c

Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Andrius Štikonas <andrius@stikonas.eu>