### PR TITLE
Add kde-frameworks/kwidgetsaddons to xwaylandvideobridge dependencies.

### DIFF
--- a/gui-apps/xwaylandvideobridge/xwaylandvideobridge-0_pre20230421-r1.ebuild
+++ b/gui-apps/xwaylandvideobridge/xwaylandvideobridge-0_pre20230421-r1.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	>=kde-frameworks/kcoreaddons-${KFMIN}:5=
 	>=kde-frameworks/ki18n-${KFMIN}:5=
 	>=kde-frameworks/knotifications-${KFMIN}:5=
+	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
 	>=kde-frameworks/kwindowsystem-${KFMIN}:5=
 	>=kde-plasma/kpipewire-5.27.4:5
 	media-libs/freetype

--- a/gui-apps/xwaylandvideobridge/xwaylandvideobridge-9999.ebuild
+++ b/gui-apps/xwaylandvideobridge/xwaylandvideobridge-9999.ebuild
@@ -26,6 +26,7 @@ DEPEND="
 	>=kde-frameworks/kcoreaddons-${KFMIN}:5=
 	>=kde-frameworks/ki18n-${KFMIN}:5=
 	>=kde-frameworks/knotifications-${KFMIN}:5=
+	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
 	>=kde-frameworks/kwindowsystem-${KFMIN}:5=
 	>=kde-plasma/kpipewire-5.27.4:5
 	media-libs/freetype


### PR DESCRIPTION
Both ebuilds fail to build without kde-frameworks/kwidgetsaddons. 

Here is the [build log](https://github.com/gentoo/kde/files/12384112/buildlog.txt) when failing.
Output is identical between ebuilds.

Additionally, I've renamed the non 9999 version for a revbump, since there were changes to RDEPEND.
