### PR TITLE
metadata/pkgcheck.conf: ignore noisy and irrelevant checks

### DIFF
--- a/metadata/pkgcheck.conf
+++ b/metadata/pkgcheck.conf
@@ -1,0 +1,2 @@
+[kde]
+keywords = -EmptyGlobalAssignment,-UnknownCategoryDirs


### PR DESCRIPTION
Makes pkgcheck more usable.

Empty KEYWORDS and IUSE are prevalent in the tree.