### PR TITLE
media-gfx/kgeotag: Adjust case of CHANGELOG.rst

### DIFF
--- a/media-gfx/kgeotag/kgeotag-9999.ebuild
+++ b/media-gfx/kgeotag/kgeotag-9999.ebuild
@@ -34,4 +34,4 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-DOCS=( ChangeLog.rst README.md )
+DOCS=( CHANGELOG.rst README.md )


### PR DESCRIPTION
Upstream [changed](https://invent.kde.org/graphics/kgeotag/-/commit/91246a200c3338b60a377ac94abafcd5a3aae98e) the case of ChangeLog.rst to CHANGELOG.rst and the ebuild failed when installing the DOCS with 
`FileNotFoundError: [Errno 2] No such file or directory: b'ChangeLog.rst'`

media-gfx/kgeotag-1.5.0::gentoo already has this, the 9999::kde was missing it. 
