### PR TITLE
kde-plasma/plasma-desktop: install our own mimeapps.list

### DIFF
--- a/kde-plasma/plasma-desktop/files/mimeapps.list
+++ b/kde-plasma/plasma-desktop/files/mimeapps.list
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: None
+
+[Default Applications]
+
+# Misc
+application/x-krita=org.kde.krita.desktop;org.kde.gwenview.desktop
+image/x-xcf=org.gimp.GIMP.desktop;org.kde.gwenview.desktop
+
+# Discover
+x-scheme-handler/appstream=org.kde.discover.urlhandler.desktop
+application/vnd.debian.binary-package=org.kde.discover.desktop
+
+# Archive Manager
+application/x-tar=org.kde.ark.desktop
+application/x-compressed-tar=org.kde.ark.desktop
+application/x-bzip-compressed-tar=org.kde.ark.desktop
+application/x-tarz=org.kde.ark.desktop
+application/x-xz-compressed-tar=org.kde.ark.desktop
+application/x-lzma-compressed-tar=org.kde.ark.desktop
+application/x-lzip-compressed-tar=org.kde.ark.desktop
+application/x-tzo=org.kde.ark.desktop
+application/x-lrzip-compressed-tar=org.kde.ark.desktop
+application/x-lz4-compressed-tar=org.kde.ark.desktop
+application/x-zstd-compressed-tar=org.kde.ark.desktop
+application/x-cd-image=org.kde.ark.desktop
+application/x-bcpio=org.kde.ark.desktop
+application/x-cpio=org.kde.ark.desktop
+application/x-cpio-compressed=org.kde.ark.desktop
+application/x-sv4cpio=org.kde.ark.desktop
+application/x-sv4crc=org.kde.ark.desktop
+application/x-source-rpm=org.kde.ark.desktop
+application/vnd.ms-cab-compressed=org.kde.ark.desktop
+application/x-xar=org.kde.ark.desktop
+application/x-iso9660-appimage=org.kde.ark.desktop
+application/x-archive=org.kde.ark.desktop
+application/vnd.rar=org.kde.ark.desktop
+application/x-rar=org.kde.ark.desktop
+application/x-7z-compressed=org.kde.ark.desktop
+application/zip=org.kde.ark.desktop
+application/x-compress=org.kde.ark.desktop
+application/gzip=org.kde.ark.desktop
+application/x-bzip=org.kde.ark.desktop
+application/x-lzma=org.kde.ark.desktop
+application/x-xz=org.kde.ark.desktop
+application/zstd=org.kde.ark.desktop
+application/x-lha=org.kde.ark.desktop
+
+# Browser
+x-scheme-handler/http=org.kde.falkon.desktop
+x-scheme-handler/https=org.kde.falkon.desktop
+
+# Email
+x-scheme-handler/mailto=org.kde.kmail2.desktop
+
+# File Manager
+inode/directory=org.kde.dolphin.desktop
+
+# Geo
+x-scheme-handler/geo=marble_geo.desktop
+
+# Image Viewer
+image/avif=org.kde.gwenview.desktop
+image/gif=org.kde.gwenview.desktop
+image/heif=org.kde.gwenview.desktop
+image/jpeg=org.kde.gwenview.desktop
+image/jxl=org.kde.gwenview.desktop
+image/png=org.kde.gwenview.desktop
+image/bmp=org.kde.gwenview.desktop
+image/x-eps=org.kde.gwenview.desktop
+image/x-icns=org.kde.gwenview.desktop
+image/x-ico=org.kde.gwenview.desktop
+image/x-portable-bitmap=org.kde.gwenview.desktop
+image/x-portable-graymap=org.kde.gwenview.desktop
+image/x-portable-pixmap=org.kde.gwenview.desktop
+image/x-xbitmap=org.kde.gwenview.desktop
+image/x-xpixmap=org.kde.gwenview.desktop
+image/tiff=org.kde.gwenview.desktop
+image/x-psd=org.kde.gwenview.desktop
+image/x-webp=org.kde.gwenview.desktop
+image/webp=org.kde.gwenview.desktop
+image/x-tga=org.kde.gwenview.desktop
+
+# Music Player
+audio/aac=org.kde.elisa.desktop
+audio/mp4=org.kde.elisa.desktop
+audio/mpeg=org.kde.elisa.desktop
+audio/mpegurl=org.kde.elisa.desktop
+audio/ogg=org.kde.elisa.desktop
+audio/vnd.rn-realaudio=org.kde.elisa.desktop
+audio/vorbis=org.kde.elisa.desktop
+audio/x-flac=org.kde.elisa.desktop
+audio/x-mp3=org.kde.elisa.desktop
+audio/x-mpegurl=org.kde.elisa.desktop
+audio/x-ms-wma=org.kde.elisa.desktop
+audio/x-musepack=org.kde.elisa.desktop
+audio/x-oggflac=org.kde.elisa.desktop
+audio/x-pn-realaudio=org.kde.elisa.desktop
+audio/x-scpls=org.kde.elisa.desktop
+audio/x-speex=org.kde.elisa.desktop
+audio/x-vorbis=org.kde.elisa.desktop
+audio/x-vorbis+ogg=org.kde.elisa.desktop
+audio/x-wav=org.kde.elisa.desktop
+
+# PDF Viewer
+application/pdf=okularApplication_pdf.desktop
+
+# Tel
+x-scheme-handler/tel=org.kde.kdeconnect.handler.desktop
+
+# Text Editor
+text/plain=org.kde.kate.desktop;org.kde.kwrite.desktop
+text/x-cmake=org.kde.kate.desktop;org.kde.kwrite.desktop
+text/markdown=org.kde.kate.desktop;org.kde.kwrite.desktop
+application/x-docbook+xml=org.kde.kate.desktop;org.kde.kwrite.desktop
+application/json=org.kde.kate.desktop;org.kde.kwrite.desktop
+application/x-yaml=org.kde.kate.desktop;org.kde.kwrite.desktop
+
+# Video Player
+video/3gp=org.kde.haruna.desktop
+video/3gpp=org.kde.haruna.desktop
+video/3gpp2=org.kde.haruna.desktop
+video/avi=org.kde.haruna.desktop
+video/divx=org.kde.haruna.desktop
+video/dv=org.kde.haruna.desktop
+video/fli=org.kde.haruna.desktop
+video/flv=org.kde.haruna.desktop
+video/mp2t=org.kde.haruna.desktop
+video/mp4=org.kde.haruna.desktop
+video/mp4v-es=org.kde.haruna.desktop
+video/mpeg=org.kde.haruna.desktop
+video/msvideo=org.kde.haruna.desktop
+video/ogg=org.kde.haruna.desktop
+video/quicktime=org.kde.haruna.desktop
+video/vnd.divx=org.kde.haruna.desktop
+video/vnd.mpegurl=org.kde.haruna.desktop
+video/vnd.rn-realvideo=org.kde.haruna.desktop
+video/webm=org.kde.haruna.desktop
+video/x-avi=org.kde.haruna.desktop
+video/x-flv=org.kde.haruna.desktop
+video/x-m4v=org.kde.haruna.desktop
+video/x-matroska=org.kde.haruna.desktop
+video/x-mpeg2=org.kde.haruna.desktop
+video/x-ms-asf=org.kde.haruna.desktop
+video/x-msvideo=org.kde.haruna.desktop
+video/x-ms-wmv=org.kde.haruna.desktop
+video/x-ms-wmx=org.kde.haruna.desktop
+video/x-ogm=org.kde.haruna.desktop
+video/x-ogm+ogg=org.kde.haruna.desktop
+video/x-theora=org.kde.haruna.desktop
+video/x-theora+ogg=org.kde.haruna.desktop
+application/x-matroska=org.kde.haruna.desktop

--- a/kde-plasma/plasma-desktop/files/mimeapps.list
+++ b/kde-plasma/plasma-desktop/files/mimeapps.list
@@ -9,7 +9,6 @@ image/x-xcf=org.gimp.GIMP.desktop;org.kde.gwenview.desktop
 
 # Discover
 x-scheme-handler/appstream=org.kde.discover.urlhandler.desktop
-application/vnd.debian.binary-package=org.kde.discover.desktop
 
 # Archive Manager
 application/x-tar=org.kde.ark.desktop
@@ -47,8 +46,8 @@ application/zstd=org.kde.ark.desktop
 application/x-lha=org.kde.ark.desktop
 
 # Browser
-x-scheme-handler/http=org.kde.falkon.desktop
-x-scheme-handler/https=org.kde.falkon.desktop
+x-scheme-handler/http=firefox.desktop;firefox-bin.desktop;chromium-browser-chromium.desktop;google-chrome.desktop;org.kde.falkon.desktop;
+x-scheme-handler/https=firefox.desktop;firefox-bin.desktop;chromium-browser-chromium.desktop;google-chrome.desktop;org.kde.falkon.desktop;
 
 # Email
 x-scheme-handler/mailto=org.kde.kmail2.desktop
@@ -102,6 +101,61 @@ audio/x-vorbis=org.kde.elisa.desktop
 audio/x-vorbis+ogg=org.kde.elisa.desktop
 audio/x-wav=org.kde.elisa.desktop
 
+# Office (spreadsheets)
+application/csv=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/excel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/msexcel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/tab-separated-values=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/vnd.lotus-1-2-3=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/vnd.ms-excel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-123=libreoffice-calc.desktop;
+application/x-dos_ms_excel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-excel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-mps=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-ms-excel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-msexcel=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-xbase=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/x-xls=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/xls=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/comma-separated-values=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/csv=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/spreadsheet=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/tab-separated-values=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/x-comma-separated-values=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+text/x-csv=org.kde.calligrasheets.desktop;libreoffice-calc.desktop;
+application/vnd.oasis.opendocument.spreadsheet=libreoffice-calc.desktop;
+application/vnd.oasis.opendocument.spreadsheet-template=libreoffice-calc.desktop;
+application/vnd.sun.xml.calc=libreoffice-calc.desktop;
+application/vnd.sun.xml.calc.template=libreoffice-calc.desktop;
+application/vnd.stardivision.calc=libreoffice-calc.desktop;
+application/vnd.stardivision.chart=libreoffice-calc.desktop;
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-calc.desktop;
+application/vnd.ms-excel.sheet.macroenabled.12=libreoffice-calc.desktop;
+application/vnd.openxmlformats-officedocument.spreadsheetml.template=libreoffice-calc.desktop;
+application/vnd.ms-excel.template.macroenabled.12=libreoffice-calc.desktop;
+application/vnd.ms-excel.sheet.binary.macroenabled.12=libreoffice-calc.desktop;
+application/vnd.oasis.opendocument.graphics=libreoffice-draw.desktop;
+application/vnd.oasis.opendocument.graphics-template=libreoffice-draw.desktop;
+application/vnd.sun.xml.draw=libreoffice-draw.desktop;
+application/vnd.sun.xml.draw.template=libreoffice-draw.desktop;
+application/vnd.stardivision.draw=libreoffice-draw.desktop;
+application/vnd.oasis.opendocument.formula=libreoffice-math.desktop;
+application/vnd.sun.xml.math=libreoffice-math.desktop;
+application/vnd.stardivision.math=libreoffice-math.desktop;
+
+# Office (presentations)
+application/vnd.oasis.opendocument.presentation=libreoffice-impress.desktop;
+application/vnd.oasis.opendocument.presentation-template=libreoffice-impress.desktop;
+application/vnd.sun.xml.impress=libreoffice-impress.desktop;
+application/vnd.sun.xml.impress.template=libreoffice-impress.desktop;
+application/vnd.stardivision.impress=libreoffice-impress.desktop;
+application/mspowerpoint=libreoffice-impress.desktop;
+application/vnd.ms-powerpoint=libreoffice-impress.desktop;
+application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-impress.desktop;
+application/vnd.ms-powerpoint.presentation.macroenabled.12=libreoffice-impress.desktop;
+application/vnd.openxmlformats-officedocument.presentationml.template=libreoffice-impress.desktop;
+application/vnd.ms-powerpoint.template.macroenabled.12=libreoffice-impress.desktop;
+
 # PDF Viewer
 application/pdf=okularApplication_pdf.desktop
 
@@ -112,9 +166,29 @@ x-scheme-handler/tel=org.kde.kdeconnect.handler.desktop
 text/plain=org.kde.kate.desktop;org.kde.kwrite.desktop
 text/x-cmake=org.kde.kate.desktop;org.kde.kwrite.desktop
 text/markdown=org.kde.kate.desktop;org.kde.kwrite.desktop
+text/richtext=libreoffice-writer.desktop;org.kde.kate.desktop;org.kde.kwrite.desktop
+text/rtf=libreoffice-writer.desktop;org.kde.kate.desktop;org.kde.kwrite.desktop
 application/x-docbook+xml=org.kde.kate.desktop;org.kde.kwrite.desktop
 application/json=org.kde.kate.desktop;org.kde.kwrite.desktop
 application/x-yaml=org.kde.kate.desktop;org.kde.kwrite.desktop
+application/rtf=libreoffice-writer.desktop;org.kde.kate.desktop;org.kde.kwrite.desktop
+application/vnd.oasis.opendocument.text=libreoffice-writer.desktop;
+application/vnd.oasis.opendocument.text-template=libreoffice-writer.desktop;
+application/vnd.oasis.opendocument.text-web=libreoffice-writer.desktop;
+application/vnd.oasis.opendocument.text-master=libreoffice-writer.desktop;
+application/vnd.sun.xml.writer=libreoffice-writer.desktop;
+application/vnd.sun.xml.writer.template=libreoffice-writer.desktop;
+application/vnd.sun.xml.writer.global=libreoffice-writer.desktop;
+application/vnd.stardivision.writer=libreoffice-writer.desktop;
+application/msword=libreoffice-writer.desktop;
+application/vnd.ms-word=libreoffice-writer.desktop;
+application/x-doc=libreoffice-writer.desktop;
+application/vnd.wordperfect=libreoffice-writer.desktop;
+application/wordperfect=libreoffice-writer.desktop;
+application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoffice-writer.desktop;
+application/vnd.ms-word.document.macroenabled.12=libreoffice-writer.desktop;
+application/vnd.openxmlformats-officedocument.wordprocessingml.template=libreoffice-writer.desktop;
+application/vnd.ms-word.template.macroenabled.12=libreoffice-writer.desktop;
 
 # Video Player
 video/3gp=org.kde.haruna.desktop

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -178,6 +178,16 @@ src_test() {
 	ecm_src_test
 }
 
+src_install() {
+	ecm_src_install
+
+	# TODO: Should we just remove the upstream one in /usr/share?
+	# /etc/xdg should really be available for site-local overrides, but then
+	# again we have CONFIG_PROTECT...
+	insinto /etc/xdg/mimeapps.list
+	doins "${FILESDIR}"/mimeapps.list
+}
+
 pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "screen reader support" "app-accessibility/orca"


### PR DESCRIPTION
Start by importing kde-plasma/plasma-desktop's own mimeapps.list and updating
the list in subsequent commits for easier review.

Bug: https://bugs.gentoo.org/926412
Signed-off-by: Sam James <sam@gentoo.org>

--
This is still very rough and I need to proof-read it, even. Let alone test it.