### PR TITLE
app-cdr/dolphin-plugins-mountiso: fix LICENSE

### DIFF
--- a/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-22.07.80.ebuild
+++ b/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-22.07.80.ebuild
@@ -15,7 +15,7 @@ inherit ecm gear.kde.org
 DESCRIPTION="Dolphin plugin for ISO loopback device mounting"
 HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE=""

--- a/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-22.08.49.9999.ebuild
+++ b/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-22.08.49.9999.ebuild
@@ -15,7 +15,7 @@ inherit ecm gear.kde.org
 DESCRIPTION="Dolphin plugin for ISO loopback device mounting"
 HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS=""
 IUSE=""

--- a/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-9999.ebuild
+++ b/app-cdr/dolphin-plugins-mountiso/dolphin-plugins-mountiso-9999.ebuild
@@ -15,7 +15,7 @@ inherit ecm gear.kde.org
 DESCRIPTION="Dolphin plugin for ISO loopback device mounting"
 HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS=""
 IUSE=""


### PR DESCRIPTION
Hi @a17r 

I saw ther're a lot of ebuilds were the `LICENSE` still needs to be validated. If you don' t mind i can have a look at them and fix them like i did now with `app-cdr/dolphin-plugins-mountiso`
I usually check a few upstream source files to find out the `LICENSE`, anything else i should consider?
In this case it was pretty simple, since the source files state:
```
SPDX-License-Identifier: GPL-2.0-or-later
```




Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Portage 3.0.32 / pkgdev 0.2.1 / pkgcheck 0.10.11