### PR TITLE
dynlink-scanner fixes

### DIFF
--- a/Documentation/maintainers/dynlink-scanner
+++ b/Documentation/maintainers/dynlink-scanner
@@ -48,7 +48,7 @@ for cpv in `portageq match $ROOT/ $1`; do
 	# For each file that belongs to package
 	#     run dynlink-scanner --linking-deps <file> to obtain its linking dependencies
 	# Assign all linking deps to packages and print package names
-	qfile -eR $ROOT `portageq contents $ROOT/ $cpv | xargs -r -L 1 "$0" --linking-deps` | cut -f1 -d' ' | sort -u
+	qfile -R $ROOT `portageq contents $ROOT/ $cpv | xargs -r -L 1 "$0" --linking-deps` | cut -f1 -d' ' | sort -u
 done
 
 # Cleanup

--- a/Documentation/maintainers/dynlink-scanner
+++ b/Documentation/maintainers/dynlink-scanner
@@ -22,7 +22,7 @@ if [[ "$1" = --linking-deps ]]; then
 		exit 1
 	fi
 	mime=`file -b --mime-type "$2"`
-	if [[ "$mime" == 'application/x-executable' ]] || [[ "${mime}" == 'application/x-sharedlib' ]]; then
+	if [[ "$mime" == 'application/x-pie-executable' ]] || [[ "$mime" == 'application/x-executable' ]] || [[ "${mime}" == 'application/x-sharedlib' ]]; then
 		LINK=`get_link_deps "$2"`
 		[[ "$mime" == 'application/x-sharedlib' ]] && /tmp/try_dlopen "$2"
 		[[ -n $LINK ]] && echo -e ${LINK//,/\\n} | sort -u


### PR DESCRIPTION
two minor fixes for dynlink-scanner

dynlink-scanner: drop the obsolete '-e' option of qfile
dynlink-scanner: add pie-executable to emime type detection list