### PR TITLE
.github/workflows: fetch full history for pkgcheck actions

### DIFF
--- a/.github/workflows/pkgcheck.yaml
+++ b/.github/workflows/pkgcheck.yaml
@@ -9,5 +9,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Run pkgcheck
         uses: pkgcore/pkgcheck-action@v1

--- a/.github/workflows/pkgcheck_merge.yaml
+++ b/.github/workflows/pkgcheck_merge.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Run pkgcheck
         uses: pkgcore/pkgcheck-action@v1
         with:


### PR DESCRIPTION
https://github.com/gentoo/kde/pull/960#issuecomment-1862435383

@a17r @thesamesam 

pkgcheck uses git history for some of its checks so its best to have the whole history to have less false positives.

This wont stop cases where you are blocking versions that only existed on ::gentoo and were never in ::kde.

Such as

```
kde-plasma/plasma-desktop
  NonexistentBlocker: version 5.27.49.9999: nonexistent blocker RDEPEND="!<kde-plasma/kdeplasma-addons-5.25.50": no matches in repo history
  NonexistentBlocker: version 9999: nonexistent blocker RDEPEND="!<kde-plasma/kdeplasma-addons-5.25.50": no matches in repo history
 ```