### PR TITLE
kde-plasma/discover: update use dep on snapd-glib

### DIFF
--- a/kde-plasma/discover/discover-6.0.49.9999.ebuild
+++ b/kde-plasma/discover/discover-6.0.49.9999.ebuild
@@ -42,7 +42,7 @@ DEPEND="
 	>=kde-frameworks/purpose-${KFMIN}:6
 	firmware? ( >=sys-apps/fwupd-1.9.4 )
 	flatpak? ( sys-apps/flatpak )
-	snap? ( sys-libs/snapd-glib:=[qt6(-)] )
+	snap? ( sys-libs/snapd-glib:=[qt6(-),-qt5(-)] )
 	telemetry? ( >=kde-frameworks/kuserfeedback-${KFMIN}:6 )
 	webengine? ( >=dev-qt/qtwebview-${QTMIN}:6 )
 "

--- a/kde-plasma/discover/discover-9999.ebuild
+++ b/kde-plasma/discover/discover-9999.ebuild
@@ -42,7 +42,7 @@ DEPEND="
 	>=kde-frameworks/purpose-${KFMIN}:6
 	firmware? ( >=sys-apps/fwupd-1.9.4 )
 	flatpak? ( sys-apps/flatpak )
-	snap? ( sys-libs/snapd-glib:=[qt6(-)] )
+	snap? ( sys-libs/snapd-glib:=[qt6(-),-qt5(-)] )
 	telemetry? ( >=kde-frameworks/kuserfeedback-${KFMIN}:6 )
 	webengine? ( >=dev-qt/qtwebview-${QTMIN}:6 )
 "


### PR DESCRIPTION
Version 1.65 of snapd-glib now allows building both for qt5 and qt6, though not at the same time. As per [Qt packaging policy](https://wiki.gentoo.org/wiki/Project:Qt/Policies) I have implemented both a `qt5` and `qt6` flag in this version and we prefer qt5 over qt6 if both flags are enabled.

This implies some changes in the discover:6 ebuild. To get the snapd-glib library we need, we must not only ensure the `qt6` flag is enabled, but also ensure the `qt5` flag is disabled.