### PR TITLE
kde-frameworks/breeze-icons: new '24px' flag

### DIFF
--- a/kde-frameworks/breeze-icons/breeze-icons-5.9999.ebuild
+++ b/kde-frameworks/breeze-icons/breeze-icons-5.9999.ebuild
@@ -11,19 +11,23 @@ DESCRIPTION="Breeze SVG icon theme"
 
 LICENSE="LGPL-3"
 KEYWORDS=""
-IUSE="test"
+IUSE="+24px test"
 
 RESTRICT="!test? ( test )"
 
 DEPEND="test? ( dev-qt/qttest:5 )"
-BDEPEND="${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
+BDEPEND="
 	dev-qt/qtcore:5
 	>=kde-frameworks/extra-cmake-modules-${PVCUT}:5
+	24px? (
+		${PYTHON_DEPS}
+		$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
+	)
 	test? ( app-misc/fdupes )
 "
 
 python_check_deps() {
+	use 24px || return 0
 	python_has_version "dev-python/lxml[${PYTHON_USEDEP}]"
 }
 
@@ -36,6 +40,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DPython_EXECUTABLE="${PYTHON}"
 		-DBINARY_ICONS_RESOURCE=OFF
+		$(cmake_use_find_package 24px Python)
 	)
 	cmake_src_configure
 }

--- a/kde-frameworks/breeze-icons/metadata.xml
+++ b/kde-frameworks/breeze-icons/metadata.xml
@@ -8,6 +8,9 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
+	<use>
+		<flag name="24px">Install additional 24x24 icons</flag>
+	</use>
 	<slots>
 		<subslots>
 			Must only be used by packages that are known to use private parts of the Frameworks API.


### PR DESCRIPTION
Makes build-time icons generation optional.

Generation of additional 24x24 icons is the only thing that requires build time processing and additional build deps.
I am not sure about the flag name though.