### PR TITLE
app-editors/okteta: new 'kparts' flag

### DIFF
--- a/app-editors/okteta/metadata.xml
+++ b/app-editors/okteta/metadata.xml
@@ -10,5 +10,6 @@
 	</upstream>
 	<use>
 		<flag name="designer">Build plugins for <pkg>dev-qt/designer</pkg></flag>
+		<flag name="kparts">Build <pkg>kde-frameworks/kparts</pkg> plugin</flag>
 	</use>
 </pkgmetadata>

--- a/app-editors/okteta/okteta-9999.ebuild
+++ b/app-editors/okteta/okteta-9999.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-2 handbook? ( FDL-1.2 )"
 SLOT="5"
-IUSE=""
+IUSE="kparts"
 
 DEPEND="
 	>=dev-qt/qtdeclarative-${QTMIN}:5
@@ -42,16 +42,17 @@ DEPEND="
 	>=kde-frameworks/kitemviews-${KFMIN}:5
 	>=kde-frameworks/kjobwidgets-${KFMIN}:5
 	>=kde-frameworks/knewstuff-${KFMIN}:5
-	>=kde-frameworks/kparts-${KFMIN}:5
 	>=kde-frameworks/kservice-${KFMIN}:5
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
 	>=kde-frameworks/kxmlgui-${KFMIN}:5
+	kparts? ( >=kde-frameworks/kparts-${KFMIN}:5 )
 "
 RDEPEND="${DEPEND}"
 
 src_configure() {
 	local mycmakeargs=(
 		-DOMIT_EXAMPLES=ON
+		-DBUILD_KPARTSPLUGIN=$(usex kparts)
 	)
 
 	ecm_src_configure


### PR DESCRIPTION
Makes KParts plugin optional.

From upstream:
> KParts usage having declined in Qt5/KF5 era, at least Krusader makes explicit use of the plugin, other KParts software can get it when requesting a viewer for the MIME/media type application/octet-stream.