### PR TITLE
[WIP] cmake.eclass: Introduce cmake_punt_find_package()

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -158,6 +158,34 @@ cmake_punt_find_package() {
 	fi
 }
 
+# @FUNCTION: cmake_unrequire_find_package
+# @USAGE: <pkg>
+# @DESCRIPTION:
+# Remove REQUIRED attribute from a given find_package(<pkg>) call inside CMakeLists.txt
+cmake_unrequire_find_package() {
+	local cmpnt="REQUIRED"
+	if [[ -z ${1} ]]; then
+		die "${FUNCNAME[0]} must be passed exactly one argument"
+	fi
+
+	[[ -e "CMakeLists.txt" ]] || return
+
+	pcre2grep -Mni "(?s)find_package\s*\(\s*${1}.*?REQUIRED.*?\)" \
+	CMakeLists.txt > "${T}/bogus${cmpnt}"
+
+	# pcre2grep returns non-zero on no matches/error
+	if [[ $? -ne 0 ]]; then
+		eqawarn "QA Notice: ${FUNCNAME}(${1}) called, but no matches found!"
+		return
+	fi
+
+	local length=$(wc -l "${T}/bogus${cmpnt}" | cut -d " " -f 1)
+	local first=$(head -n 1 "${T}/bogus${cmpnt}" | cut -d ":" -f 1)
+	local last=$(( length + first - 1))
+
+	sed -e "${first},${last}s/${cmpnt}//" -i CMakeLists.txt || die
+}
+
 # @FUNCTION: cmake_use_find_package
 # @USAGE: <USE flag> <package name>
 # @DESCRIPTION:

--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -49,6 +49,10 @@ case ${CMAKE_ECM_MODE} in
 		;;
 esac
 
+BDEPEND+="
+	dev-libs/libpcre2:*
+"
+
 # @FUNCTION: cmake_comment_add_subdirectory
 # @USAGE: [-f <filename or directory>] <subdirectory> [<subdirectories>]
 # @DESCRIPTION:
@@ -89,6 +93,69 @@ cmake_comment_add_subdirectory() {
 		sed -e "/add_subdirectory[[:space:]]*([[:space:]]*${d}\([[:space:]][a-Z_ ]*\|[[:space:]]*\))/I s/^/#DONOTBUILD /" \
 			-i ${filename} || die "failed to comment add_subdirectory(${d})"
 	done
+}
+
+# @FUNCTION: cmake_punt_find_package
+# @USAGE: [-f <filename>] <pkg> [<components>...]
+# @DESCRIPTION:
+# Default value for <filename> is CMakeLists.txt if not set.  If given a
+# directory instead, will try to modify a CMakeLists.txt below, if exists.
+# In <filename> below current directory, remove a find_package(<pkg>) call.
+# If given one or more <components>, remove those from COMPONENTS instead.
+cmake_punt_find_package() {
+	local pkg filename="CMakeLists.txt"
+	if [[ $# -lt 1 ]]; then
+		die "${FUNCNAME} must be passed at least one argument"
+	fi
+	case ${1} in
+		-f)
+			if [[ $# -ge 2 ]]; then
+				filename="${2}"
+			else
+				die "${FUNCNAME}: bad number of arguments"
+			fi
+			shift 2 ;&
+		*)
+			pkg="${1}"
+			shift ;;
+	esac
+
+	if [[ -d ${filename} ]]; then
+		filename+="/CMakeLists.txt"
+		einfo "modifying ${filename}!"
+	fi
+	if [[ ! -e ${filename} ]]; then
+		die "${FUNCNAME}: called on non-existing ${filename}"
+		return
+	fi
+
+	if [[ $# -ge 1 ]]; then
+		local cmpnt length first last
+		for cmpnt in $@; do
+			pcre2grep -Mni "(?s)find_package\s*\(\s*${pkg}(\d+|\\$\{\w*\})[^)]*?${cmpnt}.*?\)" \
+				${filename} > "${T}/bogus${cmpnt}"
+
+			# pcre2grep returns non-zero on no matches/error
+			if [[ $? -ne 0 ]]; then
+				eqawarn "QA Notice: ${FUNCNAME}(${pkg}, ${cmpnt}) called, but no matches found!"
+				continue
+			fi
+
+			length=$(wc -l "${T}/bogus${cmpnt}" | cut -d " " -f 1)
+			first=$(head -n 1 "${T}/bogus${cmpnt}" | cut -d ":" -f 1)
+			last=$(( length + first - 1))
+
+			sed -e "${first},${last}s/${cmpnt}//" -i ${filename} || die
+
+			if [[ ${length} -eq 1 ]] ; then
+				sed -e "/find_package\s*(\s*${pkg}\([0-9]\|\${[A-Z0-9_]*}\)\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# '${cmpnt}' removed by cmake.eclass - /" \
+					-i ${filename} || die
+			fi
+		done
+	else
+		sed -e "/find_package\s*(\s*${pkg}\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# removed by cmake.eclass - /" \
+			-i ${filename} || die
+	fi
 }
 
 # @FUNCTION: cmake_use_find_package

--- a/eclass/ecm.eclass
+++ b/eclass/ecm.eclass
@@ -280,7 +280,6 @@ case ${ECM_TEST} in
 esac
 
 BDEPEND+="
-	dev-libs/libpcre2:*
 	>=kde-frameworks/extra-cmake-modules-${KFMIN}:*
 "
 if [[ ${ECM_TEST} != false ]]; then
@@ -363,44 +362,13 @@ _ecm_strip_handbook_translations() {
 	done
 }
 
-# @FUNCTION: _ecm_punt_kfqt_module
-# @USAGE: <prefix> <dependency>
-# @INTERNAL
-# @DESCRIPTION:
-# Removes a specified dependency from a find_package call with multiple
-# components.
-_ecm_punt_kfqt_module() {
-	local prefix=${1}
-	local dep=${2}
-
-	[[ ! -e "CMakeLists.txt" ]] && return
-
-	# FIXME: dep=WebKit will result in 'Widgets' over 'WebKitWidgets' (no regression)
-	pcre2grep -Mni "(?s)find_package\s*\(\s*${prefix}(\d+|\\$\{\w*\})[^)]*?${dep}.*?\)" \
-		CMakeLists.txt > "${T}/bogus${dep}"
-
-	# pcre2grep returns non-zero on no matches/error
-	[[ $? -ne 0 ]] && return
-
-	local length=$(wc -l "${T}/bogus${dep}" | cut -d " " -f 1)
-	local first=$(head -n 1 "${T}/bogus${dep}" | cut -d ":" -f 1)
-	local last=$(( length + first - 1))
-
-	sed -e "${first},${last}s/${dep}//" -i CMakeLists.txt || die
-
-	if [[ ${length} -eq 1 ]] ; then
-		sed -e "/find_package\s*(\s*${prefix}\([0-9]\|\${[A-Z0-9_]*}\)\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# '${dep}' removed by ecm.eclass - /" \
-			-i CMakeLists.txt || die
-	fi
-}
-
 # @FUNCTION: ecm_punt_kf_module
 # @USAGE: <modulename>
 # @DESCRIPTION:
 # Removes a Frameworks (KF - matching any single-digit version)
 # module from a find_package call with multiple components.
 ecm_punt_kf_module() {
-	_ecm_punt_kfqt_module kf ${1}
+	cmake_punt_find_package kf ${1}
 }
 
 # @FUNCTION: ecm_punt_qt_module
@@ -409,7 +377,7 @@ ecm_punt_kf_module() {
 # Removes a Qt (matching any single-digit version) module from a
 # find_package call with multiple components.
 ecm_punt_qt_module() {
-	_ecm_punt_kfqt_module qt ${1}
+	cmake_punt_find_package qt ${1}
 }
 
 # @FUNCTION: ecm_punt_bogus_dep
@@ -418,42 +386,7 @@ ecm_punt_qt_module() {
 # Removes a specified dependency from a find_package call, optionally
 # supports prefix for find_package with multiple components.
 ecm_punt_bogus_dep() {
-
-	if [[ "$#" == 2 ]] ; then
-		local prefix=${1}
-		local dep=${2}
-	elif [[ "$#" == 1 ]] ; then
-		local dep=${1}
-	else
-		die "${FUNCNAME[0]} must be passed either one or two arguments"
-	fi
-
-	if [[ ! -e "CMakeLists.txt" ]]; then
-		return
-	fi
-
-	if [[ -z ${prefix} ]]; then
-		sed -e "/find_package\s*(\s*${dep}\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# removed by ecm.eclass - /" \
-			-i CMakeLists.txt || die
-		return
-	else
-		pcre2grep -Mni "(?s)find_package\s*\(\s*${prefix}[^)]*?${dep}.*?\)" CMakeLists.txt > "${T}/bogus${dep}"
-	fi
-
-	# pcre2grep returns non-zero on no matches/error
-	if [[ $? -ne 0 ]] ; then
-		return
-	fi
-
-	local length=$(wc -l "${T}/bogus${dep}" | cut -d " " -f 1)
-	local first=$(head -n 1 "${T}/bogus${dep}" | cut -d ":" -f 1)
-	local last=$(( length + first - 1))
-
-	sed -e "${first},${last}s/${dep}//" -i CMakeLists.txt || die
-
-	if [[ ${length} -eq 1 ]] ; then
-		sed -e "/find_package\s*(\s*${prefix}\(\s\+\(REQUIRED\|CONFIG\|COMPONENTS\|\${[A-Z0-9_]*}\)\)\+\s*)/Is/^/# removed by ecm.eclass - /" -i CMakeLists.txt || die
-	fi
+	cmake_punt_find_package $@
 }
 
 # @FUNCTION: _ecm_punt_kdoctools_install


### PR DESCRIPTION
TODO:
- [ ] replace or depend(!?) on `libpcre2`
- [ ] use `-f <file>` in more functions and create common use internal function
- [ ] current implementation still is ECM centric (`pkg=qt` will match `Qt[56]` or `Qt${SOME_VAR}`)