### PR TITLE
drkonqi-9999.ebuild missing runtime packages dependency

### DIFF
--- a/kde-plasma/drkonqi/drkonqi-9999.ebuild
+++ b/kde-plasma/drkonqi/drkonqi-9999.ebuild
@@ -44,6 +44,8 @@ DEPEND="${COMMON_DEPEND}
 	test? ( >=dev-qt/qtbase-${QTMIN}:6[network] )
 "
 RDEPEND="${COMMON_DEPEND}
+	dev-python/sentry-sdk
+	dev-python/pygdbmi
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6[qml]
 	|| (


### PR DESCRIPTION
-- The following RUNTIME packages have not been found:
 
* pygdbmi-PythonModule, Python module 'pygdbmi' is a runtime dependency.
* sentry_sdk-PythonModule, Python module 'sentry_sdk' is a runtime dependency.
 

Error:
1/98] cd /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build && /usr/bin/cmake -DPython3_EXECUTABLE=/usr/bin/python3 -D_ki18n_pmap_compile_script=/usr/lib64/cmake/KF6I18n/ts-pmap-compile.py -DCOPY_TO=/var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/locale -DPO_DIR=/var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999/po -P /usr/lib64/cmake/KF6I18n/build-tsfiles.cmake
[2/98] cd /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build && /usr/bin/cmake -DGETTEXT_MSGFMT_EXECUTABLE=/usr/bin/msgfmt -DCOPY_TO=/var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/locale -DPO_DIR=/var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999/po -P /usr/lib64/cmake/KF6I18n/build-pofiles.cmake
[3/98] cd /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data && pip_EXE-NOTFOUND install --target /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data/python pygdbmi psutil sentry-sdk
[31mFAILED: [0msrc/data/CMakeFiles/python_vendor src/data/python /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data/CMakeFiles/python_vendor /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data/python 
cd /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data && pip_EXE-NOTFOUND install --target /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/data/python pygdbmi psutil sentry-sdk
/bin/sh: line 1: pip_EXE-NOTFOUND: command not found
[4/98] cd /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/bugzillaintegration/libbugzilla && /usr/bin/cmake -E cmake_autogen /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/bugzillaintegration/libbugzilla/CMakeFiles/qbugzilla_autogen.dir/AutogenInfo.json RelWithDebInfo && /usr/bin/cmake -E touch /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/bugzillaintegration/libbugzilla/qbugzilla_autogen/timestamp && /usr/bin/cmake -E cmake_transform_depfile Ninja gccdepfile /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999 /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999/src/bugzillaintegration/libbugzilla /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/bugzillaintegration/libbugzilla /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/src/bugzillaintegration/libbugzilla/qbugzilla_autogen/deps /var/tmp/portage/kde-plasma/drkonqi-9999/work/drkonqi-9999_build/CMakeFiles/d/35907d5b7616725b980c48633df09f967ab023debce19d23e84ebdd61204f97e.d
ninja: build stopped: subcommand failed.
[31;01m*[0m ERROR: kde-plasma/drkonqi-9999::kde failed (compile phase):
[31;01m*[0m   ninja -v -j2 -l0 failed
[31;01m*[0m 
[31;01m*[0m Call stack:
[31;01m*[0m     ebuild.sh, line  136:  Called src_compile
[31;01m*[0m   environment, line 3113:  Called cmake_src_compile
[31;01m*[0m   environment, line 1197:  Called cmake_build
[31;01m*[0m   environment, line 1164:  Called eninja
[31;01m*[0m   environment, line 1847:  Called die
[31;01m*[0m The specific snippet of code:
[31;01m*[0m       "$@" || die -n "${*} failed"