### PR TITLE
kde-frameworks/breeze-icons: use BUILD_TESTING option for tests

### DIFF
--- a/kde-frameworks/breeze-icons/breeze-icons-9999.ebuild
+++ b/kde-frameworks/breeze-icons/breeze-icons-9999.ebuild
@@ -31,11 +31,6 @@ python_check_deps() {
 	python_has_version "dev-python/lxml[${PYTHON_USEDEP}]"
 }
 
-src_prepare() {
-	cmake_src_prepare
-	use test || cmake_comment_add_subdirectory autotests
-}
-
 src_configure() {
 	# bug #931904
 	filter-lto
@@ -43,6 +38,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DPython_EXECUTABLE="${PYTHON}"
 		-DBINARY_ICONS_RESOURCE=ON # TODO: remove when kexi was ported away
+		-DBUILD_TESTING="$(usex test)"
 		-DSKIP_INSTALL_ICONS=OFF
 	)
 	cmake_src_configure


### PR DESCRIPTION
https://invent.kde.org/frameworks/breeze-icons/-/commit/bedbd58775b3f504d8fdf30ac80ee11f91a0d421

include(ECMAddTests) in autotests/CMakeListst.txt implicitly brings in https://api.kde.org/ecm/module/ECMMarkNonGuiExecutable.html

```
kde-test-9999 ~ # zcat /var/log/portage/build/kde-frameworks/breeze-icons-9999\:20240610-175928.log.gz 
 * Package:    kde-frameworks/breeze-icons-9999:6/9999
 * Repository: kde
 * Maintainer: kde@gentoo.org
 * Upstream:   https://bugs.kde.org/
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
 * Checking whether python3_12 is suitable ...
 *   dev-lang/python:3.12 ...                                                                                              [ ok ]
 *   python_check_deps ...
 *     dev-python/lxml[python_targets_python3_12(-)] ...                                                                   [ ok ]
 * Using python3.12 to build (via PYTHON_COMPAT iteration)
>>> Unpacking source...
 * Repository id: frameworks_breeze-icons.git
 * To override fetched repository properties, use:
 *   EGIT_OVERRIDE_REPO_FRAMEWORKS_BREEZE_ICONS
 *   EGIT_OVERRIDE_BRANCH_FRAMEWORKS_BREEZE_ICONS
 *   EGIT_OVERRIDE_COMMIT_FRAMEWORKS_BREEZE_ICONS
 *   EGIT_OVERRIDE_COMMIT_DATE_FRAMEWORKS_BREEZE_ICONS
 * 
 * Fetching https://invent.kde.org/frameworks/breeze-icons.git ...
git fetch https://invent.kde.org/frameworks/breeze-icons.git +HEAD:refs/git-r3/HEAD
remote: Enumerating objects: 31, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 31 (delta 4), reused 31 (delta 4), pack-reused 0 (from 0)
Unpacking objects: 100% (31/31), 191.33 KiB | 1.93 MiB/s, done.
From https://invent.kde.org/frameworks/breeze-icons
   41e60007..cfa235db  HEAD       -> refs/git-r3/HEAD
 * [new tag]           v6.3.0     -> v6.3.0
git symbolic-ref refs/git-r3/kde-frameworks/breeze-icons/6/__main__ refs/git-r3/HEAD
 * Checking out https://invent.kde.org/frameworks/breeze-icons.git to /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999 ...
git checkout --quiet refs/git-r3/HEAD
GIT update -->
   repository:               https://invent.kde.org/frameworks/breeze-icons.git
   updating from commit:     41e600076cceaaaf60b8a57ecbb561ad2e2e4823
   to commit:                cfa235db6ac2787ff63d676008d4935aed382d01
 icons/actions/16/language-chooser-symbolic.svg           |  2 +-
 icons/actions/16/language-chooser.svg                    |  2 +-
 icons/actions/16/set-language-symbolic.svg               |  2 +-
 icons/actions/16/set-language.svg                        |  2 +-
 icons/actions/16/translate-symbolic.svg                  |  1 +
 icons/actions/16/translate.svg                           | 13 +++++++++++++
 icons/actions/22/language-chooser-symbolic.svg           |  2 +-
 icons/actions/22/language-chooser.svg                    |  2 +-
 icons/actions/22/set-language-symbolic.svg               |  2 +-
 icons/actions/22/set-language.svg                        |  2 +-
 icons/devices/16/network-wireless-bluetooth-symbolic.svg | 19 +------------------
 icons/devices/16/network-wireless-bluetooth.svg          | 18 ++++++++++++++++++
 icons/devices/22/network-wireless-bluetooth-symbolic.svg |  2 +-
 icons/devices/22/network-wireless-bluetooth.svg          |  1 +
 icons/places/16/folder-language-symbolic.svg             |  2 +-
 icons/places/16/folder-language.svg                      | 14 +-------------
 icons/status/16/crow-translate-tray-symbolic.svg         |  2 +-
 icons/status/16/crow-translate-tray.svg                  | 14 +-------------
 icons/status/22/network-wireless-bluetooth-symbolic.svg  | 24 +-----------------------
 icons/status/22/network-wireless-bluetooth.svg           | 23 +++++++++++++++++++++++
 src/tools/CMakeLists.txt                                 |  2 ++
 21 files changed, 73 insertions(+), 78 deletions(-)
>>> Source unpacked in /var/tmp/portage/kde-frameworks/breeze-icons-9999/work
>>> Preparing source in /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build"
>>> Source prepared.
/usr/bin/python3.12: can't open file '/usr/local/kde/Documentation/maintainers/cmake_dep_check_backup.py': [Errno 2] No such file or directory
 * Detected dependencies:
>>> Configuring source in /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build"
cmake -C /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build/gentoo_common_config.cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DPython_EXECUTABLE=/usr/bin/python3.12 -DBINARY_ICONS_RESOURCE=ON -DSKIP_INSTALL_ICONS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build/gentoo_toolchain.cmake /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999
loading initial cache file /var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build/gentoo_common_config.cmake
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- 

-- Installing in the same prefix as Qt, adopting their path scheme.
-- Could not set up the appstream test. appstreamcli is missing.
fatal: HEAD does not point to a branch
error: No such remote 'origin'
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Looking for __GLIBC__
-- Looking for __GLIBC__ - found
-- Performing Test _OFFT_IS_64BIT
-- Performing Test _OFFT_IS_64BIT - Success
-- Performing Test HAVE_DATE_TIME
-- Performing Test HAVE_DATE_TIME - Success
-- Performing Test BSYMBOLICFUNCTIONS_AVAILABLE
-- Performing Test BSYMBOLICFUNCTIONS_AVAILABLE - Success
-- Found OpenGL: /usr/lib64/libOpenGL.so
-- Found WrapOpenGL: TRUE
-- Found XKB: /usr/lib64/libxkbcommon.so (found suitable version "1.7.0", minimum required is "0.5.0")
-- Found WrapVulkanHeaders: /usr/include
-- Found Python: /usr/bin/python3.12 (found suitable version "3.12.4", minimum required is "3") found components: Interpreter
CMake Warning (dev) at CMakeLists.txt:40 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
This warning is for project developers.  Use -Wno-dev to suppress it.

running /usr/bin/python3.12 -c "import lxml; from lxml import etree; print(lxml.get_include())"  2>&1
['/usr/lib/python3.12/site-packages/lxml/includes', '/usr/lib/python3.12/site-packages/lxml', '/usr/lib/python3.12/site-packages/lxml/includes/__pycache__']
CMake Error at src/tools/CMakeLists.txt:4 (ecm_mark_nongui_executable):
  Unknown CMake command "ecm_mark_nongui_executable".


-- Configuring incomplete, errors occurred!
 * ERROR: kde-frameworks/breeze-icons-9999::kde failed (configure phase):
 *   cmake failed
 * 
 * Call stack:
 *     ebuild.sh, line  136:  Called src_configure
 *   environment, line 3636:  Called cmake_src_configure
 *   environment, line 1581:  Called die
 * The specific snippet of code:
 *       "${CMAKE_BINARY}" "${cmakeargs[@]}" "${CMAKE_USE_DIR}" || die "cmake failed";
 * 
 * If you need support, post the output of `emerge --info '=kde-frameworks/breeze-icons-9999::kde'`,
 * the complete build log and the output of `emerge -pqv '=kde-frameworks/breeze-icons-9999::kde'`.
 * The complete build log is located at '/var/log/portage/build/kde-frameworks/breeze-icons-9999:20240610-175928.log.gz'.
 * For convenience, a symlink to the build log is located at '/var/tmp/portage/kde-frameworks/breeze-icons-9999/temp/build.log.gz'.
 * The ebuild environment file is located at '/var/tmp/portage/kde-frameworks/breeze-icons-9999/temp/environment'.
 * Working directory: '/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999_build'
 * S: '/var/tmp/portage/kde-frameworks/breeze-icons-9999/work/breeze-icons-9999'
 ```