### PR TITLE
Add missing remote-id's

### DIFF
--- a/app-admin/systemdgenie/metadata.xml
+++ b/app-admin/systemdgenie/metadata.xml
@@ -13,5 +13,6 @@
 			<email>rthomsen6@gmail.com</email>
 			<name>Ragnar Thomsen</name>
 		</maintainer>
+		<remote-id type="kde-invent">system/systemdgenie</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-misc/kookbook/metadata.xml
+++ b/app-misc/kookbook/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">utilities/kookbook</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-text/chmk/metadata.xml
+++ b/app-text/chmk/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">aacid/chmk</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-libs/kopeninghours/metadata.xml
+++ b/dev-libs/kopeninghours/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/kopeninghours</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-libs/kosmindoormap/metadata.xml
+++ b/dev-libs/kosmindoormap/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/kosmindoormap</remote-id>
 	</upstream>
 	<use>
 		<flag name="openinghours">Enable support for highlighting currently open amenities/shops/etc.</flag>

--- a/dev-libs/kpeoplevcard/metadata.xml
+++ b/dev-libs/kpeoplevcard/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">pim/kpeoplevcard</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-libs/plasma-wayland-protocols/metadata.xml
+++ b/dev-libs/plasma-wayland-protocols/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/plasma-wayland-protocols</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/games-board/atlantik/metadata.xml
+++ b/games-board/atlantik/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">games/atlantik</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/games-mud/kmuddy/metadata.xml
+++ b/games-mud/kmuddy/metadata.xml
@@ -11,5 +11,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">games/kmuddy</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/gui-apps/liquidshell/metadata.xml
+++ b/gui-apps/liquidshell/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">system/liquidshell</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-apps/akonadi-search/metadata.xml
+++ b/kde-apps/akonadi-search/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">pim/akonadi-search</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-misc/akonadiclient/metadata.xml
+++ b/kde-misc/akonadiclient/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">pim/akonadiclient</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-misc/basket/metadata.xml
+++ b/kde-misc/basket/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">utilities/basket</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-misc/kio-stash/metadata.xml
+++ b/kde-misc/kio-stash/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">utilities/kio-stash</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-misc/polkit-kde-kcmodules/metadata.xml
+++ b/kde-misc/polkit-kde-kcmodules/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">system/polkit-kde-kcmodules-1</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/breeze-gtk/metadata.xml
+++ b/kde-plasma/breeze-gtk/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/breeze-gtk</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/kde-cli-tools/metadata.xml
+++ b/kde-plasma/kde-cli-tools/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/kde-cli-tools</remote-id>
 	</upstream>
 	<use>
 		<flag name="kdesu">Build graphical frontend for <pkg>kde-frameworks/kdesu</pkg></flag>

--- a/kde-plasma/kmenuedit/metadata.xml
+++ b/kde-plasma/kmenuedit/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/kmenuedit</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/kscreen/metadata.xml
+++ b/kde-plasma/kscreen/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/kscreen</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/milou/metadata.xml
+++ b/kde-plasma/milou/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/milou</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/oxygen-sounds/metadata.xml
+++ b/kde-plasma/oxygen-sounds/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/oxygen-sounds</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/sddm-kcm/metadata.xml
+++ b/kde-plasma/sddm-kcm/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/sddm-kcm</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/kde-plasma/xembed-sni-proxy/metadata.xml
+++ b/kde-plasma/xembed-sni-proxy/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/plasma-workspace</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/media-libs/kquickimageeditor/metadata.xml
+++ b/media-libs/kquickimageeditor/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/kquickimageeditor</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/media-libs/ksanecore/metadata.xml
+++ b/media-libs/ksanecore/metadata.xml
@@ -5,4 +5,7 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="kde-invent">libraries/ksanecore</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-libs/pulseaudio-qt/metadata.xml
+++ b/media-libs/pulseaudio-qt/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/pulseaudio-qt</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-libs/libmediawiki/metadata.xml
+++ b/net-libs/libmediawiki/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/libmediawiki</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-libs/libtmdbqt/metadata.xml
+++ b/net-libs/libtmdbqt/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">libraries/libtmdbqt</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-libs/telepathy-logger-qt/metadata.xml
+++ b/net-libs/telepathy-logger-qt/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">network/telepathy-logger-qt</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-misc/samba-mounter/metadata.xml
+++ b/net-misc/samba-mounter/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">system/samba-mounter</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Some low hanging fruit.

This is just what pkgcheck reports, so packages without non live packages are missed (pkgcheck only checks SRC_URI and HOMEPAGE for the check).