### PR TITLE
kde-plasma/plasma-pa: bump media-libs/pulseaudio-qt to >=1.6.0 for 9999

### DIFF
--- a/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
@@ -33,7 +33,7 @@ DEPEND="
 	>=kde-plasma/libplasma-${PVCUT}:6
 	media-libs/libcanberra
 	media-libs/libpulse
-	>=media-libs/pulseaudio-qt-1.5.0:=
+	>=media-libs/pulseaudio-qt-1.6.0:=
 "
 RDEPEND="${DEPEND}
 	dev-libs/kirigami-addons:6


### PR DESCRIPTION
Bump the minimum required version to 1.6.0 for 9999 in order to fix a build failure, 6.1.49.9999 doesn't seem to be affected.

I also tested kde-misc/kdeconnect-9999 and that doesn't seem to require a bump, at least for now.