### PR TITLE
kde-frameworks/prison: new flags

### DIFF
--- a/kde-frameworks/prison/metadata.xml
+++ b/kde-frameworks/prison/metadata.xml
@@ -9,7 +9,10 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
 	<use>
+		<flag name="dtmx">Enable generation of Data Matrix barcodes via <pkg>media-libs/libdmtx</pkg></flag>
 		<flag name="qml">Enable QML/QtQuick support via <pkg>dev-qt/qtdeclarative</pkg></flag>
+		<flag name="video">Enable scanning of barcodes from live video feed via <pkg>dev-qt/qtmultimedia</pkg></flag>
+		<flag name="zxing">Enable generation of PDF417 barcodes via <pkg>media-libs/zxing-cpp</pkg></flag>
 	</use>
 	<slots>
 		<subslots>

--- a/kde-frameworks/prison/prison-5.9999.ebuild
+++ b/kde-frameworks/prison/prison-5.9999.ebuild
@@ -11,15 +11,16 @@ HOMEPAGE="https://invent.kde.org/frameworks/prison"
 
 LICENSE="GPL-2"
 KEYWORDS=""
-IUSE="qml"
+IUSE="+dtmx qml +video +zxing"
+REQUIRED_USE="video? ( zxing )"
 
 RDEPEND="
 	>=dev-qt/qtgui-${QTMIN}:5
-	>=dev-qt/qtmultimedia-${QTMIN}:5
 	media-gfx/qrencode:=
-	media-libs/libdmtx
-	media-libs/zxing-cpp:=
+	dtmx? ( media-libs/libdmtx )
 	qml? ( >=dev-qt/qtdeclarative-${QTMIN}:5 )
+	video? ( >=dev-qt/qtmultimedia-${QTMIN}:5 )
+	zxing? ( media-libs/zxing-cpp:= )
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-qt/qtwidgets-${QTMIN}:5 )
@@ -27,7 +28,10 @@ DEPEND="${RDEPEND}
 
 src_configure() {
 	local mycmakeargs=(
+		$(cmake_use_find_package dtmx Dmtx)
 		$(cmake_use_find_package qml Qt5Quick)
+		$(cmake_use_find_package video Qt5Multimedia)
+		$(cmake_use_find_package zxing ZXing)
 	)
 
 	ecm_src_configure


### PR DESCRIPTION
`dtmx`, `video`, `zxing` - make respective plugins optional.

Dtmx plugin only used for generation of Data Matrix barcodes.
QtMultimedia plugin only used for scanning of barcodes from live video feed.
ZXing plugin only used for generation of PDF417 barcodes.