### PR TITLE
kde-plasma/plasma-nm: Remove patch that was upstreamed

### DIFF
--- a/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
@@ -57,8 +57,6 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-PATCHES=( "${FILESDIR}/${PN}-5.27.80-openconnect-optional.patch" )
-
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_OPENCONNECT=$(usex openconnect)


### PR DESCRIPTION
Introduced in commit a0e80449ec9209010354b4af8aa30b7563c98436.