### PR TITLE
kde-misc/skanpage: import from ::guru

### DIFF
--- a/media-gfx/skanpage/metadata.xml
+++ b/media-gfx/skanpage/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+</pkgmetadata>

--- a/media-gfx/skanpage/skanpage-22.04.49.9999.ebuild
+++ b/media-gfx/skanpage/skanpage-22.04.49.9999.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+KDE_ORG_CATEGORY="utilities"
+PVCUT=$(ver_cut 1-3)
+KFMIN=5.91
+QTMIN=5.15.2
+inherit ecm kde.org
+
+DESCRIPTION="Multi-page scanning application supporting image and pdf files"
+HOMEPAGE="https://apps.kde.org/skanpage/"
+
+LICENSE="|| ( GPL-2 GPL-3 ) CC0-1.0"
+SLOT="5"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	>=dev-qt/qtconcurrent-${QTMIN}:5
+	>=dev-qt/qtcore-${QTMIN}:5
+	>=dev-qt/qtdeclarative-${QTMIN}:5
+	>=dev-qt/qtgui-${QTMIN}:5
+	>=dev-qt/qtnetwork-${QTMIN}:5
+	>=dev-qt/qtprintsupport-${QTMIN}:5
+	>=dev-qt/qtquickcontrols2-${QTMIN}:5
+	>=dev-qt/qtwidgets-${QTMIN}:5
+	>=kde-apps/libksane-${PVCUT}:5
+	>=kde-frameworks/kconfig-${KFMIN}:5
+	>=kde-frameworks/kcoreaddons-${KFMIN}:5
+	>=kde-frameworks/kcrash-${KFMIN}:5
+	>=kde-frameworks/ki18n-${KFMIN}:5
+	>=kde-frameworks/kio-${KFMIN}:5
+	>=kde-frameworks/kirigami-${KFMIN}:5
+	>=kde-frameworks/kjobwidgets-${KFMIN}:5
+	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
+	>=kde-frameworks/kxmlgui-${KFMIN}:5
+	>=kde-frameworks/purpose-${KFMIN}:5
+"
+RDEPEND="${DEPEND}"

--- a/media-gfx/skanpage/skanpage-9999.ebuild
+++ b/media-gfx/skanpage/skanpage-9999.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+KDE_ORG_CATEGORY="utilities"
+PVCUT=$(ver_cut 1-3)
+KFMIN=5.91
+QTMIN=5.15.2
+inherit ecm kde.org
+
+DESCRIPTION="Multi-page scanning application supporting image and pdf files"
+HOMEPAGE="https://apps.kde.org/skanpage/"
+
+LICENSE="|| ( GPL-2 GPL-3 ) CC0-1.0"
+SLOT="5"
+KEYWORDS=""
+IUSE=""
+
+DEPEND="
+	>=dev-qt/qtconcurrent-${QTMIN}:5
+	>=dev-qt/qtcore-${QTMIN}:5
+	>=dev-qt/qtdeclarative-${QTMIN}:5
+	>=dev-qt/qtgui-${QTMIN}:5
+	>=dev-qt/qtnetwork-${QTMIN}:5
+	>=dev-qt/qtprintsupport-${QTMIN}:5
+	>=dev-qt/qtquickcontrols2-${QTMIN}:5
+	>=dev-qt/qtwidgets-${QTMIN}:5
+	>=kde-apps/libksane-${PVCUT}:5
+	>=kde-frameworks/kconfig-${KFMIN}:5
+	>=kde-frameworks/kcoreaddons-${KFMIN}:5
+	>=kde-frameworks/kcrash-${KFMIN}:5
+	>=kde-frameworks/ki18n-${KFMIN}:5
+	>=kde-frameworks/kio-${KFMIN}:5
+	>=kde-frameworks/kirigami-${KFMIN}:5
+	>=kde-frameworks/kjobwidgets-${KFMIN}:5
+	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
+	>=kde-frameworks/kxmlgui-${KFMIN}:5
+	>=kde-frameworks/purpose-${KFMIN}:5
+"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
A scanning application similar to skanlite, but unlike skanlite it supports scanning to pdf and re-ordering the scanned pages.

No release yet, but it already works pretty well, there is also a snapshot ebuild for skanpage in ::guru

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>