### PR TITLE
kde-apps/kio-extras: new 'exiv' flag

### DIFF
--- a/kde-apps/kio-extras/kio-extras-9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://invent.kde.org/network/kio-extras"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS=""
-IUSE="activities ios +man mtp nfs openexr phonon samba +sftp taglib X"
+IUSE="activities +exiv ios +man mtp nfs openexr phonon samba +sftp taglib X"
 
 # requires running Plasma environment
 RESTRICT="test"
@@ -27,7 +27,6 @@ DEPEND="
 	>=dev-qt/qtsvg-${QTMIN}:5
 	>=dev-qt/qtwidgets-${QTMIN}:5
 	>=dev-qt/qtxml-${QTMIN}:5
-	kde-apps/libkexiv2:5
 	>=kde-frameworks/karchive-${KFMIN}:5
 	>=kde-frameworks/kbookmarks-${KFMIN}:5
 	>=kde-frameworks/kcodecs-${KFMIN}:5
@@ -49,6 +48,7 @@ DEPEND="
 		>=kde-frameworks/kactivities-${KFMIN}:5
 		>=kde-frameworks/kactivities-stats-${KFMIN}:5
 	)
+	exiv? ( kde-apps/libkexiv2:5 )
 	ios? (
 		app-pda/libimobiledevice:=
 		app-pda/libplist:=
@@ -79,6 +79,7 @@ src_configure() {
 		$(cmake_use_find_package activities KF5Activities)
 		$(cmake_use_find_package activities KF5ActivitiesStats)
 		$(cmake_use_find_package activities Qt5Sql)
+		$(cmake_use_find_package exiv KF5KExiv2)
 		$(cmake_use_find_package ios IMobileDevice)
 		$(cmake_use_find_package ios PList)
 		$(cmake_use_find_package man Gperf)

--- a/kde-apps/kio-extras/metadata.xml
+++ b/kde-apps/kio-extras/metadata.xml
@@ -11,6 +11,7 @@
 	</upstream>
 	<use>
 		<flag name="activities">Enable activities KIO worker and fileitem plugin</flag>
+		<flag name="exiv">Enable extraction of JPEG thumbnails via <pkg>kde-apps/libkexiv2</pkg></flag>
 		<flag name="ios">Enable AFC (Apple File Conduit) KIO worker for iOS devices support</flag>
 		<flag name="man">Enable manpages KIO worker</flag>
 		<flag name="nfs">Enable NFS support using <pkg>net-libs/libtirpc</pkg></flag>


### PR DESCRIPTION
Makes KF5KExiv2 plugin optional.
It is only used for extraction of JPEG inbuilt thumbnails.