### PR TITLE
Stop KDE6 from pulling in Qt5

### DIFF
--- a/dev-libs/plasma-wayland-protocols/plasma-wayland-protocols-9999.ebuild
+++ b/dev-libs/plasma-wayland-protocols/plasma-wayland-protocols-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_NONGUI=true
-KFMIN=5.82.0
+KFMIN=5.240.0
 inherit ecm kde.org
 
 DESCRIPTION="Plasma Specific Protocols for Wayland"

--- a/eclass/ecm.eclass
+++ b/eclass/ecm.eclass
@@ -277,11 +277,6 @@ BDEPEND+="
 	>=kde-frameworks/extra-cmake-modules-${KFMIN}:*
 "
 RDEPEND+=" >=kde-frameworks/kf-env-4"
-if [[ ${_KFSLOT} == 6 ]]; then
-	COMMONDEPEND+=" dev-qt/qtbase:${_KFSLOT}"
-else
-	COMMONDEPEND+=" dev-qt/qtcore:${_KFSLOT}"
-fi
 
 DEPEND+=" ${COMMONDEPEND}"
 RDEPEND+=" ${COMMONDEPEND}"


### PR DESCRIPTION
Remove dependencies on qdbus:5 from kde6 ebuilds