### PR TITLE
kde-plasma/xdg-desktop-portal-kde: Add dependency on qtbase with cups

### DIFF
--- a/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-9999.ebuild
+++ b/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-9999.ebuild
@@ -16,10 +16,11 @@ SLOT="6"
 KEYWORDS=""
 IUSE=""
 
+# dev-qt/qtbase:=[cups]: includes specifically the cups private header
 # dev-qt/qtgui: QtXkbCommonSupport is provided by either IUSE libinput or X
 COMMON_DEPEND="
 	>=dev-libs/wayland-1.15
-	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+	>=dev-qt/qtbase-${QTMIN}:6=[cups,dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	|| (
 		>=dev-qt/qtbase-${QTMIN}:6[libinput]


### PR DESCRIPTION
xdg-desktop-portal-kde depends on printsupport (and a private header of it, no less) so make sure we depend on qtbase having the cups USE flag enabled.