### PR TITLE
kde-plasma/plasma-meta: allow xdg-desktop-portal-gnome with USE=-unsu…

### DIFF
--- a/kde-plasma/plasma-meta/plasma-meta-6.1.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-6.1.49.9999.ebuild
@@ -107,7 +107,6 @@ RDEPEND="
 	thunderbolt? ( >=kde-plasma/plasma-thunderbolt-${PV}:${SLOT} )
 	!unsupported? (
 		!gui-apps/qt6ct
-		!sys-apps/xdg-desktop-portal-gnome
 	)
 	wacom? ( >=kde-plasma/wacomtablet-${PV}:${SLOT} )
 	wallpapers? ( >=kde-plasma/plasma-workspace-wallpapers-${PV}:${SLOT} )

--- a/kde-plasma/plasma-meta/plasma-meta-6.1.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-6.1.49.9999.ebuild
@@ -127,7 +127,8 @@ pkg_postinst() {
 		ewarn ""
 		ewarn "A possible (no warranty!) workaround is building sys-libs/libcxx and"
 		ewarn "sys-libs/libcxxabi with the following in package.env:"
-		ewarn " MYCMAKEARGS=\"-DLIBCXX_TYPEINFO_COMPARISON_IMPLEMENTATION=1\""
+		ewarn " MYCMAKEARGS=\"-DLIBCXX_TYPEINFO_COMPARISON_IMPLEMENTATION=2\""
+		ewarn "You may then need to rebuild dev-qt/* and kde-*/*."
 	fi
 
 	if ! use qt5 && has_version dev-qt/qtgui; then

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -107,7 +107,6 @@ RDEPEND="
 	thunderbolt? ( >=kde-plasma/plasma-thunderbolt-${PV}:${SLOT} )
 	!unsupported? (
 		!gui-apps/qt6ct
-		!sys-apps/xdg-desktop-portal-gnome
 	)
 	wacom? ( >=kde-plasma/wacomtablet-${PV}:${SLOT} )
 	wallpapers? ( >=kde-plasma/plasma-workspace-wallpapers-${PV}:${SLOT} )

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -127,7 +127,8 @@ pkg_postinst() {
 		ewarn ""
 		ewarn "A possible (no warranty!) workaround is building sys-libs/libcxx and"
 		ewarn "sys-libs/libcxxabi with the following in package.env:"
-		ewarn " MYCMAKEARGS=\"-DLIBCXX_TYPEINFO_COMPARISON_IMPLEMENTATION=1\""
+		ewarn " MYCMAKEARGS=\"-DLIBCXX_TYPEINFO_COMPARISON_IMPLEMENTATION=2\""
+		ewarn "You may then need to rebuild dev-qt/* and kde-*/*."
 	fi
 
 	if ! use qt5 && has_version dev-qt/qtgui; then


### PR DESCRIPTION
…pported

USE=-unsupported (the default) banning coinstalls with sys-apps/xdg-desktop-portal-gnome
caused issues with users either migrating between KDE Plasma and GNOME or
wanting to have both installed, so it prompted me to look into it again.

xdg-desktop-portal-kde installs kde-portals.conf which is used and preferred
within the Plasma desktop, so we have no issue here. (Done in upstream
commit ae9b326e55ca4a25a762cf0bfe96f5e947765833).

The recommendation to not coinstall them was added upstream in April 2023
at https://community.kde.org/index.php?title=Distributions/Packaging_Recommendations&diff=prev&oldid=96239,
while the aforementioned upstream commit is from May 2023.

Signed-off-by: Sam James <sam@gentoo.org>