### PR TITLE
Fix `net-libs/signond` atom operator in `Documentation/package.*/`

### DIFF
--- a/Documentation/package.accept_keywords/.kde-frameworks-6.1/more-deps
+++ b/Documentation/package.accept_keywords/.kde-frameworks-6.1/more-deps
@@ -8,7 +8,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-frameworks-live.base/more-deps
+++ b/Documentation/package.accept_keywords/.kde-frameworks-live.base/more-deps
@@ -8,7 +8,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-frameworks-live/more-deps
+++ b/Documentation/package.accept_keywords/.kde-frameworks-live/more-deps
@@ -8,7 +8,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-gear-24.02/more-deps
+++ b/Documentation/package.accept_keywords/.kde-gear-24.02/more-deps
@@ -16,7 +16,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-gear-24.05.49.9999/more-deps
+++ b/Documentation/package.accept_keywords/.kde-gear-24.05.49.9999/more-deps
@@ -16,7 +16,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-gear-24.05/more-deps
+++ b/Documentation/package.accept_keywords/.kde-gear-24.05/more-deps
@@ -16,7 +16,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-gear-live.base/more-deps
+++ b/Documentation/package.accept_keywords/.kde-gear-live.base/more-deps
@@ -16,7 +16,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-gear-live/more-deps
+++ b/Documentation/package.accept_keywords/.kde-gear-live/more-deps
@@ -16,7 +16,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/.kde-plasma-6.0/more-deps
+++ b/Documentation/package.accept_keywords/.kde-plasma-6.0/more-deps
@@ -9,6 +9,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.accept_keywords/.kde-plasma-live.base/more-deps
+++ b/Documentation/package.accept_keywords/.kde-plasma-live.base/more-deps
@@ -9,6 +9,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.accept_keywords/.kde-plasma-live/more-deps
+++ b/Documentation/package.accept_keywords/.kde-plasma-live/more-deps
@@ -9,6 +9,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.accept_keywords/kde-frameworks-6.1.keywords
+++ b/Documentation/package.accept_keywords/kde-frameworks-6.1.keywords
@@ -86,7 +86,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-frameworks-live.keywords
+++ b/Documentation/package.accept_keywords/kde-frameworks-live.keywords
@@ -86,7 +86,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-gear-24.02.keywords
+++ b/Documentation/package.accept_keywords/kde-gear-24.02.keywords
@@ -265,7 +265,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-gear-24.05.49.9999.keywords
+++ b/Documentation/package.accept_keywords/kde-gear-24.05.49.9999.keywords
@@ -267,7 +267,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-gear-24.05.keywords
+++ b/Documentation/package.accept_keywords/kde-gear-24.05.keywords
@@ -267,7 +267,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-gear-live.keywords
+++ b/Documentation/package.accept_keywords/kde-gear-live.keywords
@@ -267,7 +267,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.accept_keywords/kde-plasma-6.0.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-6.0.keywords
@@ -74,6 +74,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.accept_keywords/kde-plasma-live.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-live.keywords
@@ -74,6 +74,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.mask/kde-frameworks-6.1
+++ b/Documentation/package.mask/kde-frameworks-6.1
@@ -87,7 +87,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.mask/kde-frameworks-live
+++ b/Documentation/package.mask/kde-frameworks-live
@@ -87,7 +87,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.mask/kde-gear-24.02
+++ b/Documentation/package.mask/kde-gear-24.02
@@ -262,7 +262,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.mask/kde-gear-24.05
+++ b/Documentation/package.mask/kde-gear-24.05
@@ -264,7 +264,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.mask/kde-gear-live
+++ b/Documentation/package.mask/kde-gear-live
@@ -254,7 +254,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.mask/kde-plasma-6.0
+++ b/Documentation/package.mask/kde-plasma-6.0
@@ -73,6 +73,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.mask/kde-plasma-live
+++ b/Documentation/package.mask/kde-plasma-live
@@ -73,6 +73,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.unmask/.kde-frameworks-6.1/more-deps
+++ b/Documentation/package.unmask/.kde-frameworks-6.1/more-deps
@@ -9,7 +9,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/.kde-frameworks-live/more-deps
+++ b/Documentation/package.unmask/.kde-frameworks-live/more-deps
@@ -9,7 +9,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/.kde-gear-24.02/more-deps
+++ b/Documentation/package.unmask/.kde-gear-24.02/more-deps
@@ -13,7 +13,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/.kde-gear-24.05/more-deps
+++ b/Documentation/package.unmask/.kde-gear-24.05/more-deps
@@ -13,7 +13,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/.kde-gear-live/more-deps
+++ b/Documentation/package.unmask/.kde-gear-live/more-deps
@@ -13,7 +13,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/.kde-plasma-6.0/more-deps
+++ b/Documentation/package.unmask/.kde-plasma-6.0/more-deps
@@ -8,6 +8,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.unmask/.kde-plasma-live/more-deps
+++ b/Documentation/package.unmask/.kde-plasma-live/more-deps
@@ -8,6 +8,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.unmask/kde-frameworks-6.1
+++ b/Documentation/package.unmask/kde-frameworks-6.1
@@ -87,7 +87,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/kde-frameworks-live
+++ b/Documentation/package.unmask/kde-frameworks-live
@@ -87,7 +87,7 @@
 ~media-libs/phonon-vlc-0.12.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/kde-gear-24.02
+++ b/Documentation/package.unmask/kde-gear-24.02
@@ -262,7 +262,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/kde-gear-24.05
+++ b/Documentation/package.unmask/kde-gear-24.05
@@ -264,7 +264,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/kde-gear-live
+++ b/Documentation/package.unmask/kde-gear-live
@@ -254,7 +254,7 @@
 ~net-libs/accounts-qt-1.17
 ~net-libs/kdsoap-2.2.0
 ~net-libs/kdsoap-ws-discovery-client-0.4.0
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016
 ~sys-auth/polkit-qt-0.200.0

--- a/Documentation/package.unmask/kde-plasma-6.0
+++ b/Documentation/package.unmask/kde-plasma-6.0
@@ -73,6 +73,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016

--- a/Documentation/package.unmask/kde-plasma-live
+++ b/Documentation/package.unmask/kde-plasma-live
@@ -73,6 +73,6 @@
 ~media-libs/libqaccessibilityclient-0.6.0
 ~net-libs/accounts-qml-0.7_p20231028
 ~net-libs/accounts-qt-1.17
-~net-libs/signond-8.61-r100
+=net-libs/signond-8.61-r100
 ~net-libs/signon-oauth2-0.25_p20210102
 ~net-libs/signon-ui-0.15_p20231016


### PR DESCRIPTION
Currently, the files in `Documentation/package.*/` contain this atom:

```
~net-libs/signond-8.61-r100
```

Which leads to pkgcore warnings:

```
WARNING:pkgcore:'/etc/portage/package.accept_keywords/kde-frameworks-6.1.keywords', line 89: parsing error: invalid package atom: '~net-libs/signond-8.61-r100': ~ revision operator cannot be combined with a revision
```

This fixes it by switching to:

```
=net-libs/signond-8.61-r100
```