### PR TITLE
Cleanup KAccounts situation + phonon backend IUSE change

### DIFF
--- a/kde-apps/akonadi/akonadi-24.05.49.9999.ebuild
+++ b/kde-apps/akonadi/akonadi-24.05.49.9999.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://community.kde.org/KDE_PIM/akonadi"
 LICENSE="LGPL-2.1+"
 SLOT="6"
 KEYWORDS=""
-IUSE="+kaccounts +mysql postgres sqlite tools xml"
+IUSE="+mysql postgres sqlite tools +webengine xml"
 
 REQUIRED_USE="|| ( mysql postgres sqlite ) test? ( tools )"
 
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	kaccounts? (
+	webengine? (
 		kde-apps/kaccounts-integration:6
 		>=net-libs/accounts-qt-1.16_p20220803[qt6]
 	)
@@ -65,9 +65,9 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package kaccounts AccountsQt6)
-		$(cmake_use_find_package kaccounts KAccounts6)
 		-DBUILD_TOOLS=$(usex tools)
+		$(cmake_use_find_package webengine AccountsQt6)
+		$(cmake_use_find_package webengine KAccounts6)
 		$(cmake_use_find_package xml LibXml2)
 	)
 

--- a/kde-apps/akonadi/akonadi-9999.ebuild
+++ b/kde-apps/akonadi/akonadi-9999.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://community.kde.org/KDE_PIM/akonadi"
 LICENSE="LGPL-2.1+"
 SLOT="6"
 KEYWORDS=""
-IUSE="+kaccounts +mysql postgres sqlite tools xml"
+IUSE="+mysql postgres sqlite tools +webengine xml"
 
 REQUIRED_USE="|| ( mysql postgres sqlite ) test? ( tools )"
 
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	kaccounts? (
+	webengine? (
 		kde-apps/kaccounts-integration:6
 		>=net-libs/accounts-qt-1.16_p20220803[qt6]
 	)
@@ -65,9 +65,9 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package kaccounts AccountsQt6)
-		$(cmake_use_find_package kaccounts KAccounts6)
 		-DBUILD_TOOLS=$(usex tools)
+		$(cmake_use_find_package webengine AccountsQt6)
+		$(cmake_use_find_package webengine KAccounts6)
 		$(cmake_use_find_package xml LibXml2)
 	)
 

--- a/kde-apps/akonadi/metadata.xml
+++ b/kde-apps/akonadi/metadata.xml
@@ -10,7 +10,7 @@
 	</upstream>
 	<use>
 		<flag name="designer">Install plugin for <pkg>dev-qt/designer</pkg></flag>
-		<flag name="kaccounts">Enable support for system-wide defined KAccounts</flag>
 		<flag name="tools">Install tools for developers and testing</flag>
+		<flag name="webengine">Enable support for system-wide defined KAccounts</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kaccounts-integration/kaccounts-integration-24.05.49.9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-24.05.49.9999.ebuild
@@ -55,9 +55,11 @@ DEPEND="${COMMON_DEPEND}
 		>=kde-frameworks/kcmutils-${KF5MIN}:5
 	)
 "
-# KAccountsMacros.cmake needs intltool
+# KAccountsMacros.cmake needs intltool; TODO: Watch:
+# https://invent.kde.org/network/kaccounts-integration/-/merge_requests/61
 RDEPEND="${COMMON_DEPEND}
 	dev-util/intltool
+	kde-apps/signon-kwallet-extension:6
 "
 BDEPEND="sys-devel/gettext"
 PDEPEND=">=kde-apps/kaccounts-providers-${PVCUT}:6"

--- a/kde-apps/kaccounts-integration/kaccounts-integration-24.05.49.9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-24.05.49.9999.ebuild
@@ -6,6 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KF5MIN=5.115.0
 KFMIN=6.3.0
+PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.6.2
 VIRTUALDBUS_TEST="true"
@@ -58,9 +59,8 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}
 	dev-util/intltool
 "
-BDEPEND="
-	sys-devel/gettext
-"
+BDEPEND="sys-devel/gettext"
+PDEPEND=">=kde-apps/kaccounts-providers-${PVCUT}:6"
 
 pkg_setup() {
 	MULTIBUILD_VARIANTS=( $(usev qt5) default )

--- a/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
@@ -55,9 +55,11 @@ DEPEND="${COMMON_DEPEND}
 		>=kde-frameworks/kcmutils-${KF5MIN}:5
 	)
 "
-# KAccountsMacros.cmake needs intltool
+# KAccountsMacros.cmake needs intltool; TODO: Watch:
+# https://invent.kde.org/network/kaccounts-integration/-/merge_requests/61
 RDEPEND="${COMMON_DEPEND}
 	dev-util/intltool
+	kde-apps/signon-kwallet-extension:6
 "
 BDEPEND="sys-devel/gettext"
 PDEPEND=">=kde-apps/kaccounts-providers-${PVCUT}:6"

--- a/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
+++ b/kde-apps/kaccounts-integration/kaccounts-integration-9999.ebuild
@@ -6,6 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KF5MIN=5.115.0
 KFMIN=6.3.0
+PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.6.2
 VIRTUALDBUS_TEST="true"
@@ -58,9 +59,8 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}
 	dev-util/intltool
 "
-BDEPEND="
-	sys-devel/gettext
-"
+BDEPEND="sys-devel/gettext"
+PDEPEND=">=kde-apps/kaccounts-providers-${PVCUT}:6"
 
 pkg_setup() {
 	MULTIBUILD_VARIANTS=( $(usev qt5) default )

--- a/kde-apps/kaccounts-providers/kaccounts-providers-24.05.49.9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-24.05.49.9999.ebuild
@@ -14,27 +14,20 @@ HOMEPAGE="https://community.kde.org/KTp"
 LICENSE="LGPL-2.1"
 SLOT="6"
 KEYWORDS=""
-IUSE="+webengine"
+IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
+	>=dev-qt/qtwebengine-${QTMIN}:6[qml]
 	>=kde-apps/kaccounts-integration-${PVCUT}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/kpackage-${KFMIN}:6
-	webengine? ( >=dev-qt/qtwebengine-${QTMIN}:6 )
 "
 RDEPEND="${DEPEND}
 	>=net-libs/signon-oauth2-0.25_p20210102[qt6]
 	>=net-libs/signon-ui-0.15_p20231016
 "
 BDEPEND="dev-util/intltool"
-
-src_configure() {
-	local mycmakeargs=(
-		$(cmake_use_find_package webengine Qt6WebEngineQuick)
-	)
-	ecm_src_configure
-}

--- a/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
@@ -14,27 +14,20 @@ HOMEPAGE="https://community.kde.org/KTp"
 LICENSE="LGPL-2.1"
 SLOT="6"
 KEYWORDS=""
-IUSE="+webengine"
+IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
+	>=dev-qt/qtwebengine-${QTMIN}:6[qml]
 	>=kde-apps/kaccounts-integration-${PVCUT}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/kpackage-${KFMIN}:6
-	webengine? ( >=dev-qt/qtwebengine-${QTMIN}:6 )
 "
 RDEPEND="${DEPEND}
 	>=net-libs/signon-oauth2-0.25_p20210102[qt6]
 	>=net-libs/signon-ui-0.15_p20231016
 "
 BDEPEND="dev-util/intltool"
-
-src_configure() {
-	local mycmakeargs=(
-		$(cmake_use_find_package webengine Qt6WebEngineQuick)
-	)
-	ecm_src_configure
-}

--- a/kde-apps/kaccounts-providers/metadata.xml
+++ b/kde-apps/kaccounts-providers/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="webengine">Enable Nextcloud KAccounts plugin using <pkg>dev-qt/qtwebengine</pkg></flag>
-	</use>
 </pkgmetadata>

--- a/kde-frameworks/purpose/metadata.xml
+++ b/kde-frameworks/purpose/metadata.xml
@@ -11,6 +11,7 @@
 	<use>
 		<flag name="kaccounts">Enable support for system-wide defined KAccounts</flag>
 		<flag name="kf6compat">Disable components colliding with KF6, depend on KF6 components instead</flag>
+		<flag name="webengine">Enable support for system-wide defined KAccounts</flag>
 	</use>
 	<slots>
 		<subslots>

--- a/kde-frameworks/purpose/purpose-5.239.9999.ebuild
+++ b/kde-frameworks/purpose/purpose-5.239.9999.ebuild
@@ -40,7 +40,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	kf6compat? ( kde-frameworks/purpose:6[kaccounts?] )
+	kf6compat? ( kaccounts? ( >=kde-frameworks/purpose-6.3.0-r1:6[webengine] ) )
 	>=dev-qt/qtquickcontrols-${QTMIN}:5
 	>=dev-qt/qtquickcontrols2-${QTMIN}:5
 	>=kde-frameworks/kdeclarative-${PVCUT}:5

--- a/kde-frameworks/purpose/purpose-9999.ebuild
+++ b/kde-frameworks/purpose/purpose-9999.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="Library for providing abstractions to get the developer's purposes 
 
 LICENSE="LGPL-2.1+"
 KEYWORDS=""
-IUSE="bluetooth kaccounts"
+IUSE="bluetooth webengine"
 
 # requires running environment
 RESTRICT="test"
@@ -29,7 +29,7 @@ DEPEND="
 	=kde-frameworks/knotifications-${PVCUT}*:6
 	=kde-frameworks/kservice-${PVCUT}*:6
 	=kde-frameworks/prison-${PVCUT}*:6
-	kaccounts? (
+	webengine? (
 		kde-apps/kaccounts-integration:6
 		>=net-libs/accounts-qt-1.16_p20220803[qt6]
 	)
@@ -38,9 +38,9 @@ RDEPEND="${DEPEND}
 	!${CATEGORY}/${PN}:5[-kf6compat(-)]
 	>=kde-frameworks/kdeclarative-${PVCUT}:6
 	bluetooth? ( =kde-frameworks/bluez-qt-${PVCUT}*:6 )
-	kaccounts? ( >=net-libs/accounts-qml-0.7_p20231028[qt6] )
+	webengine? ( >=net-libs/accounts-qml-0.7_p20231028[qt6] )
 "
-BDEPEND="kaccounts? ( dev-util/intltool )"
+BDEPEND="webengine? ( dev-util/intltool )"
 
 src_prepare() {
 	ecm_src_prepare
@@ -51,7 +51,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package kaccounts KAccounts6)
+		$(cmake_use_find_package webengine KAccounts6)
 	)
 
 	ecm_src_configure

--- a/kde-plasma/plasma-desktop/metadata.xml
+++ b/kde-plasma/plasma-desktop/metadata.xml
@@ -10,9 +10,9 @@
 	</upstream>
 	<use>
 		<flag name="ibus">Use ibus input method via <pkg>app-i18n/ibus</pkg></flag>
-		<flag name="kaccounts">Build the OpenDesktop integration plugin</flag>
 		<flag name="scim">Enable applets that use <pkg>app-i18n/scim</pkg></flag>
 		<flag name="screencast">Enable screencast portal thumbnails using <pkg>kde-plasma/kpipewire</pkg></flag>
 		<flag name="sdl">Enable gamepad support using <pkg>media-libs/libsdl2</pkg></flag>
+		<flag name="webengine">Build the OpenDesktop integration plugin</flag>
 	</use>
 </pkgmetadata>

--- a/kde-plasma/plasma-desktop/plasma-desktop-6.1.49.9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-6.1.49.9999.ebuild
@@ -17,7 +17,7 @@ SRC_URI+=" https://dev.gentoo.org/~asturm/distfiles/${XORGHDRS}.tar.xz"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS=""
-IUSE="ibus kaccounts scim screencast sdl +semantic-desktop"
+IUSE="ibus scim screencast sdl +semantic-desktop webengine"
 
 RESTRICT="test" # missing selenium-webdriver-at-spi
 
@@ -84,13 +84,13 @@ COMMON_DEPEND="
 		dev-libs/glib:2
 		x11-libs/xcb-util-keysyms
 	)
-	kaccounts? (
-		kde-apps/kaccounts-integration:6
-		>=net-libs/accounts-qt-1.16_p20220803[qt6]
-	)
 	scim? ( app-i18n/scim )
 	sdl? ( media-libs/libsdl2[joystick] )
 	semantic-desktop? ( >=kde-frameworks/baloo-${KFMIN}:6 )
+	webengine? (
+		kde-apps/kaccounts-integration:6
+		>=net-libs/accounts-qt-1.16_p20220803[qt6]
+	)
 "
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/wayland-protocols-1.25
@@ -115,8 +115,8 @@ RDEPEND="${COMMON_DEPEND}
 	sys-apps/util-linux
 	x11-apps/setxkbmap
 	x11-misc/xdg-user-dirs
-	kaccounts? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6] )
 	screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 )
+	webengine? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6] )
 "
 BDEPEND="
 	dev-util/intltool
@@ -151,10 +151,10 @@ src_configure() {
 		-DXORGSERVER_INCLUDE_DIRS="${WORKDIR}/${XORGHDRS}"/include
 		-DCMAKE_DISABLE_FIND_PACKAGE_PackageKitQt6=ON # not packaged
 		$(cmake_use_find_package ibus GLIB2)
-		$(cmake_use_find_package kaccounts AccountsQt6)
-		$(cmake_use_find_package kaccounts KAccounts6)
 		$(cmake_use_find_package sdl SDL2)
 		$(cmake_use_find_package semantic-desktop KF6Baloo)
+		$(cmake_use_find_package webengine AccountsQt6)
+		$(cmake_use_find_package webengine KAccounts6)
 	)
 
 	ecm_src_configure

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -17,7 +17,7 @@ SRC_URI+=" https://dev.gentoo.org/~asturm/distfiles/${XORGHDRS}.tar.xz"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS=""
-IUSE="ibus kaccounts scim screencast sdl +semantic-desktop"
+IUSE="ibus scim screencast sdl +semantic-desktop webengine"
 
 RESTRICT="test" # missing selenium-webdriver-at-spi
 
@@ -84,13 +84,13 @@ COMMON_DEPEND="
 		dev-libs/glib:2
 		x11-libs/xcb-util-keysyms
 	)
-	kaccounts? (
-		kde-apps/kaccounts-integration:6
-		>=net-libs/accounts-qt-1.16_p20220803[qt6]
-	)
 	scim? ( app-i18n/scim )
 	sdl? ( media-libs/libsdl2[joystick] )
 	semantic-desktop? ( >=kde-frameworks/baloo-${KFMIN}:6 )
+	webengine? (
+		kde-apps/kaccounts-integration:6
+		>=net-libs/accounts-qt-1.16_p20220803[qt6]
+	)
 "
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/wayland-protocols-1.25
@@ -115,8 +115,8 @@ RDEPEND="${COMMON_DEPEND}
 	sys-apps/util-linux
 	x11-apps/setxkbmap
 	x11-misc/xdg-user-dirs
-	kaccounts? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6] )
 	screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 )
+	webengine? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6] )
 "
 BDEPEND="
 	dev-util/intltool
@@ -151,10 +151,10 @@ src_configure() {
 		-DXORGSERVER_INCLUDE_DIRS="${WORKDIR}/${XORGHDRS}"/include
 		-DCMAKE_DISABLE_FIND_PACKAGE_PackageKitQt6=ON # not packaged
 		$(cmake_use_find_package ibus GLIB2)
-		$(cmake_use_find_package kaccounts AccountsQt6)
-		$(cmake_use_find_package kaccounts KAccounts6)
 		$(cmake_use_find_package sdl SDL2)
 		$(cmake_use_find_package semantic-desktop KF6Baloo)
+		$(cmake_use_find_package webengine AccountsQt6)
+		$(cmake_use_find_package webengine KAccounts6)
 	)
 
 	ecm_src_configure

--- a/media-libs/phonon/metadata.xml
+++ b/media-libs/phonon/metadata.xml
@@ -10,6 +10,5 @@
 	</upstream>
 	<use>
 		<flag name="designer">Install plugin for <pkg>dev-qt/designer</pkg></flag>
-		<flag name="vlc">Install VLC Phonon backend</flag>
 	</use>
 </pkgmetadata>

--- a/media-libs/phonon/phonon-9999.ebuild
+++ b/media-libs/phonon/phonon-9999.ebuild
@@ -15,7 +15,7 @@ fi
 
 LICENSE="|| ( LGPL-2.1 LGPL-3 ) !pulseaudio? ( || ( GPL-2 GPL-3 ) )"
 SLOT="0"
-IUSE="debug designer pulseaudio +qt5 qt6 +vlc"
+IUSE="debug designer minimal pulseaudio +qt5 qt6"
 REQUIRED_USE="|| ( qt5 qt6 )"
 
 DEPEND="
@@ -54,7 +54,7 @@ BDEPEND="
 	)
 "
 PDEPEND="
-	vlc? ( >=media-libs/phonon-vlc-0.12.0[qt5?,qt6?] )
+	!minimal? ( >=media-libs/phonon-vlc-0.12.0[qt5?,qt6?] )
 "
 
 pkg_setup() {


### PR DESCRIPTION
Summary:

kde-apps/kaccounts-providers: Drop IUSE +webengine, add qml USEdep
    
    Let's not kid ourselves: net-libs/signon-ui will pull in dev-qt/qtwebengine
    anyway.
    
kde-apps/kaccounts-integration: Add PDEPEND=kde-apps/kaccounts-providers
    
    kde-apps/kaccounts-integration provides kcm_accounts for systemsettings,
    however without kde-apps/kaccounts-providers the list is practically empty
    which makes no sense.
    
    So far, only kde-apps/kdenetwork-meta and kde-misc/kio-gdrive had been
    pulling it in but we cannot assume every Plasma user would have those
    installed.

kde-apps/kaccounts-integration: RDEPEND on signon-kwallet-extension:6
    
    This package already depends on kde-frameworks/kwallet so in this case
    we do not introduce a perceived extra dependency. It is also where Arch
    Linux chose to put it.
    
    Closes: https://bugs.gentoo.org/642420

Various packages: Rename IUSE kaccounts -> webengine
    
    kde-apps/kaccounts-integration inevitably pulls in -providers which
    pulls in dev-qt/qtwebengine.

media-libs/phonon: Switch IUSE +vlc to minimal
    
    With only a single available backend left, it does not make that much sense
    to rely on a commonly disabled flag to provide major functionality, even if
    enabled by default.
    
    Bug: https://bugs.gentoo.org/935033