### PR TITLE
kde-frameworks/kauth: requires wayland backend unconditionally from k…

### DIFF
--- a/kde-frameworks/kauth/kauth-9999.ebuild
+++ b/kde-frameworks/kauth/kauth-9999.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	=kde-frameworks/kcoreaddons-${PVCUT}*:6
 	policykit? (
 		>=dev-qt/qtbase-${QTMIN}:6[dbus]
-		=kde-frameworks/kwindowsystem-${PVCUT}*:6
+		=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland]
 		>=sys-auth/polkit-qt-0.113.0[qt6(-)]
 	)
 "


### PR DESCRIPTION
…windowsystem

https://invent.kde.org/frameworks/kauth/-/commit/382b6ae8c7cc19cb2c1b1f5e8f32f767f09222ce

Closes: https://bugs.gentoo.org/934246

https://github.com/gentoo/gentoo/pull/37155