### PR TITLE
gui-apps/xwaylandvideobridge: require kde-frameworks/kwindowsystem[X]

### DIFF
--- a/gui-apps/xwaylandvideobridge/xwaylandvideobridge-9999.ebuild
+++ b/gui-apps/xwaylandvideobridge/xwaylandvideobridge-9999.ebuild
@@ -29,7 +29,7 @@ DEPEND="
 	>=kde-frameworks/kcoreaddons-${KFMIN}:5
 	>=kde-frameworks/ki18n-${KFMIN}:5
 	>=kde-frameworks/knotifications-${KFMIN}:5
-	>=kde-frameworks/kwindowsystem-${KFMIN}:5
+	>=kde-frameworks/kwindowsystem-${KFMIN}:5[X]
 	>=kde-plasma/kpipewire-5.27.4:5
 	media-libs/freetype
 	x11-libs/libxcb:=


### PR DESCRIPTION
kde-frameworks/kwindowsystem must be built with USE="X", since KX11Extras is not installed without it. 