### PR TITLE
kde-apps/filelight: Add missing kirigami-addons dependency

### DIFF
--- a/kde-apps/filelight/filelight-9999.ebuild
+++ b/kde-apps/filelight/filelight-9999.ebuild
@@ -18,6 +18,7 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
+	>=dev-libs/kirigami-addons-0.11:6
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=kde-frameworks/kcompletion-${KFMIN}:6


### PR DESCRIPTION
Was recently added in the Qt6 port, is normally a runtime dependency but in this case is also added to the CMakeLists.