### PR TITLE
oxygen-9999.ebuild add qt5 useflag

### DIFF
--- a/kde-plasma/oxygen/oxygen-9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-9999.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://invent.kde.org/plasma/oxygen"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS=""
-IUSE=""
+IUSE="qt5"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
@@ -31,8 +31,32 @@ RDEPEND="
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-plasma/kdecoration-${PVCUT}:6
 	x11-libs/libxcb
+	qt5? (
+                >=dev-qt/qtdbus-${QT5MIN}:5
+                >=dev-qt/qtdeclarative-${QT5MIN}:5
+                >=dev-qt/qtgui-${QT5MIN}:5
+                >=dev-qt/qtwidgets-${QT5MIN}:5
+                >=dev-qt/qtx11extras-${QT5MIN}:5
+                >=kde-frameworks/frameworkintegration-${KF5MIN}:5
+                >=kde-frameworks/kcmutils-${KF5MIN}:5
+                >=kde-frameworks/kconfig-${KF5MIN}:5
+                >=kde-frameworks/kconfigwidgets-${KF5MIN}:5
+                >=kde-frameworks/kcoreaddons-${KF5MIN}:5
+                >=kde-frameworks/kguiaddons-${KF5MIN}:5
+                >=kde-frameworks/ki18n-${KF5MIN}:5
+                >=kde-frameworks/kwidgetsaddons-${KF5MIN}:5
+                >=kde-frameworks/kwindowsystem-${KF5MIN}:5
+        )
 "
 DEPEND="${RDEPEND}
 	>=kde-frameworks/kservice-${KFMIN}:6
 "
 PDEPEND=">=kde-plasma/kde-cli-tools-${PVCUT}:*"
+
+src_preparesrc_configure() {
+        local mycmakeargs=(
+                -DBUILD_QT6=ON
+                -DBUILD_QT5=$(usex qt5)
+        )
+        ecm_src_configure
+}

--- a/kde-plasma/oxygen/oxygen-9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-9999.ebuild
@@ -3,9 +3,11 @@
 
 EAPI=8
 
+KF5MIN=5.102.0
 KFMIN=5.245.0
 PVCUT=$(ver_cut 1-3)
 QTMIN=6.6.0
+QT5MIN=5.15.2
 inherit ecm plasma.kde.org
 
 DESCRIPTION="Oxygen visual style for the Plasma desktop"

--- a/kde-plasma/oxygen/oxygen-9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-9999.ebuild
@@ -55,7 +55,7 @@ DEPEND="${RDEPEND}
 "
 PDEPEND=">=kde-plasma/kde-cli-tools-${PVCUT}:*"
 
-src_preparesrc_configure() {
+src_configure() {
         local mycmakeargs=(
                 -DBUILD_QT6=ON
                 -DBUILD_QT5=$(usex qt5)


### PR DESCRIPTION
Based on upstream the default is to build both qt5 and qt6. adding the ability to just build qt6.