### PR TITLE
kde-plasma/kwin: require wayland to be enabled in KF dependencies

### DIFF
--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -37,16 +37,16 @@ COMMON_DEPEND="
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/kdeclarative-${KFMIN}:6
 	>=kde-frameworks/kglobalaccel-${KFMIN}:6=[X(+)]
-	>=kde-frameworks/kguiaddons-${KFMIN}:6
+	>=kde-frameworks/kguiaddons-${KFMIN}:6[wayland]
 	>=kde-frameworks/ki18n-${KFMIN}:6
-	>=kde-frameworks/kidletime-${KFMIN}:6=
+	>=kde-frameworks/kidletime-${KFMIN}:6=[wayland]
 	>=kde-frameworks/knewstuff-${KFMIN}:6
 	>=kde-frameworks/knotifications-${KFMIN}:6
 	>=kde-frameworks/kpackage-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-frameworks/kwindowsystem-${KFMIN}:6=[X]
+	>=kde-frameworks/kwindowsystem-${KFMIN}:6=[wayland,X]
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-plasma/breeze-${PVCUT}:6
 	>=kde-plasma/kdecoration-${PVCUT}:6
@@ -80,7 +80,7 @@ RDEPEND="${COMMON_DEPEND}
 	!kde-plasma/kwayland-server
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${PVCUT}:6[wayland]
 	sys-apps/hwdata
 	x11-base/xwayland
 	multimedia? ( >=dev-qt/qtmultimedia-${QTMIN}:6[gstreamer,qml] )


### PR DESCRIPTION
* Kwin uses wayland unconditionally and expects wayland headers which are available only with the wayland use flags.