### PR TITLE
kde-apps/dolphin-plugins-git: Don't punt XmlGui

### DIFF
--- a/kde-apps/dolphin-plugins-git/dolphin-plugins-git-9999.ebuild
+++ b/kde-apps/dolphin-plugins-git/dolphin-plugins-git-9999.ebuild
@@ -38,9 +38,8 @@ src_prepare() {
 	# solid, qtdbus only required by mountiso
 	ecm_punt_qt_module DBus
 	ecm_punt_kf_module Solid
-	# kxmlgui, qtnetwork only required by dropbox
+	# qtnetwork only required by dropbox
 	ecm_punt_qt_module Network
-	ecm_punt_kf_module XmlGui
 	# delete non-${PN} translations
 	find po -type f -name "*po" -and -not -name "*${MY_PLUGIN_NAME}plugin" -delete || die
 }


### PR DESCRIPTION
The build currently fails as it can't find XmlGui