### PR TITLE
Move akonadiserverrc and optional RDEPENDS to kde-apps/akonadi-config (new package)

### DIFF
--- a/kde-apps/akonadi-config/akonadi-config-0.ebuild
+++ b/kde-apps/akonadi-config/akonadi-config-0.ebuild
@@ -12,7 +12,7 @@ S=${WORKDIR}
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="+mysql postgres sqlite"
+IUSE="mysql postgres +sqlite"
 
 REQUIRED_USE="|| ( mysql postgres sqlite )"
 
@@ -42,11 +42,11 @@ pkg_pretend() {
 }
 
 pkg_setup() {
-	# Set default storage backend in order: MySQL, SQLite, PostgreSQL
+	# Set default storage backend in order: SQLite, MySQL, PostgreSQL
 	# reverse driver check to keep the order
 	use postgres && DRIVER="QPSQL"
-	use sqlite && DRIVER="QSQLITE"
 	use mysql && DRIVER="QMYSQL"
+	use sqlite && DRIVER="QSQLITE"
 }
 
 src_unpack() { :; }
@@ -66,8 +66,8 @@ src_install() {
 pkg_postinst() {
 	elog "You can select the storage backend in ~/.config/akonadi/akonadiserverrc."
 	elog "Available drivers (by enabled USE flags) are:"
-	use mysql && elog "  QMYSQL"
 	use sqlite && elog "  QSQLITE"
+	use mysql && elog "  QMYSQL"
 	use postgres && elog "  QPSQL"
 	elog "${DRIVER} has been set as your default akonadi storage backend."
 	elog


### PR DESCRIPTION
- [x] **kde-apps/akonadi-config: new package, add 0**

```
    Essentially split out of kde-apps/akonadi.
    
    This is now responsible for setting up default akonadiserverrc, and at
    the same time, switching default backend to QSQLITE (USE=sqlite) with
    some basic instructions.
    
    In terms of optional RDEPEND IUSE, we can treat this like a metapackage
    ensuring appropriate runtime dependencies.
    
    Bug: https://bugs.gentoo.org/936102
```

- [x] **kde-apps/akonadi: Drop IUSE mysql,postgres,sqlite and akonadiserverrc**
```
    Moved to kde-apps/akonadi-config. These flags were never ticking build
    system arguments to begin with.
```

- [ ] kde-apps/akonadi-config: Switch default to QSQLITE (IUSE sqlite)