### PR TITLE
*/*: fix LICENSES

### DIFF
--- a/app-office/kexi/kexi-9999.ebuild
+++ b/app-office/kexi/kexi-9999.ebuild
@@ -18,7 +18,7 @@ if [[ ${KDE_BUILD_TYPE} != live ]]; then
 	KEYWORDS="~amd64 ~x86"
 fi
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 IUSE="debug experimental marble mdb mysql postgres sqlite"
 

--- a/dev-libs/kdiagram/kdiagram-9999.ebuild
+++ b/dev-libs/kdiagram/kdiagram-9999.ebuild
@@ -21,7 +21,7 @@ if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 fi
 
-LICENSE="GPL-2" # TODO CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 
 REQUIRED_USE="test? ( examples )"

--- a/dev-util/kdevelop-embedded/kdevelop-embedded-9999.ebuild
+++ b/dev-util/kdevelop-embedded/kdevelop-embedded-9999.ebuild
@@ -12,7 +12,7 @@ inherit ecm kde.org
 DESCRIPTION="Plugin for KDevelop to support the development of embedded systems"
 HOMEPAGE="https://www.kdevelop.org/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 IUSE=""
 

--- a/dev-util/kdevelop-python/kdevelop-python-9999.ebuild
+++ b/dev-util/kdevelop-python/kdevelop-python-9999.ebuild
@@ -14,7 +14,7 @@ inherit ecm gear.kde.org python-single-r1
 DESCRIPTION="Python plugin for KDevelop"
 HOMEPAGE="https://www.kdevelop.org/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2 GPL-2+ GPL-3 LGPL-2 LGPL-2+ MIT"
 SLOT="5"
 IUSE=""
 KEYWORDS=""


### PR DESCRIPTION
Hi,

another few `LICENSE` fixes.
For `dev-util/kdevelop-python` i choose to use the LICENSES listed from here: https://invent.kde.org/kdevelop/kdev-python/-/tree/master/LICENSES. Hope that's fine.