### PR TITLE
.github/workflows: ignore more keywords for merge requests

### DIFF
--- a/.github/workflows/pkgcheck_merge.yaml
+++ b/.github/workflows/pkgcheck_merge.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Run pkgcheck
         uses: pkgcore/pkgcheck-action@v1
         with:
-          args: --exit warning --commits HEAD^..${{ github.sha }}
+          args: --exit warning -k ,-EmptyGlobalAssignment,-NonexistentBlocker,-UnknownCategoryDirs --commits HEAD^..${{ github.sha }}


### PR DESCRIPTION
* Kde overlay adds blockers for packages that are outside the repo, which means false positives.