### PR TITLE
kde-plasma/plasma-sdk: Add missing plasma5support dependency

### DIFF
--- a/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
@@ -34,6 +34,7 @@ DEPEND="
 	>=kde-frameworks/ktexteditor-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/plasma5support-${PVCUT}:6
 "
 RDEPEND="${DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6


### PR DESCRIPTION
This seems to be a new one, and it's enforced by CMake