### PR TITLE
kde-apps/*: remove obsolete Homepage

### DIFF
--- a/kde-apps/katomic/katomic-22.03.90.ebuild
+++ b/kde-apps/katomic/katomic-22.03.90.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Atomic Entertainment Game"
-HOMEPAGE="https://apps.kde.org/katomic/ https://games.kde.org/games/katomic/"
+HOMEPAGE="https://apps.kde.org/katomic/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/katomic/katomic-22.04.0.ebuild
+++ b/kde-apps/katomic/katomic-22.04.0.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Atomic Entertainment Game"
-HOMEPAGE="https://apps.kde.org/katomic/ https://games.kde.org/games/katomic/"
+HOMEPAGE="https://apps.kde.org/katomic/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/katomic/katomic-22.04.49.9999.ebuild
+++ b/kde-apps/katomic/katomic-22.04.49.9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Atomic Entertainment Game"
-HOMEPAGE="https://apps.kde.org/katomic/ https://games.kde.org/games/katomic/"
+HOMEPAGE="https://apps.kde.org/katomic/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/katomic/katomic-9999.ebuild
+++ b/kde-apps/katomic/katomic-9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Atomic Entertainment Game"
-HOMEPAGE="https://apps.kde.org/katomic/ https://games.kde.org/games/katomic/"
+HOMEPAGE="https://apps.kde.org/katomic/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbounce/kbounce-22.03.90.ebuild
+++ b/kde-apps/kbounce/kbounce-22.03.90.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Bounce Ball Game"
-HOMEPAGE="https://apps.kde.org/kbounce/ https://games.kde.org/games/kbounce/"
+HOMEPAGE="https://apps.kde.org/kbounce/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbounce/kbounce-22.04.0.ebuild
+++ b/kde-apps/kbounce/kbounce-22.04.0.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Bounce Ball Game"
-HOMEPAGE="https://apps.kde.org/kbounce/ https://games.kde.org/games/kbounce/"
+HOMEPAGE="https://apps.kde.org/kbounce/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbounce/kbounce-22.04.49.9999.ebuild
+++ b/kde-apps/kbounce/kbounce-22.04.49.9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Bounce Ball Game"
-HOMEPAGE="https://apps.kde.org/kbounce/ https://games.kde.org/games/kbounce/"
+HOMEPAGE="https://apps.kde.org/kbounce/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbounce/kbounce-9999.ebuild
+++ b/kde-apps/kbounce/kbounce-9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE Bounce Ball Game"
-HOMEPAGE="https://apps.kde.org/kbounce/ https://games.kde.org/games/kbounce/"
+HOMEPAGE="https://apps.kde.org/kbounce/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbreakout/kbreakout-22.03.90.ebuild
+++ b/kde-apps/kbreakout/kbreakout-22.03.90.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Breakout-like game by KDE"
-HOMEPAGE="https://apps.kde.org/kbreakout/
-https://games.kde.org/games/kbreakout/"
+HOMEPAGE="https://apps.kde.org/kbreakout/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbreakout/kbreakout-22.04.0.ebuild
+++ b/kde-apps/kbreakout/kbreakout-22.04.0.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Breakout-like game by KDE"
-HOMEPAGE="https://apps.kde.org/kbreakout/
-https://games.kde.org/games/kbreakout/"
+HOMEPAGE="https://apps.kde.org/kbreakout/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbreakout/kbreakout-22.04.49.9999.ebuild
+++ b/kde-apps/kbreakout/kbreakout-22.04.49.9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Breakout-like game by KDE"
-HOMEPAGE="https://apps.kde.org/kbreakout/
-https://games.kde.org/games/kbreakout/"
+HOMEPAGE="https://apps.kde.org/kbreakout/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kbreakout/kbreakout-9999.ebuild
+++ b/kde-apps/kbreakout/kbreakout-9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Breakout-like game by KDE"
-HOMEPAGE="https://apps.kde.org/kbreakout/
-https://games.kde.org/games/kbreakout/"
+HOMEPAGE="https://apps.kde.org/kbreakout/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kdegames-meta/kdegames-meta-22.03.90.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-22.03.90.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
-HOMEPAGE="https://games.kde.org/"
+HOMEPAGE="https://apps.kde.org/categories/games/"
 
 LICENSE="metapackage"
 SLOT="5"

--- a/kde-apps/kdegames-meta/kdegames-meta-22.04.0.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-22.04.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
-HOMEPAGE="https://games.kde.org/"
+HOMEPAGE="https://apps.kde.org/categories/games/"
 
 LICENSE="metapackage"
 SLOT="5"

--- a/kde-apps/kdegames-meta/kdegames-meta-22.04.49.9999.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-22.04.49.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
-HOMEPAGE="https://games.kde.org/"
+HOMEPAGE="https://apps.kde.org/categories/games/"
 
 LICENSE="metapackage"
 SLOT="5"

--- a/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
+++ b/kde-apps/kdegames-meta/kdegames-meta-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="kdegames - merge this to pull in all kdegames-derived packages"
-HOMEPAGE="https://games.kde.org/"
+HOMEPAGE="https://apps.kde.org/categories/games/"
 
 LICENSE="metapackage"
 SLOT="5"

--- a/kde-apps/kdiamond/kdiamond-22.03.90.ebuild
+++ b/kde-apps/kdiamond/kdiamond-22.03.90.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Single player three-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kdiamond/ https://games.kde.org/games/kdiamond/"
+HOMEPAGE="https://apps.kde.org/kdiamond/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kdiamond/kdiamond-22.04.0.ebuild
+++ b/kde-apps/kdiamond/kdiamond-22.04.0.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Single player three-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kdiamond/ https://games.kde.org/games/kdiamond/"
+HOMEPAGE="https://apps.kde.org/kdiamond/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kdiamond/kdiamond-22.04.49.9999.ebuild
+++ b/kde-apps/kdiamond/kdiamond-22.04.49.9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Single player three-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kdiamond/ https://games.kde.org/games/kdiamond/"
+HOMEPAGE="https://apps.kde.org/kdiamond/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kdiamond/kdiamond-9999.ebuild
+++ b/kde-apps/kdiamond/kdiamond-9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Single player three-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kdiamond/ https://games.kde.org/games/kdiamond/"
+HOMEPAGE="https://apps.kde.org/kdiamond/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kfourinline/kfourinline-22.03.90.ebuild
+++ b/kde-apps/kfourinline/kfourinline-22.03.90.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE four-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kfourinline/
-https://games.kde.org/games/kfourinline/"
+HOMEPAGE="https://apps.kde.org/kfourinline/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kfourinline/kfourinline-22.04.0.ebuild
+++ b/kde-apps/kfourinline/kfourinline-22.04.0.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE four-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kfourinline/
-https://games.kde.org/games/kfourinline/"
+HOMEPAGE="https://apps.kde.org/kfourinline/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kfourinline/kfourinline-22.04.49.9999.ebuild
+++ b/kde-apps/kfourinline/kfourinline-22.04.49.9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE four-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kfourinline/
-https://games.kde.org/games/kfourinline/"
+HOMEPAGE="https://apps.kde.org/kfourinline/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kfourinline/kfourinline-9999.ebuild
+++ b/kde-apps/kfourinline/kfourinline-9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE four-in-a-row game"
-HOMEPAGE="https://apps.kde.org/kfourinline/
-https://games.kde.org/games/kfourinline/"
+HOMEPAGE="https://apps.kde.org/kfourinline/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kgoldrunner/kgoldrunner-22.03.90.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Game of action and puzzle solving by KDE"
-HOMEPAGE="https://apps.kde.org/kgoldrunner/
-https://games.kde.org/games/kgoldrunner/"
+HOMEPAGE="https://apps.kde.org/kgoldrunner/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kgoldrunner/kgoldrunner-22.04.0.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Game of action and puzzle solving by KDE"
-HOMEPAGE="https://apps.kde.org/kgoldrunner/
-https://games.kde.org/games/kgoldrunner/"
+HOMEPAGE="https://apps.kde.org/kgoldrunner/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kgoldrunner/kgoldrunner-22.04.49.9999.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Game of action and puzzle solving by KDE"
-HOMEPAGE="https://apps.kde.org/kgoldrunner/
-https://games.kde.org/games/kgoldrunner/"
+HOMEPAGE="https://apps.kde.org/kgoldrunner/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kgoldrunner/kgoldrunner-9999.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Game of action and puzzle solving by KDE"
-HOMEPAGE="https://apps.kde.org/kgoldrunner/
-https://games.kde.org/games/kgoldrunner/"
+HOMEPAGE="https://apps.kde.org/kgoldrunner/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kiriki/kiriki-22.03.90.ebuild
+++ b/kde-apps/kiriki/kiriki-22.03.90.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An addictive and fun dice game"
-HOMEPAGE="https://apps.kde.org/kiriki/
-https://games.kde.org/games/kiriki/"
+HOMEPAGE="https://apps.kde.org/kiriki/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kiriki/kiriki-22.04.0.ebuild
+++ b/kde-apps/kiriki/kiriki-22.04.0.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An addictive and fun dice game"
-HOMEPAGE="https://apps.kde.org/kiriki/
-https://games.kde.org/games/kiriki/"
+HOMEPAGE="https://apps.kde.org/kiriki/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kiriki/kiriki-22.04.49.9999.ebuild
+++ b/kde-apps/kiriki/kiriki-22.04.49.9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An addictive and fun dice game"
-HOMEPAGE="https://apps.kde.org/kiriki/
-https://games.kde.org/games/kiriki/"
+HOMEPAGE="https://apps.kde.org/kiriki/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kiriki/kiriki-9999.ebuild
+++ b/kde-apps/kiriki/kiriki-9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An addictive and fun dice game"
-HOMEPAGE="https://apps.kde.org/kiriki/
-https://games.kde.org/games/kiriki/"
+HOMEPAGE="https://apps.kde.org/kiriki/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kjumpingcube/kjumpingcube-22.03.90.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Tactical one or two player game"
-HOMEPAGE="https://apps.kde.org/kjumpingcube/
-https://games.kde.org/games/kjumpingcube/"
+HOMEPAGE="https://apps.kde.org/kjumpingcube/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kjumpingcube/kjumpingcube-22.04.0.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Tactical one or two player game"
-HOMEPAGE="https://apps.kde.org/kjumpingcube/
-https://games.kde.org/games/kjumpingcube/"
+HOMEPAGE="https://apps.kde.org/kjumpingcube/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kjumpingcube/kjumpingcube-22.04.49.9999.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Tactical one or two player game"
-HOMEPAGE="https://apps.kde.org/kjumpingcube/
-https://games.kde.org/games/kjumpingcube/"
+HOMEPAGE="https://apps.kde.org/kjumpingcube/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Tactical one or two player game"
-HOMEPAGE="https://apps.kde.org/kjumpingcube/
-https://games.kde.org/games/kjumpingcube/"
+HOMEPAGE="https://apps.kde.org/kjumpingcube/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klickety/klickety-22.03.90.ebuild
+++ b/kde-apps/klickety/klickety-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An adaptation of the Clickomania game"
-HOMEPAGE="https://apps.kde.org/klickety/
-https://games.kde.org/games/klickety/"
+HOMEPAGE="https://apps.kde.org/klickety/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klickety/klickety-22.04.0.ebuild
+++ b/kde-apps/klickety/klickety-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An adaptation of the Clickomania game"
-HOMEPAGE="https://apps.kde.org/klickety/
-https://games.kde.org/games/klickety/"
+HOMEPAGE="https://apps.kde.org/klickety/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klickety/klickety-22.04.49.9999.ebuild
+++ b/kde-apps/klickety/klickety-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An adaptation of the Clickomania game"
-HOMEPAGE="https://apps.kde.org/klickety/
-https://games.kde.org/games/klickety/"
+HOMEPAGE="https://apps.kde.org/klickety/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klickety/klickety-9999.ebuild
+++ b/kde-apps/klickety/klickety-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="An adaptation of the Clickomania game"
-HOMEPAGE="https://apps.kde.org/klickety/
-https://games.kde.org/games/klickety/"
+HOMEPAGE="https://apps.kde.org/klickety/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klines/klines-22.03.90.ebuild
+++ b/kde-apps/klines/klines-22.03.90.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A little KDE game about balls and how to get rid of them"
-HOMEPAGE="https://apps.kde.org/klines/ https://games.kde.org/games/klines/"
+HOMEPAGE="https://apps.kde.org/klines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klines/klines-22.04.0.ebuild
+++ b/kde-apps/klines/klines-22.04.0.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A little KDE game about balls and how to get rid of them"
-HOMEPAGE="https://apps.kde.org/klines/ https://games.kde.org/games/klines/"
+HOMEPAGE="https://apps.kde.org/klines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klines/klines-22.04.49.9999.ebuild
+++ b/kde-apps/klines/klines-22.04.49.9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A little KDE game about balls and how to get rid of them"
-HOMEPAGE="https://apps.kde.org/klines/ https://games.kde.org/games/klines/"
+HOMEPAGE="https://apps.kde.org/klines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/klines/klines-9999.ebuild
+++ b/kde-apps/klines/klines-9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A little KDE game about balls and how to get rid of them"
-HOMEPAGE="https://apps.kde.org/klines/ https://games.kde.org/games/klines/"
+HOMEPAGE="https://apps.kde.org/klines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmahjongg/kmahjongg-22.03.90.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A tile matching game for one or two players"
-HOMEPAGE="https://apps.kde.org/kmahjongg/
-https://games.kde.org/games/kmahjongg/"
+HOMEPAGE="https://apps.kde.org/kmahjongg/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmahjongg/kmahjongg-22.04.0.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A tile matching game for one or two players"
-HOMEPAGE="https://apps.kde.org/kmahjongg/
-https://games.kde.org/games/kmahjongg/"
+HOMEPAGE="https://apps.kde.org/kmahjongg/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmahjongg/kmahjongg-22.04.49.9999.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A tile matching game for one or two players"
-HOMEPAGE="https://apps.kde.org/kmahjongg/
-https://games.kde.org/games/kmahjongg/"
+HOMEPAGE="https://apps.kde.org/kmahjongg/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmahjongg/kmahjongg-9999.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="A tile matching game for one or two players"
-HOMEPAGE="https://apps.kde.org/kmahjongg/
-https://games.kde.org/games/kmahjongg/"
+HOMEPAGE="https://apps.kde.org/kmahjongg/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmines/kmines-22.03.90.ebuild
+++ b/kde-apps/kmines/kmines-22.03.90.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Classic mine sweeper game"
-HOMEPAGE="https://apps.kde.org/kmines/ https://games.kde.org/games/kmines/"
+HOMEPAGE="https://apps.kde.org/kmines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmines/kmines-22.04.0.ebuild
+++ b/kde-apps/kmines/kmines-22.04.0.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Classic mine sweeper game"
-HOMEPAGE="https://apps.kde.org/kmines/ https://games.kde.org/games/kmines/"
+HOMEPAGE="https://apps.kde.org/kmines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmines/kmines-22.04.49.9999.ebuild
+++ b/kde-apps/kmines/kmines-22.04.49.9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Classic mine sweeper game"
-HOMEPAGE="https://apps.kde.org/kmines/ https://games.kde.org/games/kmines/"
+HOMEPAGE="https://apps.kde.org/kmines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kmines/kmines-9999.ebuild
+++ b/kde-apps/kmines/kmines-9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Classic mine sweeper game"
-HOMEPAGE="https://apps.kde.org/kmines/ https://games.kde.org/games/kmines/"
+HOMEPAGE="https://apps.kde.org/kmines/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knavalbattle/knavalbattle-22.03.90.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Battleship clone by KDE"
-HOMEPAGE="https://apps.kde.org/knavalbattle/
-https://games.kde.org/games/kbattleship/"
+HOMEPAGE="https://apps.kde.org/knavalbattle/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knavalbattle/knavalbattle-22.04.0.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Battleship clone by KDE"
-HOMEPAGE="https://apps.kde.org/knavalbattle/
-https://games.kde.org/games/kbattleship/"
+HOMEPAGE="https://apps.kde.org/knavalbattle/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knavalbattle/knavalbattle-22.04.49.9999.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Battleship clone by KDE"
-HOMEPAGE="https://apps.kde.org/knavalbattle/
-https://games.kde.org/games/kbattleship/"
+HOMEPAGE="https://apps.kde.org/knavalbattle/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knavalbattle/knavalbattle-9999.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Battleship clone by KDE"
-HOMEPAGE="https://apps.kde.org/knavalbattle/
-https://games.kde.org/games/kbattleship/"
+HOMEPAGE="https://apps.kde.org/knavalbattle/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knetwalk/knetwalk-22.03.90.ebuild
+++ b/kde-apps/knetwalk/knetwalk-22.03.90.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"
-HOMEPAGE="https://apps.kde.org/knetwalk/
-https://games.kde.org/games/knetwalk/"
+HOMEPAGE="https://apps.kde.org/knetwalk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knetwalk/knetwalk-22.04.0.ebuild
+++ b/kde-apps/knetwalk/knetwalk-22.04.0.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"
-HOMEPAGE="https://apps.kde.org/knetwalk/
-https://games.kde.org/games/knetwalk/"
+HOMEPAGE="https://apps.kde.org/knetwalk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knetwalk/knetwalk-22.04.49.9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-22.04.49.9999.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"
-HOMEPAGE="https://apps.kde.org/knetwalk/
-https://games.kde.org/games/knetwalk/"
+HOMEPAGE="https://apps.kde.org/knetwalk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/knetwalk/knetwalk-9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-9999.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"
-HOMEPAGE="https://apps.kde.org/knetwalk/
-https://games.kde.org/games/knetwalk/"
+HOMEPAGE="https://apps.kde.org/knetwalk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kolf/kolf-22.03.90.ebuild
+++ b/kde-apps/kolf/kolf-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Minigolf game by KDE"
-HOMEPAGE="https://apps.kde.org/kolf/
-https://games.kde.org/games/kolf/"
+HOMEPAGE="https://apps.kde.org/kolf/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kolf/kolf-22.04.0.ebuild
+++ b/kde-apps/kolf/kolf-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Minigolf game by KDE"
-HOMEPAGE="https://apps.kde.org/kolf/
-https://games.kde.org/games/kolf/"
+HOMEPAGE="https://apps.kde.org/kolf/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kolf/kolf-22.04.49.9999.ebuild
+++ b/kde-apps/kolf/kolf-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Minigolf game by KDE"
-HOMEPAGE="https://apps.kde.org/kolf/
-https://games.kde.org/games/kolf/"
+HOMEPAGE="https://apps.kde.org/kolf/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kolf/kolf-9999.ebuild
+++ b/kde-apps/kolf/kolf-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Minigolf game by KDE"
-HOMEPAGE="https://apps.kde.org/kolf/
-https://games.kde.org/games/kolf/"
+HOMEPAGE="https://apps.kde.org/kolf/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kollision/kollision-22.03.90.ebuild
+++ b/kde-apps/kollision/kollision-22.03.90.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Simple ball dodging game"
-HOMEPAGE="https://apps.kde.org/kollision/
-https://games.kde.org/games/kollision/"
+HOMEPAGE="https://apps.kde.org/kollision/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kollision/kollision-22.04.0.ebuild
+++ b/kde-apps/kollision/kollision-22.04.0.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Simple ball dodging game"
-HOMEPAGE="https://apps.kde.org/kollision/
-https://games.kde.org/games/kollision/"
+HOMEPAGE="https://apps.kde.org/kollision/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kollision/kollision-22.04.49.9999.ebuild
+++ b/kde-apps/kollision/kollision-22.04.49.9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Simple ball dodging game"
-HOMEPAGE="https://apps.kde.org/kollision/
-https://games.kde.org/games/kollision/"
+HOMEPAGE="https://apps.kde.org/kollision/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kollision/kollision-9999.ebuild
+++ b/kde-apps/kollision/kollision-9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Simple ball dodging game"
-HOMEPAGE="https://apps.kde.org/kollision/
-https://games.kde.org/games/kollision/"
+HOMEPAGE="https://apps.kde.org/kollision/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/konquest/konquest-22.03.90.ebuild
+++ b/kde-apps/konquest/konquest-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Galactic Strategy KDE Game"
-HOMEPAGE="https://apps.kde.org/konquest/
-https://games.kde.org/games/konquest/"
+HOMEPAGE="https://apps.kde.org/konquest/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/konquest/konquest-22.04.0.ebuild
+++ b/kde-apps/konquest/konquest-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Galactic Strategy KDE Game"
-HOMEPAGE="https://apps.kde.org/konquest/
-https://games.kde.org/games/konquest/"
+HOMEPAGE="https://apps.kde.org/konquest/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/konquest/konquest-22.04.49.9999.ebuild
+++ b/kde-apps/konquest/konquest-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Galactic Strategy KDE Game"
-HOMEPAGE="https://apps.kde.org/konquest/
-https://games.kde.org/games/konquest/"
+HOMEPAGE="https://apps.kde.org/konquest/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/konquest/konquest-9999.ebuild
+++ b/kde-apps/konquest/konquest-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Galactic Strategy KDE Game"
-HOMEPAGE="https://apps.kde.org/konquest/
-https://games.kde.org/games/konquest/"
+HOMEPAGE="https://apps.kde.org/konquest/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kpat/kpat-22.03.90.ebuild
+++ b/kde-apps/kpat/kpat-22.03.90.ebuild
@@ -13,8 +13,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE patience game"
-HOMEPAGE="https://apps.kde.org/kpat/
-https://games.kde.org/games/kpat/"
+HOMEPAGE="https://apps.kde.org/kpat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kpat/kpat-22.04.0.ebuild
+++ b/kde-apps/kpat/kpat-22.04.0.ebuild
@@ -13,8 +13,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE patience game"
-HOMEPAGE="https://apps.kde.org/kpat/
-https://games.kde.org/games/kpat/"
+HOMEPAGE="https://apps.kde.org/kpat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kpat/kpat-22.04.49.9999.ebuild
+++ b/kde-apps/kpat/kpat-22.04.49.9999.ebuild
@@ -13,8 +13,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE patience game"
-HOMEPAGE="https://apps.kde.org/kpat/
-https://games.kde.org/games/kpat/"
+HOMEPAGE="https://apps.kde.org/kpat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kpat/kpat-9999.ebuild
+++ b/kde-apps/kpat/kpat-9999.ebuild
@@ -13,8 +13,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="KDE patience game"
-HOMEPAGE="https://apps.kde.org/kpat/
-https://games.kde.org/games/kpat/"
+HOMEPAGE="https://apps.kde.org/kpat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kreversi/kreversi-22.03.90.ebuild
+++ b/kde-apps/kreversi/kreversi-22.03.90.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Board game by KDE"
-HOMEPAGE="https://apps.kde.org/kreversi/ https://games.kde.org/games/kreversi/"
+HOMEPAGE="https://apps.kde.org/kreversi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kreversi/kreversi-22.04.0.ebuild
+++ b/kde-apps/kreversi/kreversi-22.04.0.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Board game by KDE"
-HOMEPAGE="https://apps.kde.org/kreversi/ https://games.kde.org/games/kreversi/"
+HOMEPAGE="https://apps.kde.org/kreversi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kreversi/kreversi-22.04.49.9999.ebuild
+++ b/kde-apps/kreversi/kreversi-22.04.49.9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Board game by KDE"
-HOMEPAGE="https://apps.kde.org/kreversi/ https://games.kde.org/games/kreversi/"
+HOMEPAGE="https://apps.kde.org/kreversi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kreversi/kreversi-9999.ebuild
+++ b/kde-apps/kreversi/kreversi-9999.ebuild
@@ -11,7 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Board game by KDE"
-HOMEPAGE="https://apps.kde.org/kreversi/ https://games.kde.org/games/kreversi/"
+HOMEPAGE="https://apps.kde.org/kreversi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kshisen/kshisen-22.03.90.ebuild
+++ b/kde-apps/kshisen/kshisen-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Solitaire-like game played using the standard set of Mahjong tiles"
-HOMEPAGE="https://apps.kde.org/kshisen/
-https://games.kde.org/games/kshisen/"
+HOMEPAGE="https://apps.kde.org/kshisen/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kshisen/kshisen-22.04.0.ebuild
+++ b/kde-apps/kshisen/kshisen-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Solitaire-like game played using the standard set of Mahjong tiles"
-HOMEPAGE="https://apps.kde.org/kshisen/
-https://games.kde.org/games/kshisen/"
+HOMEPAGE="https://apps.kde.org/kshisen/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kshisen/kshisen-22.04.49.9999.ebuild
+++ b/kde-apps/kshisen/kshisen-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Solitaire-like game played using the standard set of Mahjong tiles"
-HOMEPAGE="https://apps.kde.org/kshisen/
-https://games.kde.org/games/kshisen/"
+HOMEPAGE="https://apps.kde.org/kshisen/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kshisen/kshisen-9999.ebuild
+++ b/kde-apps/kshisen/kshisen-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Solitaire-like game played using the standard set of Mahjong tiles"
-HOMEPAGE="https://apps.kde.org/kshisen/
-https://games.kde.org/games/kshisen/"
+HOMEPAGE="https://apps.kde.org/kshisen/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksirk/ksirk-22.03.90.ebuild
+++ b/kde-apps/ksirk/ksirk-22.03.90.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Port of the board game risk"
-HOMEPAGE="https://apps.kde.org/ksirk/
-https://games.kde.org/games/ksirk/"
+HOMEPAGE="https://apps.kde.org/ksirk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksirk/ksirk-22.04.0.ebuild
+++ b/kde-apps/ksirk/ksirk-22.04.0.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Port of the board game risk"
-HOMEPAGE="https://apps.kde.org/ksirk/
-https://games.kde.org/games/ksirk/"
+HOMEPAGE="https://apps.kde.org/ksirk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksirk/ksirk-22.04.49.9999.ebuild
+++ b/kde-apps/ksirk/ksirk-22.04.49.9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Port of the board game risk"
-HOMEPAGE="https://apps.kde.org/ksirk/
-https://games.kde.org/games/ksirk/"
+HOMEPAGE="https://apps.kde.org/ksirk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksirk/ksirk-9999.ebuild
+++ b/kde-apps/ksirk/ksirk-9999.ebuild
@@ -10,8 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Port of the board game risk"
-HOMEPAGE="https://apps.kde.org/ksirk/
-https://games.kde.org/games/ksirk/"
+HOMEPAGE="https://apps.kde.org/ksirk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kspaceduel/kspaceduel-22.03.90.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Space Game by KDE"
-HOMEPAGE="https://apps.kde.org/kspaceduel/
-https://games.kde.org/games/kspaceduel/"
+HOMEPAGE="https://apps.kde.org/kspaceduel/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kspaceduel/kspaceduel-22.04.0.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Space Game by KDE"
-HOMEPAGE="https://apps.kde.org/kspaceduel/
-https://games.kde.org/games/kspaceduel/"
+HOMEPAGE="https://apps.kde.org/kspaceduel/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kspaceduel/kspaceduel-22.04.49.9999.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Space Game by KDE"
-HOMEPAGE="https://apps.kde.org/kspaceduel/
-https://games.kde.org/games/kspaceduel/"
+HOMEPAGE="https://apps.kde.org/kspaceduel/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/kspaceduel/kspaceduel-9999.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Space Game by KDE"
-HOMEPAGE="https://apps.kde.org/kspaceduel/
-https://games.kde.org/games/kspaceduel/"
+HOMEPAGE="https://apps.kde.org/kspaceduel/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksquares/ksquares-22.03.90.ebuild
+++ b/kde-apps/ksquares/ksquares-22.03.90.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE clone of the game squares"
-HOMEPAGE="https://apps.kde.org/ksquares/ https://games.kde.org/games/ksquares/"
+HOMEPAGE="https://apps.kde.org/ksquares/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksquares/ksquares-22.04.0.ebuild
+++ b/kde-apps/ksquares/ksquares-22.04.0.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE clone of the game squares"
-HOMEPAGE="https://apps.kde.org/ksquares/ https://games.kde.org/games/ksquares/"
+HOMEPAGE="https://apps.kde.org/ksquares/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksquares/ksquares-22.04.49.9999.ebuild
+++ b/kde-apps/ksquares/ksquares-22.04.49.9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE clone of the game squares"
-HOMEPAGE="https://apps.kde.org/ksquares/ https://games.kde.org/games/ksquares/"
+HOMEPAGE="https://apps.kde.org/ksquares/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksquares/ksquares-9999.ebuild
+++ b/kde-apps/ksquares/ksquares-9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="KDE clone of the game squares"
-HOMEPAGE="https://apps.kde.org/ksquares/ https://games.kde.org/games/ksquares/"
+HOMEPAGE="https://apps.kde.org/ksquares/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksudoku/ksudoku-22.03.90.ebuild
+++ b/kde-apps/ksudoku/ksudoku-22.03.90.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Logic-based symbol placement puzzle by KDE"
-HOMEPAGE="https://apps.kde.org/ksudoku/ https://games.kde.org/games/ksudoku/"
+HOMEPAGE="https://apps.kde.org/ksudoku/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksudoku/ksudoku-22.04.0.ebuild
+++ b/kde-apps/ksudoku/ksudoku-22.04.0.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Logic-based symbol placement puzzle by KDE"
-HOMEPAGE="https://apps.kde.org/ksudoku/ https://games.kde.org/games/ksudoku/"
+HOMEPAGE="https://apps.kde.org/ksudoku/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksudoku/ksudoku-22.04.49.9999.ebuild
+++ b/kde-apps/ksudoku/ksudoku-22.04.49.9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Logic-based symbol placement puzzle by KDE"
-HOMEPAGE="https://apps.kde.org/ksudoku/ https://games.kde.org/games/ksudoku/"
+HOMEPAGE="https://apps.kde.org/ksudoku/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ksudoku/ksudoku-9999.ebuild
+++ b/kde-apps/ksudoku/ksudoku-9999.ebuild
@@ -10,7 +10,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Logic-based symbol placement puzzle by KDE"
-HOMEPAGE="https://apps.kde.org/ksudoku/ https://games.kde.org/games/ksudoku/"
+HOMEPAGE="https://apps.kde.org/ksudoku/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ktuberling/ktuberling-22.03.90.ebuild
+++ b/kde-apps/ktuberling/ktuberling-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Potato game for kids by KDE"
-HOMEPAGE="https://apps.kde.org/ktuberling/
-https://games.kde.org/games/ktuberling/"
+HOMEPAGE="https://apps.kde.org/ktuberling/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ktuberling/ktuberling-22.04.0.ebuild
+++ b/kde-apps/ktuberling/ktuberling-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Potato game for kids by KDE"
-HOMEPAGE="https://apps.kde.org/ktuberling/
-https://games.kde.org/games/ktuberling/"
+HOMEPAGE="https://apps.kde.org/ktuberling/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ktuberling/ktuberling-22.04.49.9999.ebuild
+++ b/kde-apps/ktuberling/ktuberling-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Potato game for kids by KDE"
-HOMEPAGE="https://apps.kde.org/ktuberling/
-https://games.kde.org/games/ktuberling/"
+HOMEPAGE="https://apps.kde.org/ktuberling/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/ktuberling/ktuberling-9999.ebuild
+++ b/kde-apps/ktuberling/ktuberling-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Potato game for kids by KDE"
-HOMEPAGE="https://apps.kde.org/ktuberling/
-https://games.kde.org/games/ktuberling/"
+HOMEPAGE="https://apps.kde.org/ktuberling/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/lskat/lskat-22.03.90.ebuild
+++ b/kde-apps/lskat/lskat-22.03.90.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Skat game by KDE"
-HOMEPAGE="https://apps.kde.org/lskat/
-https://games.kde.org/games/lskat/"
+HOMEPAGE="https://apps.kde.org/lskat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/lskat/lskat-22.04.0.ebuild
+++ b/kde-apps/lskat/lskat-22.04.0.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Skat game by KDE"
-HOMEPAGE="https://apps.kde.org/lskat/
-https://games.kde.org/games/lskat/"
+HOMEPAGE="https://apps.kde.org/lskat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/lskat/lskat-22.04.49.9999.ebuild
+++ b/kde-apps/lskat/lskat-22.04.49.9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Skat game by KDE"
-HOMEPAGE="https://apps.kde.org/lskat/
-https://games.kde.org/games/lskat/"
+HOMEPAGE="https://apps.kde.org/lskat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/lskat/lskat-9999.ebuild
+++ b/kde-apps/lskat/lskat-9999.ebuild
@@ -11,8 +11,7 @@ QTMIN=5.15.2
 inherit ecm kde.org
 
 DESCRIPTION="Skat game by KDE"
-HOMEPAGE="https://apps.kde.org/lskat/
-https://games.kde.org/games/lskat/"
+HOMEPAGE="https://apps.kde.org/lskat/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/picmi/picmi-22.03.90.ebuild
+++ b/kde-apps/picmi/picmi-22.03.90.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="Nonogram logic game by KDE"
-HOMEPAGE="https://apps.kde.org/picmi/
-https://games.kde.org/games/picmi/"
+HOMEPAGE="https://apps.kde.org/picmi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/picmi/picmi-22.04.0.ebuild
+++ b/kde-apps/picmi/picmi-22.04.0.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="Nonogram logic game by KDE"
-HOMEPAGE="https://apps.kde.org/picmi/
-https://games.kde.org/games/picmi/"
+HOMEPAGE="https://apps.kde.org/picmi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/picmi/picmi-22.04.49.9999.ebuild
+++ b/kde-apps/picmi/picmi-22.04.49.9999.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="Nonogram logic game by KDE"
-HOMEPAGE="https://apps.kde.org/picmi/
-https://games.kde.org/games/picmi/"
+HOMEPAGE="https://apps.kde.org/picmi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"

--- a/kde-apps/picmi/picmi-9999.ebuild
+++ b/kde-apps/picmi/picmi-9999.ebuild
@@ -12,8 +12,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 DESCRIPTION="Nonogram logic game by KDE"
-HOMEPAGE="https://apps.kde.org/picmi/
-https://games.kde.org/games/picmi/"
+HOMEPAGE="https://apps.kde.org/picmi/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"


### PR DESCRIPTION
Hi,

I've checked all ebuilds which still used `https://games.kde.org/games/...` as HOMEPAGE and removed it since it would redirect to `apps.kde.org` anyway.