### PR TITLE
kde-plasma/discover: add flag for enabling snap backend

### DIFF
--- a/kde-plasma/discover/discover-5.27.49.9999.ebuild
+++ b/kde-plasma/discover/discover-5.27.49.9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://userbase.kde.org/Discover"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS=""
-IUSE="+firmware flatpak telemetry webengine"
+IUSE="+firmware flatpak snap telemetry webengine"
 
 # libmarkdown (app-text/discount) only used in PackageKitBackend
 DEPEND="
@@ -45,11 +45,13 @@ DEPEND="
 	>=kde-frameworks/purpose-${KFMIN}:5
 	firmware? ( >=sys-apps/fwupd-1.5.0 )
 	flatpak? ( sys-apps/flatpak )
+	snap? ( sys-libs/snapd-glib:=[qt5] )
 	telemetry? ( dev-libs/kuserfeedback:5 )
 	webengine? ( >=dev-qt/qtwebview-${QTMIN}:5 )
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qtquickcontrols2-${QTMIN}:5
+	snap? ( app-containers/snapd )
 "
 BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:5"
 
@@ -67,11 +69,18 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		# TODO: Port PackageKit's portage back-end to python3 and
+		# move from layman to eselect-repository
 		-DCMAKE_DISABLE_FIND_PACKAGE_packagekitqt5=ON
-		-DCMAKE_DISABLE_FIND_PACKAGE_Snapd=ON
+		# Automated updates will not work for us
+		# https://invent.kde.org/plasma/discover/-/merge_requests/142
 		-DWITH_KCM=OFF
+		-DBUILD_DummyBackend=OFF
 		-DBUILD_FlatpakBackend=$(usex flatpak)
 		-DBUILD_FwupdBackend=$(usex firmware)
+		-DBUILD_RpmOstreeBackend=OFF
+		-DBUILD_SnapBackend=$(usex snap)
+		-DBUILD_SteamOSBackend=OFF
 		$(cmake_use_find_package telemetry KUserFeedback)
 		$(cmake_use_find_package webengine Qt5WebView)
 	)

--- a/kde-plasma/discover/discover-9999.ebuild
+++ b/kde-plasma/discover/discover-9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://userbase.kde.org/Discover"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS=""
-IUSE="+firmware flatpak telemetry webengine"
+IUSE="+firmware flatpak snap telemetry webengine"
 
 # libmarkdown (app-text/discount) only used in PackageKitBackend
 DEPEND="
@@ -45,11 +45,13 @@ DEPEND="
 	>=kde-frameworks/purpose-${KFMIN}:5
 	firmware? ( >=sys-apps/fwupd-1.5.0 )
 	flatpak? ( sys-apps/flatpak )
+	snap? ( sys-libs/snapd-glib:=[qt5] )
 	telemetry? ( dev-libs/kuserfeedback:5 )
 	webengine? ( >=dev-qt/qtwebview-${QTMIN}:5 )
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qtquickcontrols2-${QTMIN}:5
+	snap? ( app-containers/snapd )
 "
 BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:5"
 
@@ -67,11 +69,18 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		# TODO: Port PackageKit's portage back-end to python3 and
+		# move from layman to eselect-repository
 		-DCMAKE_DISABLE_FIND_PACKAGE_packagekitqt5=ON
-		-DCMAKE_DISABLE_FIND_PACKAGE_Snapd=ON
+		# Automated updates will not work for us
+		# https://invent.kde.org/plasma/discover/-/merge_requests/142
 		-DWITH_KCM=OFF
+		-DBUILD_DummyBackend=OFF
 		-DBUILD_FlatpakBackend=$(usex flatpak)
 		-DBUILD_FwupdBackend=$(usex firmware)
+		-DBUILD_RpmOstreeBackend=OFF
+		-DBUILD_SnapBackend=$(usex snap)
+		-DBUILD_SteamOSBackend=OFF
 		$(cmake_use_find_package telemetry KUserFeedback)
 		$(cmake_use_find_package webengine Qt5WebView)
 	)

--- a/kde-plasma/discover/metadata.xml
+++ b/kde-plasma/discover/metadata.xml
@@ -12,6 +12,7 @@
 	<use>
 		<flag name="firmware">Enable support for firmware upgrades using <pkg>sys-apps/fwupd</pkg></flag>
 		<flag name="flatpak">Enable support for flatpak repositories using <pkg>sys-apps/flatpak</pkg></flag>
+		<flag name="snap">Enable support for snap packages using <pkg>app-containers/snapd</pkg></flag>
 		<flag name="webengine">Enable webflow support using <pkg>dev-qt/qtwebview</pkg> and <pkg>dev-qt/qtwebengine</pkg> instead of default URL handler</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
This adds a flag to discover to build the snap backend and adds the library we need as intermediary. 

@gentoo/kde Please let me know if this is conceptually OK. If it is, I'll merge the `sys-libs/snapd-glib` library to ::gentoo with appropriate use masks for `kde-plasma/discover snap` (snap is only available on amd64 with systemd, so the flag needs to be globally masked, and unmasked only on the `default/linux/amd64/*/systemd/*` profiles). The changes to `kde-plasma/discover` can be merged here and can trickle down to ::gentoo in the next release.

Still TODO is to maybe at some point in the future add a flag for the PackageKit backend. This is a bit more work since PackageKit's portage backend needs to be fixed-up first (bump to python3 and migrated away from layman). Though to be honest I am not yet fully convinced this is worth the effort.

Also CC'ing the maintainer of `app-containers/snapd` @zmedico 