### PR TITLE
kde-plasma/plasma-workspace: Use kde-plasma/plasma-login-sessions (new package)

### DIFF
--- a/Documentation/package.accept_keywords/.kde-plasma-6.2.49.9999/kde-plasma-6.2
+++ b/Documentation/package.accept_keywords/.kde-plasma-6.2.49.9999/kde-plasma-6.2
@@ -43,6 +43,7 @@
 ~kde-plasma/plasma-disks-6.2.49.9999 **
 ~kde-plasma/plasma-firewall-6.2.49.9999 **
 ~kde-plasma/plasma-integration-6.2.49.9999 **
+~kde-plasma/plasma-login-sessions-6.2.49.9999 **
 ~kde-plasma/plasma-meta-6.2.49.9999 **
 ~kde-plasma/plasma-nm-6.2.49.9999 **
 ~kde-plasma/plasma-pa-6.2.49.9999 **

--- a/Documentation/package.accept_keywords/.kde-plasma-live/kde-plasma-live
+++ b/Documentation/package.accept_keywords/.kde-plasma-live/kde-plasma-live
@@ -43,6 +43,7 @@
 ~kde-plasma/plasma-disks-9999 **
 ~kde-plasma/plasma-firewall-9999 **
 ~kde-plasma/plasma-integration-9999 **
+~kde-plasma/plasma-login-sessions-9999 **
 ~kde-plasma/plasma-meta-9999 **
 ~kde-plasma/plasma-nm-9999 **
 ~kde-plasma/plasma-pa-9999 **

--- a/Documentation/package.accept_keywords/kde-plasma-6.2.49.9999.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-6.2.49.9999.keywords
@@ -46,6 +46,7 @@
 ~kde-plasma/plasma-disks-6.2.49.9999 **
 ~kde-plasma/plasma-firewall-6.2.49.9999 **
 ~kde-plasma/plasma-integration-6.2.49.9999 **
+~kde-plasma/plasma-login-sessions-6.2.49.9999 **
 ~kde-plasma/plasma-meta-6.2.49.9999 **
 ~kde-plasma/plasma-nm-6.2.49.9999 **
 ~kde-plasma/plasma-pa-6.2.49.9999 **

--- a/Documentation/package.accept_keywords/kde-plasma-6.2.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-6.2.keywords
@@ -46,6 +46,7 @@
 <kde-plasma/plasma-disks-6.2.50
 <kde-plasma/plasma-firewall-6.2.50
 <kde-plasma/plasma-integration-6.2.50
+<kde-plasma/plasma-login-sessions-6.2.50
 <kde-plasma/plasma-meta-6.2.50
 <kde-plasma/plasma-nm-6.2.50
 <kde-plasma/plasma-pa-6.2.50

--- a/Documentation/package.accept_keywords/kde-plasma-live.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-live.keywords
@@ -46,6 +46,7 @@
 ~kde-plasma/plasma-disks-9999 **
 ~kde-plasma/plasma-firewall-9999 **
 ~kde-plasma/plasma-integration-9999 **
+~kde-plasma/plasma-login-sessions-9999 **
 ~kde-plasma/plasma-meta-9999 **
 ~kde-plasma/plasma-nm-9999 **
 ~kde-plasma/plasma-pa-9999 **

--- a/Documentation/package.mask/kde-plasma-6.2
+++ b/Documentation/package.mask/kde-plasma-6.2
@@ -46,6 +46,7 @@
 <kde-plasma/plasma-disks-6.2.50
 <kde-plasma/plasma-firewall-6.2.50
 <kde-plasma/plasma-integration-6.2.50
+<kde-plasma/plasma-login-sessions-6.2.50
 <kde-plasma/plasma-meta-6.2.50
 <kde-plasma/plasma-nm-6.2.50
 <kde-plasma/plasma-pa-6.2.50

--- a/Documentation/package.mask/kde-plasma-live
+++ b/Documentation/package.mask/kde-plasma-live
@@ -46,6 +46,7 @@
 ~kde-plasma/plasma-disks-9999
 ~kde-plasma/plasma-firewall-9999
 ~kde-plasma/plasma-integration-9999
+~kde-plasma/plasma-login-sessions-9999
 ~kde-plasma/plasma-meta-9999
 ~kde-plasma/plasma-nm-9999
 ~kde-plasma/plasma-pa-9999

--- a/Documentation/package.unmask/kde-plasma-6.2
+++ b/Documentation/package.unmask/kde-plasma-6.2
@@ -46,6 +46,7 @@
 <kde-plasma/plasma-disks-6.2.50
 <kde-plasma/plasma-firewall-6.2.50
 <kde-plasma/plasma-integration-6.2.50
+<kde-plasma/plasma-login-sessions-6.2.50
 <kde-plasma/plasma-meta-6.2.50
 <kde-plasma/plasma-nm-6.2.50
 <kde-plasma/plasma-pa-6.2.50

--- a/Documentation/package.unmask/kde-plasma-live
+++ b/Documentation/package.unmask/kde-plasma-live
@@ -46,6 +46,7 @@
 ~kde-plasma/plasma-disks-9999
 ~kde-plasma/plasma-firewall-9999
 ~kde-plasma/plasma-integration-9999
+~kde-plasma/plasma-login-sessions-9999
 ~kde-plasma/plasma-meta-9999
 ~kde-plasma/plasma-nm-9999
 ~kde-plasma/plasma-pa-9999

--- a/eclass/ecm-common.eclass
+++ b/eclass/ecm-common.eclass
@@ -392,7 +392,11 @@ ecm-common_src_prepare() {
 # Passes -DQT_MAJOR_VERSION=${_KFSLOT} only.
 ecm-common_src_configure() {
 	# necessary for at least KF6KCMUtils
-	local mycmakeargs=( -DQT_MAJOR_VERSION=${_KFSLOT} )
+	local cmakeargs=( -DQT_MAJOR_VERSION=${_KFSLOT} )
+
+	# allow the ebuild to override what we set here
+	mycmakeargs=("${cmakeargs[@]}" "${mycmakeargs[@]}")
+
 	cmake_src_configure
 }
 

--- a/kde-plasma/plasma-login-sessions/metadata.xml
+++ b/kde-plasma/plasma-login-sessions/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<use>
+		<flag name="wayland">Install Wayland session file for Display Managers</flag>
+		<flag name="X">Install X11 session file for Display Managers (default is Wayland if both enabled)</flag>
+	</use>
+</pkgmetadata>

--- a/kde-plasma/plasma-login-sessions/plasma-login-sessions-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-login-sessions/plasma-login-sessions-6.2.49.9999.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ECM_HANDBOOK="false"
+ECM_I18N="false"
+KDE_ORG_NAME="${PN/login-sessions/workspace}"
+inherit ecm-common plasma.kde.org
+
+DESCRIPTION="KDE Plasma login sessions"
+
+LICENSE="GPL-2" # TODO: CHECK
+SLOT="6"
+KEYWORDS=""
+IUSE="+wayland X"
+
+REQUIRED_USE="|| ( wayland X )"
+
+RDEPEND="!<kde-plasma/plasma-workspace-6.2.1"
+
+ecm-common_inject_heredoc() {
+	cat >> CMakeLists.txt <<- _EOF_ || die
+		add_subdirectory(login-sessions)
+	_EOF_
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DPLASMA_X11_DEFAULT_SESSION=$(usex !wayland)
+	)
+	ecm-common_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	if ! use wayland; then
+		rm -rv "${ED}"/usr/share/wayland-sessions || die
+	fi
+	if ! use X; then
+		rm -rv "${ED}"/usr/share/xsessions || die
+	fi
+}

--- a/kde-plasma/plasma-login-sessions/plasma-login-sessions-9999.ebuild
+++ b/kde-plasma/plasma-login-sessions/plasma-login-sessions-9999.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ECM_HANDBOOK="false"
+ECM_I18N="false"
+KDE_ORG_NAME="${PN/login-sessions/workspace}"
+inherit ecm-common plasma.kde.org
+
+DESCRIPTION="KDE Plasma login sessions"
+
+LICENSE="GPL-2" # TODO: CHECK
+SLOT="6"
+KEYWORDS=""
+IUSE="+wayland X"
+
+REQUIRED_USE="|| ( wayland X )"
+
+RDEPEND="!<kde-plasma/plasma-workspace-6.2.1"
+
+ecm-common_inject_heredoc() {
+	cat >> CMakeLists.txt <<- _EOF_ || die
+		add_subdirectory(login-sessions)
+	_EOF_
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DPLASMA_X11_DEFAULT_SESSION=$(usex !wayland)
+	)
+	ecm-common_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	if ! use wayland; then
+		rm -rv "${ED}"/usr/share/wayland-sessions || die
+	fi
+	if ! use X; then
+		rm -rv "${ED}"/usr/share/xsessions || die
+	fi
+}

--- a/kde-plasma/plasma-meta/plasma-meta-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-6.2.49.9999.ebuild
@@ -50,6 +50,7 @@ RDEPEND="
 	>=kde-plasma/plasma-activities-stats-${PV}:${SLOT}
 	>=kde-plasma/plasma-desktop-${PV}:${SLOT}
 	>=kde-plasma/plasma-integration-${PV}:${SLOT}[qt5?]
+	>=kde-plasma/plasma-login-sessions-${PV}:${SLOT}
 	>=kde-plasma/plasma-systemmonitor-${PV}:${SLOT}
 	>=kde-plasma/plasma-welcome-${PV}:${SLOT}
 	>=kde-plasma/plasma-workspace-${PV}:${SLOT}

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -50,6 +50,7 @@ RDEPEND="
 	>=kde-plasma/plasma-activities-stats-${PV}:${SLOT}
 	>=kde-plasma/plasma-desktop-${PV}:${SLOT}
 	>=kde-plasma/plasma-integration-${PV}:${SLOT}[qt5?]
+	>=kde-plasma/plasma-login-sessions-${PV}:${SLOT}
 	>=kde-plasma/plasma-systemmonitor-${PV}:${SLOT}
 	>=kde-plasma/plasma-welcome-${PV}:${SLOT}
 	>=kde-plasma/plasma-workspace-${PV}:${SLOT}

--- a/kde-plasma/plasma-workspace/plasma-workspace-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-6.2.49.9999.ebuild
@@ -147,6 +147,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-plasma/kdesu-gui-${PVCUT}:*
 	>=kde-plasma/milou-${PVCUT}:6
 	>=kde-plasma/plasma-integration-${PVCUT}:6
+	>=kde-plasma/plasma-login-sessions-${PVCUT}:6
 	sys-apps/dbus
 	x11-apps/xmessage
 	x11-apps/xprop
@@ -168,6 +169,8 @@ PATCHES=(
 
 src_prepare() {
 	ecm_src_prepare
+
+	cmake_comment_add_subdirectory login-sessions
 
 	# TODO: try to get a build switch upstreamed
 	if ! use screencast; then

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -144,6 +144,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-plasma/kdesu-gui-${PVCUT}:*
 	>=kde-plasma/milou-${PVCUT}:6
 	>=kde-plasma/plasma-integration-${PVCUT}:6
+	>=kde-plasma/plasma-login-sessions-${PVCUT}:6
 	sys-apps/dbus
 	x11-apps/xmessage
 	x11-apps/xprop
@@ -165,6 +166,8 @@ PATCHES=(
 
 src_prepare() {
 	ecm_src_prepare
+
+	cmake_comment_add_subdirectory login-sessions
 
 	# TODO: try to get a build switch upstreamed
 	if ! use screencast; then

--- a/sets/kde-plasma-6.2
+++ b/sets/kde-plasma-6.2
@@ -43,6 +43,7 @@
 <kde-plasma/plasma-disks-6.2.50
 <kde-plasma/plasma-firewall-6.2.50
 <kde-plasma/plasma-integration-6.2.50
+<kde-plasma/plasma-login-sessions-6.2.50
 <kde-plasma/plasma-meta-6.2.50
 <kde-plasma/plasma-nm-6.2.50
 <kde-plasma/plasma-pa-6.2.50

--- a/sets/kde-plasma-live
+++ b/sets/kde-plasma-live
@@ -43,6 +43,7 @@
 ~kde-plasma/plasma-disks-9999
 ~kde-plasma/plasma-firewall-9999
 ~kde-plasma/plasma-integration-9999
+~kde-plasma/plasma-login-sessions-9999
 ~kde-plasma/plasma-meta-9999
 ~kde-plasma/plasma-nm-9999
 ~kde-plasma/plasma-pa-9999


### PR DESCRIPTION
Outsourcing available Plasma login sessions from kde-plasma/plasma-workspace.
By doing that, we can afford exposing which sessions are being provided via
IUSE.

We probably do not want people globally setting USE="-wayland" have a default
Plasma Wayland session available to them, and we need to prepare for a world
where KWin can be built without X/xwayland anyway.