### PR TITLE
kde-plasma/keditfiletype: new package, add 6.2.49.9999, 9999 

### DIFF
--- a/Documentation/CONTRIBUTORS
+++ b/Documentation/CONTRIBUTORS
@@ -15,7 +15,6 @@ Andreas Eckstein <andreas.eckstein@gmx.net>
 Andreas K. Hüttel <dilfridge@gentoo.org>
 Andreas Sturmlechner <asturm@gentoo.org>
 Andrej Rode <mail@andrejro.de>
-Nowa Ammerlaan <nowa@gentoo.org>
 Andrew Wilcox <AWilcox@Wilcox-Tech.com>
 Andrius Štikonas <andrius@stikonas.eu>
 Anna “CyberTailor” <cyber@sysrq.in>
@@ -131,6 +130,7 @@ My Th <rei4dan@gmail.com>
 Nic Boet <nic@boet.cc>
 Nikoli <nikoli@gmx.us>
 Nils Freydank <holgersson@posteo.de>
+Nowa Ammerlaan <nowa@gentoo.org>
 Oldřich Jedlička <oldium.pro@seznam.cz>
 Ondrej Sukup <mimi.vx@gmail.com>
 Pablo Cholaky <waltercool@slash.cl>

--- a/Documentation/package.accept_keywords/.kde-plasma-6.2.49.9999/kde-plasma-6.2
+++ b/Documentation/package.accept_keywords/.kde-plasma-6.2.49.9999/kde-plasma-6.2
@@ -13,6 +13,7 @@
 ~kde-plasma/kdecoration-6.2.49.9999 **
 ~kde-plasma/kdeplasma-addons-6.2.49.9999 **
 ~kde-plasma/kdesu-gui-6.2.49.9999 **
+~kde-plasma/keditfiletype-6.2.49.9999 **
 ~kde-plasma/kgamma-6.2.49.9999 **
 ~kde-plasma/kglobalacceld-6.2.49.9999 **
 ~kde-plasma/kinfocenter-6.2.49.9999 **

--- a/Documentation/package.accept_keywords/.kde-plasma-live/kde-plasma-live
+++ b/Documentation/package.accept_keywords/.kde-plasma-live/kde-plasma-live
@@ -13,6 +13,7 @@
 ~kde-plasma/kdecoration-9999 **
 ~kde-plasma/kdeplasma-addons-9999 **
 ~kde-plasma/kdesu-gui-9999 **
+~kde-plasma/keditfiletype-9999 **
 ~kde-plasma/kgamma-9999 **
 ~kde-plasma/kglobalacceld-9999 **
 ~kde-plasma/kinfocenter-9999 **

--- a/Documentation/package.accept_keywords/kde-plasma-6.2.49.9999.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-6.2.49.9999.keywords
@@ -16,6 +16,7 @@
 ~kde-plasma/kdecoration-6.2.49.9999 **
 ~kde-plasma/kdeplasma-addons-6.2.49.9999 **
 ~kde-plasma/kdesu-gui-6.2.49.9999 **
+~kde-plasma/keditfiletype-6.2.49.9999 **
 ~kde-plasma/kgamma-6.2.49.9999 **
 ~kde-plasma/kglobalacceld-6.2.49.9999 **
 ~kde-plasma/kinfocenter-6.2.49.9999 **

--- a/Documentation/package.accept_keywords/kde-plasma-6.2.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-6.2.keywords
@@ -16,6 +16,7 @@
 <kde-plasma/kdecoration-6.2.50
 <kde-plasma/kdeplasma-addons-6.2.50
 <kde-plasma/kdesu-gui-6.2.50
+<kde-plasma/keditfiletype-6.2.50
 <kde-plasma/kgamma-6.2.50
 <kde-plasma/kglobalacceld-6.2.50
 <kde-plasma/kinfocenter-6.2.50

--- a/Documentation/package.accept_keywords/kde-plasma-live.keywords
+++ b/Documentation/package.accept_keywords/kde-plasma-live.keywords
@@ -16,6 +16,7 @@
 ~kde-plasma/kdecoration-9999 **
 ~kde-plasma/kdeplasma-addons-9999 **
 ~kde-plasma/kdesu-gui-9999 **
+~kde-plasma/keditfiletype-9999 **
 ~kde-plasma/kgamma-9999 **
 ~kde-plasma/kglobalacceld-9999 **
 ~kde-plasma/kinfocenter-9999 **

--- a/Documentation/package.mask/kde-plasma-6.2
+++ b/Documentation/package.mask/kde-plasma-6.2
@@ -16,6 +16,7 @@
 <kde-plasma/kdecoration-6.2.50
 <kde-plasma/kdeplasma-addons-6.2.50
 <kde-plasma/kdesu-gui-6.2.50
+<kde-plasma/keditfiletype-6.2.50
 <kde-plasma/kgamma-6.2.50
 <kde-plasma/kglobalacceld-6.2.50
 <kde-plasma/kinfocenter-6.2.50

--- a/Documentation/package.mask/kde-plasma-live
+++ b/Documentation/package.mask/kde-plasma-live
@@ -16,6 +16,7 @@
 ~kde-plasma/kdecoration-9999
 ~kde-plasma/kdeplasma-addons-9999
 ~kde-plasma/kdesu-gui-9999
+~kde-plasma/keditfiletype-9999
 ~kde-plasma/kgamma-9999
 ~kde-plasma/kglobalacceld-9999
 ~kde-plasma/kinfocenter-9999

--- a/Documentation/package.unmask/kde-plasma-6.2
+++ b/Documentation/package.unmask/kde-plasma-6.2
@@ -16,6 +16,7 @@
 <kde-plasma/kdecoration-6.2.50
 <kde-plasma/kdeplasma-addons-6.2.50
 <kde-plasma/kdesu-gui-6.2.50
+<kde-plasma/keditfiletype-6.2.50
 <kde-plasma/kgamma-6.2.50
 <kde-plasma/kglobalacceld-6.2.50
 <kde-plasma/kinfocenter-6.2.50

--- a/Documentation/package.unmask/kde-plasma-live
+++ b/Documentation/package.unmask/kde-plasma-live
@@ -16,6 +16,7 @@
 ~kde-plasma/kdecoration-9999
 ~kde-plasma/kdeplasma-addons-9999
 ~kde-plasma/kdesu-gui-9999
+~kde-plasma/keditfiletype-9999
 ~kde-plasma/kgamma-9999
 ~kde-plasma/kglobalacceld-9999
 ~kde-plasma/kinfocenter-9999

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -66,7 +66,13 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtbase-${QTMIN}:6[libproxy]
 	sys-power/switcheroo-control
 "
-PDEPEND=">=kde-frameworks/kded-${PVCUT}:6"
+# bug 944812: File Properties is accessible from KFileWidget (KIO); this
+# provides access to keditfiletype binary via KWidgetsAddons (Tier1)
+# Typical KIO revdeps (dolphin, krusader et al.) can rely on this dep
+PDEPEND="
+	>=kde-frameworks/kded-${PVCUT}:6
+	kde-plasma/keditfiletype
+"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/kde-cli-tools/kde-cli-tools-6.2.49.9999.ebuild
+++ b/kde-plasma/kde-cli-tools/kde-cli-tools-6.2.49.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_HANDBOOK="forceoff"
-ECM_TEST="true"
+ECM_TEST="false"
 KFMIN=6.6.0
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -17,25 +17,14 @@ SLOT="6"
 KEYWORDS=""
 IUSE="kdesu X"
 
-# requires running kde environment
-RESTRICT="test"
-
-# slot op: Uses Qt6::GuiPrivate for qtx11extras_p.h
+# slot op: kstart Uses Qt6::GuiPrivate for qtx11extras_p.h
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtsvg-${QTMIN}:6
-	>=kde-frameworks/kcmutils-${KFMIN}:6
-	>=kde-frameworks/kcompletion-${KFMIN}:6
-	>=kde-frameworks/kconfig-${KFMIN}:6
-	>=kde-frameworks/kconfigwidgets-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
-	>=kde-frameworks/kiconthemes-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
-	>=kde-frameworks/kparts-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
-	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X?]
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[gui,X] )
 "
 RDEPEND="${DEPEND}
@@ -47,6 +36,7 @@ BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
 src_prepare() {
 	ecm_src_prepare
 	ecm_punt_po_install
+	cmake_comment_add_subdirectory keditfiletype # split package
 }
 
 src_configure() {

--- a/kde-plasma/kde-cli-tools/kde-cli-tools-9999.ebuild
+++ b/kde-plasma/kde-cli-tools/kde-cli-tools-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_HANDBOOK="forceoff"
-ECM_TEST="true"
+ECM_TEST="false"
 KFMIN=9999
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -17,25 +17,14 @@ SLOT="6"
 KEYWORDS=""
 IUSE="kdesu X"
 
-# requires running kde environment
-RESTRICT="test"
-
-# slot op: Uses Qt6::GuiPrivate for qtx11extras_p.h
+# slot op: kstart Uses Qt6::GuiPrivate for qtx11extras_p.h
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtsvg-${QTMIN}:6
-	>=kde-frameworks/kcmutils-${KFMIN}:6
-	>=kde-frameworks/kcompletion-${KFMIN}:6
-	>=kde-frameworks/kconfig-${KFMIN}:6
-	>=kde-frameworks/kconfigwidgets-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
-	>=kde-frameworks/kiconthemes-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
-	>=kde-frameworks/kparts-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
-	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X?]
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[gui,X] )
 "
 RDEPEND="${DEPEND}
@@ -47,6 +36,7 @@ BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
 src_prepare() {
 	ecm_src_prepare
 	ecm_punt_po_install
+	cmake_comment_add_subdirectory keditfiletype # split package
 }
 
 src_configure() {

--- a/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-build-restrict.patch
+++ b/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-build-restrict.patch
@@ -1,0 +1,74 @@
+From aca455335ebcbc8818aacb75ffb7ef026ccc82e4 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Mon, 2 Sep 2024 23:18:46 +0200
+Subject: [PATCH] Make all KF6 and Qt6 modules optional, disable all subdirs
+ except kdesu
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ CMakeLists.txt | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f1092bf8..4667f06d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,7 @@ include(ECMDeprecationSettings)
+ 
+ include(KDEGitCommitHooks)
+ 
+-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
++find_package(Qt6 ${QT_MIN_VERSION} CONFIG COMPONENTS
+     Widgets
+     Svg
+     DBus
+@@ -44,7 +44,7 @@ if (NOT Qt6Test_FOUND)
+     set(BUILD_TESTING OFF CACHE BOOL "Build the testing tree.")
+ endif()
+ 
+-find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
++find_package(KF6 ${KF6_MIN_VERSION} COMPONENTS
+     Config
+     DocTools
+     IconThemes
+@@ -79,23 +79,23 @@ function(install_compat_symlink executable_target)
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${executable_target}5 DESTINATION ${KDE_INSTALL_FULL_BINDIR})
+ endfunction()
+ 
+ add_subdirectory(keditfiletype)
+-add_subdirectory(kmimetypefinder)
+-add_subdirectory(kioclient)
+-add_subdirectory(ksvgtopng)
+-add_subdirectory(kdeinhibit)
+-add_subdirectory(plasma-open-settings)
+-add_subdirectory(kinfo)
+-add_subdirectory(kstart)
++#add_subdirectory(kmimetypefinder)
++#add_subdirectory(kioclient)
++#add_subdirectory(ksvgtopng)
++#add_subdirectory(kdeinhibit)
++#add_subdirectory(plasma-open-settings)
++#add_subdirectory(kinfo)
++#add_subdirectory(kstart)
+ 
+-if(KF6Su_FOUND AND KF6WidgetsAddons_FOUND)
+-    add_subdirectory(kdesu)
+-endif()
++#if(KF6Su_FOUND AND KF6WidgetsAddons_FOUND)
++#    add_subdirectory(kdesu)
++#endif()
+ 
+-if(UNIX)
+-    add_subdirectory(kdeeject)
+-    add_subdirectory(kbroadcastnotification)
+-endif()
++#if(UNIX)
++#    add_subdirectory(kdeeject)
++#    add_subdirectory(kbroadcastnotification)
++#endif()
+ 
+ check_include_files(sys/wait.h HAVE_SYS_WAIT_H)
+ 
+-- 
+2.46.0
+

--- a/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-unused-dep.patch
+++ b/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-unused-dep.patch
@@ -1,0 +1,26 @@
+From 73cc55ac619067339afc9741a62e6ad47f1cf2df Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Mon, 25 Nov 2024 21:53:19 +0100
+Subject: [PATCH] keditfiletype: KF6ConfigCore is used, not KF6ConfigWidgets
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ keditfiletype/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/keditfiletype/CMakeLists.txt b/keditfiletype/CMakeLists.txt
+index 7fdf6f2e..a3c6df3f 100644
+--- a/keditfiletype/CMakeLists.txt
++++ b/keditfiletype/CMakeLists.txt
+@@ -40,7 +40,7 @@ kcoreaddons_add_plugin(kcm_filetypes SOURCES ${kcm_filetypes_SRCS} INSTALL_NAMES
+ 
+ kcmutils_generate_desktop_file(kcm_filetypes)
+ target_link_libraries(kcm_filetypes
+-    KF6::ConfigWidgets
++    KF6::ConfigCore
+     KF6::IconThemes
+     KF6::IconWidgets
+     KF6::I18n
+-- 
+2.47.0
+

--- a/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-unused-include.patch
+++ b/kde-plasma/keditfiletype/files/keditfiletype-6.2.4-unused-include.patch
@@ -1,0 +1,25 @@
+From 34dcc4b9787eb73a658acded7fa93469f4b5cb8b Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Mon, 25 Nov 2024 23:02:56 +0100
+Subject: [PATCH] keditfiletype: Drop unused KMessageBox include
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ keditfiletype/kservicelistwidget.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/keditfiletype/kservicelistwidget.cpp b/keditfiletype/kservicelistwidget.cpp
+index 6c638fd5..32b2a413 100644
+--- a/keditfiletype/kservicelistwidget.cpp
++++ b/keditfiletype/kservicelistwidget.cpp
+@@ -17,7 +17,6 @@
+ 
+ // KDE
+ #include <KLocalizedString>
+-#include <KMessageBox>
+ #include <KOpenWithDialog>
+ #include <KPropertiesDialog>
+ 
+-- 
+2.47.0
+

--- a/kde-plasma/keditfiletype/keditfiletype-6.2.49.9999.ebuild
+++ b/kde-plasma/keditfiletype/keditfiletype-6.2.49.9999.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ECM_HANDBOOK="forceoff"
+ECM_TEST="true"
+KDE_ORG_NAME="kde-cli-tools"
+KFMIN=6.6.0
+QTMIN=6.7.2
+inherit ecm plasma.kde.org
+
+DESCRIPTION="File Type Editor"
+HOMEPAGE="https://invent.kde.org/plasma/kde-cli-tools"
+
+LICENSE="GPL-2" # TODO: CHECK
+SLOT="0"
+KEYWORDS=""
+IUSE=""
+
+# requires running Plasma environment
+RESTRICT="test"
+
+DEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+	>=kde-frameworks/kcmutils-${KFMIN}:6
+	>=kde-frameworks/kcompletion-${KFMIN}:6
+	>=kde-frameworks/kconfig-${KFMIN}:6
+	>=kde-frameworks/kcoreaddons-${KFMIN}:6
+	>=kde-frameworks/ki18n-${KFMIN}:6
+	>=kde-frameworks/kiconthemes-${KFMIN}:6
+	>=kde-frameworks/kio-${KFMIN}:6
+	>=kde-frameworks/kparts-${KFMIN}:6
+	>=kde-frameworks/kservice-${KFMIN}:6
+	>=kde-frameworks/kwindowsystem-${KFMIN}:6
+"
+RDEPEND="${DEPEND}
+	!<${CATEGORY}/${KDE_ORG_NAME}-6.2.4:*
+	>=${CATEGORY}/${KDE_ORG_NAME}-common-${PV}
+"
+BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-6.2.4-build-restrict.patch" # downstream split
+	"${FILESDIR}/${PN}-6.2.4-unused-dep.patch" # in 6.3
+	"${FILESDIR}/${PN}-6.2.4-unused-include.patch" # pending for 6.3
+)
+
+src_prepare() {
+	ecm_src_prepare
+	ecm_punt_po_install
+}

--- a/kde-plasma/keditfiletype/keditfiletype-9999.ebuild
+++ b/kde-plasma/keditfiletype/keditfiletype-9999.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ECM_HANDBOOK="forceoff"
+ECM_TEST="true"
+KDE_ORG_NAME="kde-cli-tools"
+KFMIN=9999
+QTMIN=6.7.2
+inherit ecm plasma.kde.org
+
+DESCRIPTION="File Type Editor"
+HOMEPAGE="https://invent.kde.org/plasma/kde-cli-tools"
+
+LICENSE="GPL-2" # TODO: CHECK
+SLOT="0"
+KEYWORDS=""
+IUSE=""
+
+# requires running Plasma environment
+RESTRICT="test"
+
+DEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+	>=kde-frameworks/kcmutils-${KFMIN}:6
+	>=kde-frameworks/kcompletion-${KFMIN}:6
+	>=kde-frameworks/kconfig-${KFMIN}:6
+	>=kde-frameworks/kcoreaddons-${KFMIN}:6
+	>=kde-frameworks/ki18n-${KFMIN}:6
+	>=kde-frameworks/kiconthemes-${KFMIN}:6
+	>=kde-frameworks/kio-${KFMIN}:6
+	>=kde-frameworks/kparts-${KFMIN}:6
+	>=kde-frameworks/kservice-${KFMIN}:6
+	>=kde-frameworks/kwindowsystem-${KFMIN}:6
+"
+RDEPEND="${DEPEND}
+	!<${CATEGORY}/${KDE_ORG_NAME}-6.2.4:*
+	>=${CATEGORY}/${KDE_ORG_NAME}-common-${PV}
+"
+BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
+
+# downstream split
+PATCHES=( "${FILESDIR}/${PN}-6.2.4-build-restrict.patch" )
+
+src_prepare() {
+	ecm_src_prepare
+	ecm_punt_po_install
+}

--- a/kde-plasma/keditfiletype/metadata.xml
+++ b/kde-plasma/keditfiletype/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<upstream>
+		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">plasma/kde-cli-tools</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/kde-plasma/plasma-meta/plasma-meta-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-6.2.49.9999.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	>=kde-plasma/kdecoration-${PV}:${SLOT}
 	>=kde-plasma/kdeplasma-addons-${PV}:${SLOT}
 	>=kde-plasma/kdesu-gui-${PV}
+	>=kde-plasma/keditfiletype-${PV}
 	>=kde-plasma/kgamma-${PV}:${SLOT}
 	>=kde-plasma/kglobalacceld-${PV}:${SLOT}
 	>=kde-plasma/kinfocenter-${PV}:${SLOT}

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	>=kde-plasma/kdecoration-${PV}:${SLOT}
 	>=kde-plasma/kdeplasma-addons-${PV}:${SLOT}
 	>=kde-plasma/kdesu-gui-${PV}
+	>=kde-plasma/keditfiletype-${PV}
 	>=kde-plasma/kgamma-${PV}:${SLOT}
 	>=kde-plasma/kglobalacceld-${PV}:${SLOT}
 	>=kde-plasma/kinfocenter-${PV}:${SLOT}

--- a/sets/kde-plasma-6.2
+++ b/sets/kde-plasma-6.2
@@ -13,6 +13,7 @@
 <kde-plasma/kdecoration-6.2.50
 <kde-plasma/kdeplasma-addons-6.2.50
 <kde-plasma/kdesu-gui-6.2.50
+<kde-plasma/keditfiletype-6.2.50
 <kde-plasma/kgamma-6.2.50
 <kde-plasma/kglobalacceld-6.2.50
 <kde-plasma/kinfocenter-6.2.50

--- a/sets/kde-plasma-live
+++ b/sets/kde-plasma-live
@@ -13,6 +13,7 @@
 ~kde-plasma/kdecoration-9999
 ~kde-plasma/kdeplasma-addons-9999
 ~kde-plasma/kdesu-gui-9999
+~kde-plasma/keditfiletype-9999
 ~kde-plasma/kgamma-9999
 ~kde-plasma/kglobalacceld-9999
 ~kde-plasma/kinfocenter-9999


### PR DESCRIPTION
[kde-frameworks/kio: PDEPEND on kde-plasma/keditfiletype](https://github.com/gentoo/kde/pull/1011/commits/ce6fd88be362f16b1b0621451eb467e6e877e283)
```
KWidgetsAddons has runtime dependency on keditfiletype binary, but as Tier1
Framework only depends on Qt modules. keditfiletype otoh has rather heavy
dependencies (including KIO itself), so it cannot be a dependency of
KWidgetsAddons.

As a compromise, put it into PDEPEND here, since KFileWidget exposes this
KWidgetsAddons component, and revdeps like dolphin and krusader (typical
consumers of KIO) too.
```
Bug: https://bugs.gentoo.org/944812