### PR TITLE
Transfer dependencies from some packages into `plasma-meta`

### DIFF
--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -111,8 +111,6 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:5
 	>=kde-frameworks/qqc2-desktop-style-${KFMIN}:5
 	>=kde-plasma/kde-cli-tools-${PVCUT}:5
-	>=kde-plasma/oxygen-${PVCUT}:5
-	media-fonts/noto-emoji
 	sys-apps/util-linux
 	x11-apps/setxkbmap
 	x11-misc/xdg-user-dirs

--- a/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
@@ -46,11 +46,7 @@ COMMON_DEPEND="
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/plasma-wayland-protocols-1.6.0
 "
-RDEPEND="${COMMON_DEPEND}
-	>=kde-plasma/xdg-desktop-portal-kde-${PVCUT}:5
-	media-fonts/hack
-	media-fonts/noto
-"
+RDEPEND="${COMMON_DEPEND}"
 BDEPEND="
 	>=dev-qt/qtwaylandscanner-${QTMIN}:5
 "

--- a/kde-plasma/plasma-meta/metadata.xml
+++ b/kde-plasma/plasma-meta/metadata.xml
@@ -18,6 +18,7 @@
 		<flag name="display-manager">Pull in a graphical display manager</flag>
 		<flag name="firewall">Pull in <pkg>kde-plasma/plasma-firewall</pkg> for system firewall administration</flag>
 		<flag name="flatpak">Pull in <pkg>kde-plasma/flatpak-kcm</pkg> for flatpak permissions administration</flag>
+		<flag name="fonts">Pull in default fonts (<pkg>media-fonts/hack</pkg>, <pkg>media-fonts/noto</pkg>, <pkg>media-fonts/noto-emoji</pkg>)</flag>
 		<flag name="grub">Pull in Breeze theme for <pkg>sys-boot/grub</pkg></flag>
 		<flag name="gtk">Enable Breeze widget style and system settings module for GTK+</flag>
 		<flag name="kwallet">Enable support for KWallet auto-unlocking via <pkg>kde-plasma/kwallet-pam</pkg></flag>

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -10,7 +10,7 @@ LICENSE="metapackage"
 SLOT="5"
 KEYWORDS=""
 IUSE="accessibility bluetooth +browser-integration colord +crash-handler crypt
-discover +display-manager +elogind +firewall flatpak grub gtk +handbook
+discover +display-manager +elogind +firewall flatpak +fonts grub gtk +handbook
 +kwallet +legacy-systray +networkmanager plymouth pulseaudio +sddm sdk +smart
 systemd thunderbolt +wallpapers"
 
@@ -66,6 +66,11 @@ RDEPEND="
 	)
 	elogind? ( sys-auth/elogind[pam] )
 	flatpak? ( >=kde-plasma/flatpak-kcm-${PV}:${SLOT} )
+	fonts? (
+		media-fonts/hack
+		media-fonts/noto
+		media-fonts/noto-emoji
+	)
 	grub? ( >=kde-plasma/breeze-grub-${PV}:${SLOT} )
 	gtk? (
 		>=kde-plasma/breeze-gtk-${PV}:${SLOT}


### PR DESCRIPTION
Some packages are depend on unnecessary stuff like fonts.
It may be a good idea to make this stuff optional, presumably transferring the deps into full `plasma-meta` package.

## Details

- `kde-plasma/plasma-desktop`: remove `oxygen` and `noto-emoji` dependencies. Oxygen is an old Plasma theme from KDE 4, not required for KDE 5 operation at all. It is also already included in `plasma-meta` anyway. The font is also obviously not mandatory.
- `kde-plasma/plasma-integration`: remove fonts and portal dependencies. Same thing goes for fonts. The portal dependency is also not mandatory (in fact it is not there in current release ebuild).
- `kde-plasma/plasma-meta`: introduce new `fonts` use flag for fonts removed from other packages.