### PR TITLE
*.kde.org: Push PVCUT from ebuilds into new eclass var

### DIFF
--- a/eclass/frameworks.kde.org.eclass
+++ b/eclass/frameworks.kde.org.eclass
@@ -25,6 +25,13 @@ esac
 if [[ -z ${_FRAMEWORKS_KDE_ORG_ECLASS} ]]; then
 _FRAMEWORKS_KDE_ORG_ECLASS=1
 
+# @ECLASS_VARIABLE: KDE_CATV
+# @DESCRIPTION:
+# Holds main Frameworks release number (major.minor) for use on same-category
+# dependencies.
+KDE_CATV=$(ver_cut 1-2)
+readonly KDE_CATV
+
 # @ECLASS_VARIABLE: KDE_PV_UNRELEASED
 # @INTERNAL
 # @DESCRIPTION:
@@ -43,7 +50,7 @@ if [[ ${PN} == extra-cmake-modules ]]; then
 	SLOT=0
 else
 	if [[ ${KDE_BUILD_TYPE} == release ]]; then
-		SLOT=${SLOT}/$(ver_cut 1-2)
+		SLOT=${SLOT}/${KDE_CATV}
 	else
 		SLOT=${SLOT}/9999
 	fi
@@ -63,7 +70,7 @@ _KDE_SRC_URI="mirror://kde/"
 
 # TODO: Remove after last KF5 PortingAid treecleaned; bug 755956
 if [[ ${KDE_BUILD_TYPE} != live && -z ${KDE_ORG_COMMIT} ]]; then
-	_KDE_SRC_URI+="stable/frameworks/$(ver_cut 1-2)/"
+	_KDE_SRC_URI+="stable/frameworks/${KDE_CATV}/"
 	case ${KDE_ORG_NAME} in
 		kdelibs4support | \
 		kdesignerplugin | \

--- a/eclass/plasma.kde.org.eclass
+++ b/eclass/plasma.kde.org.eclass
@@ -25,6 +25,13 @@ esac
 if [[ -z ${_PLASMA_KDE_ORG_ECLASS} ]]; then
 _PLASMA_KDE_ORG_ECLASS=1
 
+# @ECLASS_VARIABLE: KDE_CATV
+# @DESCRIPTION:
+# Holds main Plasma release number (major.minor.micro) for use on same-category
+# dependencies.
+KDE_CATV=$(ver_cut 1-3)
+readonly KDE_CATV
+
 # @ECLASS_VARIABLE: KDE_PV_UNRELEASED
 # @INTERNAL
 # @DESCRIPTION:
@@ -64,10 +71,10 @@ if [[ ${KDE_BUILD_TYPE} == live ]]; then
 elif [[ -z ${KDE_ORG_COMMIT} ]]; then
 	case ${PV} in
 		5.??.[6-9][05]* | 6.?.[6-9][05]* )
-			_KDE_SRC_URI+="unstable/plasma/$(ver_cut 1-3)/"
+			_KDE_SRC_URI+="unstable/plasma/${KDE_CATV}/"
 			RESTRICT+=" mirror"
 			;;
-		*) _KDE_SRC_URI+="stable/plasma/$(ver_cut 1-3)/" ;;
+		*) _KDE_SRC_URI+="stable/plasma/${KDE_CATV}/" ;;
 	esac
 
 	SRC_URI="${_KDE_SRC_URI}${KDE_ORG_TAR_PN}-${PV}.tar.xz"

--- a/kde-frameworks/baloo/baloo-6.9.0.ebuild
+++ b/kde-frameworks/baloo/baloo-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -20,15 +19,15 @@ DEPEND="
 	>=dev-db/lmdb-0.9.17
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kfilemetadata-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kidletime-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/solid-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kfilemetadata-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kidletime-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/solid-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}
 	!${CATEGORY}/${PN}:5[-kf6compat(-)]

--- a/kde-frameworks/baloo/baloo-9999.ebuild
+++ b/kde-frameworks/baloo/baloo-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -20,15 +19,15 @@ DEPEND="
 	>=dev-db/lmdb-0.9.17
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kfilemetadata-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kidletime-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/solid-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kfilemetadata-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kidletime-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/solid-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}
 	!${CATEGORY}/${PN}:5[-kf6compat(-)]

--- a/kde-frameworks/breeze-icons/breeze-icons-6.9.0.ebuild
+++ b/kde-frameworks/breeze-icons/breeze-icons-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 PYTHON_COMPAT=( python3_{10..13} )
 inherit cmake frameworks.kde.org python-any-r1 xdg
 
@@ -23,7 +22,7 @@ RDEPEND="
 BDEPEND="${PYTHON_DEPS}
 	$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
 	dev-qt/qtbase:6[gui]
-	>=kde-frameworks/extra-cmake-modules-${PVCUT}:*
+	>=kde-frameworks/extra-cmake-modules-${KDE_CATV}:*
 	test? ( app-misc/fdupes )
 "
 

--- a/kde-frameworks/breeze-icons/breeze-icons-9999.ebuild
+++ b/kde-frameworks/breeze-icons/breeze-icons-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 PYTHON_COMPAT=( python3_{10..13} )
 inherit cmake frameworks.kde.org python-any-r1 xdg
 
@@ -23,7 +22,7 @@ RDEPEND="
 BDEPEND="${PYTHON_DEPS}
 	$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
 	dev-qt/qtbase:6[gui]
-	>=kde-frameworks/extra-cmake-modules-${PVCUT}:*
+	>=kde-frameworks/extra-cmake-modules-${KDE_CATV}:*
 	test? ( app-misc/fdupes )
 "
 

--- a/kde-frameworks/frameworkintegration/frameworkintegration-6.9.0.ebuild
+++ b/kde-frameworks/frameworkintegration/frameworkintegration-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,16 +18,16 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/knewstuff-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/knewstuff-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
-	=kde-frameworks/kpackage-${PVCUT}*:6
+	=kde-frameworks/kpackage-${KDE_CATV}*:6
 "
 
 src_configure() {

--- a/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
+++ b/kde-frameworks/frameworkintegration/frameworkintegration-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,16 +18,16 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/knewstuff-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/knewstuff-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
-	=kde-frameworks/kpackage-${PVCUT}*:6
+	=kde-frameworks/kpackage-${KDE_CATV}*:6
 "
 
 src_configure() {

--- a/kde-frameworks/kauth/kauth-6.9.0.ebuild
+++ b/kde-frameworks/kauth/kauth-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE="+policykit"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
 	policykit? (
 		>=dev-qt/qtbase-${QTMIN}:6[dbus]
-		=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland]
+		=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[wayland]
 		>=sys-auth/polkit-qt-0.175.0[qt6(+)]
 	)
 "

--- a/kde-frameworks/kauth/kauth-9999.ebuild
+++ b/kde-frameworks/kauth/kauth-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE="+policykit"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
 	policykit? (
 		>=dev-qt/qtbase-${QTMIN}:6[dbus]
-		=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland]
+		=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[wayland]
 		>=sys-auth/polkit-qt-0.175.0[qt6(+)]
 	)
 "

--- a/kde-frameworks/kbookmarks/kbookmarks-6.9.0.ebuild
+++ b/kde-frameworks/kbookmarks/kbookmarks-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/kbookmarks/kbookmarks-9999.ebuild
+++ b/kde-frameworks/kbookmarks/kbookmarks-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/kcmutils/kcmutils-6.9.0.ebuild
+++ b/kde-frameworks/kcmutils/kcmutils-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,14 +16,14 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kcmutils/kcmutils-9999.ebuild
+++ b/kde-frameworks/kcmutils/kcmutils-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,14 +16,14 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kcolorscheme/kcolorscheme-6.9.0.ebuild
+++ b/kde-frameworks/kcolorscheme/kcolorscheme-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,8 +16,8 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kcolorscheme/kcolorscheme-9999.ebuild
+++ b/kde-frameworks/kcolorscheme/kcolorscheme-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,8 +16,8 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kcompletion/kcompletion-6.9.0.ebuild
+++ b/kde-frameworks/kcompletion/kcompletion-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,10 +15,10 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/kcompletion/kcompletion-9999.ebuild
+++ b/kde-frameworks/kcompletion/kcompletion-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,10 +15,10 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/kconfigwidgets/kconfigwidgets-6.9.0.ebuild
+++ b/kde-frameworks/kconfigwidgets/kconfigwidgets-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -23,14 +22,14 @@ CMAKE_SKIP_TESTS=(
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
-	test? ( =kde-frameworks/kconfig-${PVCUT}*:6[dbus] )
+	test? ( =kde-frameworks/kconfig-${KDE_CATV}*:6[dbus] )
 "

--- a/kde-frameworks/kconfigwidgets/kconfigwidgets-9999.ebuild
+++ b/kde-frameworks/kconfigwidgets/kconfigwidgets-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -23,14 +22,14 @@ CMAKE_SKIP_TESTS=(
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
-	test? ( =kde-frameworks/kconfig-${PVCUT}*:6[dbus] )
+	test? ( =kde-frameworks/kconfig-${KDE_CATV}*:6[dbus] )
 "

--- a/kde-frameworks/kcontacts/kcontacts-6.9.0.ebuild
+++ b/kde-frameworks/kcontacts/kcontacts-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,10 +16,10 @@ IUSE=""
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kcontacts/kcontacts-9999.ebuild
+++ b/kde-frameworks/kcontacts/kcontacts-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,10 +16,10 @@ IUSE=""
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kcrash/kcrash-6.9.0.ebuild
+++ b/kde-frameworks/kcrash/kcrash-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,7 +18,7 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,opengl]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
 	X? ( x11-libs/libX11 )
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kcrash/kcrash-9999.ebuild
+++ b/kde-frameworks/kcrash/kcrash-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,7 +18,7 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,opengl]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
 	X? ( x11-libs/libX11 )
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kdav/kdav-6.9.0.ebuild
+++ b/kde-frameworks/kdav/kdav-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,9 +15,9 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
-	>=kde-frameworks/kcoreaddons-${PVCUT}:6
-	>=kde-frameworks/ki18n-${PVCUT}:6
-	>=kde-frameworks/kio-${PVCUT}:6
+	>=kde-frameworks/kcoreaddons-${KDE_CATV}:6
+	>=kde-frameworks/ki18n-${KDE_CATV}:6
+	>=kde-frameworks/kio-${KDE_CATV}:6
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kdav/kdav-9999.ebuild
+++ b/kde-frameworks/kdav/kdav-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,9 +15,9 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
-	>=kde-frameworks/kcoreaddons-${PVCUT}:6
-	>=kde-frameworks/ki18n-${PVCUT}:6
-	>=kde-frameworks/kio-${PVCUT}:6
+	>=kde-frameworks/kcoreaddons-${KDE_CATV}:6
+	>=kde-frameworks/ki18n-${KDE_CATV}:6
+	>=kde-frameworks/kio-${KDE_CATV}:6
 "
 DEPEND="${RDEPEND}"
 

--- a/kde-frameworks/kdeclarative/kdeclarative-6.9.0.ebuild
+++ b/kde-frameworks/kdeclarative/kdeclarative-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,12 +16,12 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kglobalaccel-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kglobalaccel-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kdeclarative/kdeclarative-9999.ebuild
+++ b/kde-frameworks/kdeclarative/kdeclarative-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,12 +16,12 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kglobalaccel-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kglobalaccel-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kded/kded-6.9.0.ebuild
+++ b/kde-frameworks/kded/kded-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,14 +16,14 @@ IUSE="+man"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kconfig-${PVCUT}*:6[dbus]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6[dbus]
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kded/kded-9999.ebuild
+++ b/kde-frameworks/kded/kded-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,14 +16,14 @@ IUSE="+man"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kconfig-${PVCUT}*:6[dbus]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6[dbus]
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kdesu/kdesu-6.9.0.ebuild
+++ b/kde-frameworks/kdesu/kdesu-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Framework to handle super user actions"
@@ -14,10 +13,10 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="X"
 
 RDEPEND="
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kpty-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kpty-${KDE_CATV}*:6
 	X? ( x11-libs/libX11 )
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kdesu/kdesu-9999.ebuild
+++ b/kde-frameworks/kdesu/kdesu-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Framework to handle super user actions"
@@ -14,10 +13,10 @@ KEYWORDS=""
 IUSE="X"
 
 RDEPEND="
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kpty-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kpty-${KDE_CATV}*:6
 	X? ( x11-libs/libX11 )
 "
 DEPEND="${RDEPEND}

--- a/kde-frameworks/kdoctools/kdoctools-6.9.0.ebuild
+++ b/kde-frameworks/kdoctools/kdoctools-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Tools to generate documentation in various formats from DocBook files"
@@ -19,13 +18,13 @@ DEPEND="
 	app-text/sgml-common
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	=kde-frameworks/karchive-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-lang/perl
 	dev-perl/URI
-	nls? ( >=kde-frameworks/ki18n-${PVCUT}:6 )
+	nls? ( >=kde-frameworks/ki18n-${KDE_CATV}:6 )
 "
 
 CMAKE_SKIP_TESTS=(

--- a/kde-frameworks/kdoctools/kdoctools-9999.ebuild
+++ b/kde-frameworks/kdoctools/kdoctools-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Tools to generate documentation in various formats from DocBook files"
@@ -19,13 +18,13 @@ DEPEND="
 	app-text/sgml-common
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	=kde-frameworks/karchive-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-lang/perl
 	dev-perl/URI
-	nls? ( >=kde-frameworks/ki18n-${PVCUT}:6 )
+	nls? ( >=kde-frameworks/ki18n-${KDE_CATV}:6 )
 "
 
 CMAKE_SKIP_TESTS=(

--- a/kde-frameworks/kfilemetadata/kfilemetadata-6.9.0.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature python-any-r1
 
@@ -18,10 +17,10 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 	epub? ( app-text/ebook-tools )
 	exif? ( media-gfx/exiv2:= )
 	ffmpeg? ( media-video/ffmpeg:0= )

--- a/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature python-any-r1
 
@@ -18,10 +17,10 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,xml]
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 	epub? ( app-text/ebook-tools )
 	exif? ( media-gfx/exiv2:= )
 	ffmpeg? ( media-video/ffmpeg:0= )

--- a/kde-frameworks/kiconthemes/kiconthemes-6.9.0.ebuild
+++ b/kde-frameworks/kiconthemes/kiconthemes-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -21,11 +20,11 @@ RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtsvg-${QTMIN}:6
-	=kde-frameworks/breeze-icons-${PVCUT}*:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/breeze-icons-${KDE_CATV}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kiconthemes/kiconthemes-9999.ebuild
+++ b/kde-frameworks/kiconthemes/kiconthemes-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -21,11 +20,11 @@ RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtsvg-${QTMIN}:6
-	=kde-frameworks/breeze-icons-${PVCUT}*:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/breeze-icons-${KDE_CATV}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kimageformats/kimageformats-6.9.0.ebuild
+++ b/kde-frameworks/kimageformats/kimageformats-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE="avif eps heif jpegxl openexr raw"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/karchive-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
 	avif? ( >=media-libs/libavif-0.8.2:= )
 	eps? ( >=dev-qt/qtbase-${QTMIN}:6[widgets] )
 	heif? ( >=media-libs/libheif-1.10.0:= )

--- a/kde-frameworks/kimageformats/kimageformats-9999.ebuild
+++ b/kde-frameworks/kimageformats/kimageformats-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE="avif eps heif jpegxl openexr raw"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
-	=kde-frameworks/karchive-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
 	avif? ( >=media-libs/libavif-0.8.2:= )
 	eps? ( >=dev-qt/qtbase-${QTMIN}:6[widgets] )
 	heif? ( >=media-libs/libheif-1.10.0:= )

--- a/kde-frameworks/kio/kio-6.9.0.ebuild
+++ b/kde-frameworks/kio/kio-6.9.0.ebuild
@@ -7,7 +7,6 @@ ECM_DESIGNERPLUGIN="true"
 ECM_HANDBOOK="optional"
 ECM_HANDBOOK_DIR="docs"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org xdg-utils
 
@@ -24,27 +23,27 @@ RESTRICT="test"
 COMMON_DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,network,ssl,widgets,X?]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kauth-${PVCUT}*:6
-	=kde-frameworks/kbookmarks-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/ktextwidgets-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland?,X?]
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
-	=kde-frameworks/solid-${PVCUT}*:6
+	=kde-frameworks/kauth-${KDE_CATV}*:6
+	=kde-frameworks/kbookmarks-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/ktextwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[wayland?,X?]
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
+	=kde-frameworks/solid-${KDE_CATV}*:6
 	sys-power/switcheroo-control
 	acl? (
 		sys-apps/attr
@@ -53,10 +52,10 @@ COMMON_DEPEND="
 	handbook? (
 		dev-libs/libxml2
 		dev-libs/libxslt
-		=kde-frameworks/karchive-${PVCUT}*:6
-		=kde-frameworks/kdoctools-${PVCUT}*:6
+		=kde-frameworks/karchive-${KDE_CATV}*:6
+		=kde-frameworks/kdoctools-${KDE_CATV}*:6
 	)
-	kwallet? ( =kde-frameworks/kwallet-${PVCUT}*:6 )
+	kwallet? ( =kde-frameworks/kwallet-${KDE_CATV}*:6 )
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[gui] )
 "
 DEPEND="${COMMON_DEPEND}
@@ -70,7 +69,7 @@ RDEPEND="${COMMON_DEPEND}
 # provides access to keditfiletype binary via KWidgetsAddons (Tier1)
 # Typical KIO revdeps (dolphin, krusader et al.) can rely on this dep
 PDEPEND="
-	>=kde-frameworks/kded-${PVCUT}:6
+	>=kde-frameworks/kded-${KDE_CATV}:6
 	kde-plasma/keditfiletype
 "
 

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -7,7 +7,6 @@ ECM_DESIGNERPLUGIN="true"
 ECM_HANDBOOK="optional"
 ECM_HANDBOOK_DIR="docs"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org xdg-utils
 
@@ -24,27 +23,27 @@ RESTRICT="test"
 COMMON_DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,network,ssl,widgets,X?]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kauth-${PVCUT}*:6
-	=kde-frameworks/kbookmarks-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/ktextwidgets-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland?,X?]
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
-	=kde-frameworks/solid-${PVCUT}*:6
+	=kde-frameworks/kauth-${KDE_CATV}*:6
+	=kde-frameworks/kbookmarks-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/ktextwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[wayland?,X?]
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
+	=kde-frameworks/solid-${KDE_CATV}*:6
 	sys-power/switcheroo-control
 	acl? (
 		sys-apps/attr
@@ -53,10 +52,10 @@ COMMON_DEPEND="
 	handbook? (
 		dev-libs/libxml2
 		dev-libs/libxslt
-		=kde-frameworks/karchive-${PVCUT}*:6
-		=kde-frameworks/kdoctools-${PVCUT}*:6
+		=kde-frameworks/karchive-${KDE_CATV}*:6
+		=kde-frameworks/kdoctools-${KDE_CATV}*:6
 	)
-	kwallet? ( =kde-frameworks/kwallet-${PVCUT}*:6 )
+	kwallet? ( =kde-frameworks/kwallet-${KDE_CATV}*:6 )
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[gui] )
 "
 DEPEND="${COMMON_DEPEND}
@@ -70,7 +69,7 @@ RDEPEND="${COMMON_DEPEND}
 # provides access to keditfiletype binary via KWidgetsAddons (Tier1)
 # Typical KIO revdeps (dolphin, krusader et al.) can rely on this dep
 PDEPEND="
-	>=kde-frameworks/kded-${PVCUT}:6
+	>=kde-frameworks/kded-${KDE_CATV}:6
 	kde-plasma/keditfiletype
 "
 

--- a/kde-frameworks/kjobwidgets/kjobwidgets-6.9.0.ebuild
+++ b/kde-frameworks/kjobwidgets/kjobwidgets-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,9 +15,9 @@ IUSE="X"
 # slot op: WITH_X11 uses Qt6::GuiPrivate for qtx11extras_p.h
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[X] )
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kjobwidgets/kjobwidgets-9999.ebuild
+++ b/kde-frameworks/kjobwidgets/kjobwidgets-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,9 +15,9 @@ IUSE="X"
 # slot op: WITH_X11 uses Qt6::GuiPrivate for qtx11extras_p.h
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 	X? ( >=dev-qt/qtbase-${QTMIN}:6=[X] )
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/knewstuff/knewstuff-6.9.0.ebuild
+++ b/kde-frameworks/knewstuff/knewstuff-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,18 +17,18 @@ IUSE="opds"
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,network,widgets,xml]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
-	=kde-frameworks/attica-${PVCUT}*:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kpackage-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	opds? ( =kde-frameworks/syndication-${PVCUT}*:6 )
+	=kde-frameworks/attica-${KDE_CATV}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kpackage-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	opds? ( =kde-frameworks/syndication-${KDE_CATV}*:6 )
 "
 RDEPEND="${DEPEND}
-	>=kde-frameworks/kcmutils-${PVCUT}:6
-	>=kde-frameworks/kirigami-${PVCUT}:6
+	>=kde-frameworks/kcmutils-${KDE_CATV}:6
+	>=kde-frameworks/kirigami-${KDE_CATV}:6
 "
 
 src_configure() {

--- a/kde-frameworks/knewstuff/knewstuff-9999.ebuild
+++ b/kde-frameworks/knewstuff/knewstuff-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,18 +17,18 @@ IUSE="opds"
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,network,widgets,xml]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
-	=kde-frameworks/attica-${PVCUT}*:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kpackage-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	opds? ( =kde-frameworks/syndication-${PVCUT}*:6 )
+	=kde-frameworks/attica-${KDE_CATV}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kpackage-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	opds? ( =kde-frameworks/syndication-${KDE_CATV}*:6 )
 "
 RDEPEND="${DEPEND}
-	>=kde-frameworks/kcmutils-${PVCUT}:6
-	>=kde-frameworks/kirigami-${PVCUT}:6
+	>=kde-frameworks/kcmutils-${KDE_CATV}:6
+	>=kde-frameworks/kirigami-${KDE_CATV}:6
 "
 
 src_configure() {

--- a/kde-frameworks/knotifications/knotifications-6.9.0.ebuild
+++ b/kde-frameworks/knotifications/knotifications-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_PYTHON_BINDINGS="off"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,7 +16,7 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
 	media-libs/libcanberra
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/knotifications/knotifications-9999.ebuild
+++ b/kde-frameworks/knotifications/knotifications-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_PYTHON_BINDINGS="off"
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,7 +16,7 @@ KEYWORDS=""
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
 	media-libs/libcanberra
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/knotifyconfig/knotifyconfig-6.9.0.ebuild
+++ b/kde-frameworks/knotifyconfig/knotifyconfig-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,10 +16,10 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtmultimedia-${QTMIN}:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/knotifyconfig/knotifyconfig-9999.ebuild
+++ b/kde-frameworks/knotifyconfig/knotifyconfig-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,10 +16,10 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtmultimedia-${QTMIN}:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kpackage/kpackage-6.9.0.ebuild
+++ b/kde-frameworks/kpackage/kpackage-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,12 +14,12 @@ IUSE="man"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus]
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 CMAKE_SKIP_TESTS=(
 	# bugs 650214, 939041

--- a/kde-frameworks/kpackage/kpackage-9999.ebuild
+++ b/kde-frameworks/kpackage/kpackage-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,12 +14,12 @@ IUSE="man"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus]
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 CMAKE_SKIP_TESTS=(
 	# bugs 650214, 939041

--- a/kde-frameworks/kparts/kparts-6.9.0.ebuild
+++ b/kde-frameworks/kparts/kparts-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,14 +14,14 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kparts/kparts-9999.ebuild
+++ b/kde-frameworks/kparts/kparts-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,14 +14,14 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}"

--- a/kde-frameworks/kpeople/kpeople-6.9.0.ebuild
+++ b/kde-frameworks/kpeople/kpeople-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 VIRTUALX_REQUIRED="test" # bug 816588 (test fails)
 inherit ecm frameworks.kde.org
@@ -18,12 +17,12 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,sql,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcontacts-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcontacts-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kpeople/kpeople-9999.ebuild
+++ b/kde-frameworks/kpeople/kpeople-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 VIRTUALX_REQUIRED="test" # bug 816588 (test fails)
 inherit ecm frameworks.kde.org
@@ -18,12 +17,12 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,sql,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcontacts-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcontacts-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kpty/kpty-6.9.0.ebuild
+++ b/kde-frameworks/kpty/kpty-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Framework for pseudo terminal devices and running child processes"
@@ -13,8 +12,8 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 	sys-libs/libutempter
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kpty/kpty-9999.ebuild
+++ b/kde-frameworks/kpty/kpty-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 inherit ecm frameworks.kde.org
 
 DESCRIPTION="Framework for pseudo terminal devices and running child processes"
@@ -13,8 +12,8 @@ KEYWORDS=""
 IUSE=""
 
 DEPEND="
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 	sys-libs/libutempter
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kquickcharts/kquickcharts-6.9.0.ebuild
+++ b/kde-frameworks/kquickcharts/kquickcharts-6.9.0.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_EXAMPLES="true"
 ECM_QTHELP="false"
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -23,8 +22,8 @@ DEPEND="
 	>=dev-qt/qtshadertools-${QTMIN}:6
 	examples? (
 		>=dev-qt/qtbase-${QTMIN}:6[widgets]
-		=kde-frameworks/kdeclarative-${PVCUT}*:6
-		=kde-frameworks/kirigami-${PVCUT}*:6
+		=kde-frameworks/kdeclarative-${KDE_CATV}*:6
+		=kde-frameworks/kirigami-${KDE_CATV}*:6
 	)
 "
 RDEPEND="${DEPEND}

--- a/kde-frameworks/kquickcharts/kquickcharts-9999.ebuild
+++ b/kde-frameworks/kquickcharts/kquickcharts-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_EXAMPLES="true"
 ECM_QTHELP="false"
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -23,8 +22,8 @@ DEPEND="
 	>=dev-qt/qtshadertools-${QTMIN}:6
 	examples? (
 		>=dev-qt/qtbase-${QTMIN}:6[widgets]
-		=kde-frameworks/kdeclarative-${PVCUT}*:6
-		=kde-frameworks/kirigami-${PVCUT}*:6
+		=kde-frameworks/kdeclarative-${KDE_CATV}*:6
+		=kde-frameworks/kirigami-${KDE_CATV}*:6
 	)
 "
 RDEPEND="${DEPEND}

--- a/kde-frameworks/krunner/krunner-6.9.0.ebuild
+++ b/kde-frameworks/krunner/krunner-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kitemmodels-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kitemmodels-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/krunner/krunner-9999.ebuild
+++ b/kde-frameworks/krunner/krunner-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -15,10 +14,10 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kitemmodels-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kitemmodels-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kservice/kservice-6.9.0.ebuild
+++ b/kde-frameworks/kservice/kservice-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,15 +17,15 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-qt/qtbase-${QTMIN}:6[concurrent] )
 "
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kservice/kservice-9999.ebuild
+++ b/kde-frameworks/kservice/kservice-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,15 +17,15 @@ RESTRICT="test"
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-qt/qtbase-${QTMIN}:6[concurrent] )
 "
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-6.9.0.ebuild
+++ b/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE="X"
 # slot op: Qt6::WidgetsPrivate use
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,widgets]
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[X?]
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
 "
 DEPEND="${RDEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-9999.ebuild
+++ b/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE="X"
 # slot op: Qt6::WidgetsPrivate use
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,widgets]
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[X?]
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
 "
 DEPEND="${RDEPEND}"
 BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"

--- a/kde-frameworks/ksvg/ksvg-6.9.0.ebuild
+++ b/kde-frameworks/ksvg/ksvg-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,11 +16,11 @@ DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtsvg-${QTMIN}:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/ksvg/ksvg-9999.ebuild
+++ b/kde-frameworks/ksvg/ksvg-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -17,11 +16,11 @@ DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtsvg-${QTMIN}:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/ktexteditor/ktexteditor-6.9.0.ebuild
+++ b/kde-frameworks/ktexteditor/ktexteditor-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,29 +18,29 @@ DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtspeech-${QTMIN}:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kauth-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/kparts-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6
-	=kde-frameworks/syntax-highlighting-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kauth-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kparts-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6
+	=kde-frameworks/syntax-highlighting-${KDE_CATV}*:6
 	editorconfig? ( app-text/editorconfig-core-c )
 "
 RDEPEND="${DEPEND}"
-BDEPEND="test? ( >=kde-frameworks/kservice-${PVCUT}:6 )"
+BDEPEND="test? ( >=kde-frameworks/kservice-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/ktexteditor/ktexteditor-9999.ebuild
+++ b/kde-frameworks/ktexteditor/ktexteditor-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,29 +18,29 @@ DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtspeech-${QTMIN}:6
-	=kde-frameworks/karchive-${PVCUT}*:6
-	=kde-frameworks/kauth-${PVCUT}*:6
-	=kde-frameworks/kcodecs-${PVCUT}*:6
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kjobwidgets-${PVCUT}*:6
-	=kde-frameworks/kparts-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6
-	=kde-frameworks/kxmlgui-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6
-	=kde-frameworks/syntax-highlighting-${PVCUT}*:6
+	=kde-frameworks/karchive-${KDE_CATV}*:6
+	=kde-frameworks/kauth-${KDE_CATV}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kjobwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kparts-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6
+	=kde-frameworks/kxmlgui-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6
+	=kde-frameworks/syntax-highlighting-${KDE_CATV}*:6
 	editorconfig? ( app-text/editorconfig-core-c )
 "
 RDEPEND="${DEPEND}"
-BDEPEND="test? ( >=kde-frameworks/kservice-${PVCUT}:6 )"
+BDEPEND="test? ( >=kde-frameworks/kservice-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/ktexttemplate/ktexttemplate-6.9.0.ebuild
+++ b/kde-frameworks/ktexttemplate/ktexttemplate-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm flag-o-matic frameworks.kde.org
 

--- a/kde-frameworks/ktexttemplate/ktexttemplate-9999.ebuild
+++ b/kde-frameworks/ktexttemplate/ktexttemplate-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm flag-o-matic frameworks.kde.org
 

--- a/kde-frameworks/ktextwidgets/ktextwidgets-6.9.0.ebuild
+++ b/kde-frameworks/ktextwidgets/ktextwidgets-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,14 +15,14 @@ IUSE="speech"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6
 	speech? ( >=dev-qt/qtspeech-${QTMIN}:6 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/ktextwidgets/ktextwidgets-9999.ebuild
+++ b/kde-frameworks/ktextwidgets/ktextwidgets-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,14 +15,14 @@ IUSE="speech"
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
-	=kde-frameworks/kcompletion-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6
+	=kde-frameworks/kcompletion-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6
 	speech? ( >=dev-qt/qtspeech-${QTMIN}:6 )
 "
 RDEPEND="${DEPEND}"

--- a/kde-frameworks/kunitconversion/kunitconversion-6.9.0.ebuild
+++ b/kde-frameworks/kunitconversion/kunitconversion-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_PYTHON_BINDINGS="off"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[network]
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kunitconversion/kunitconversion-9999.ebuild
+++ b/kde-frameworks/kunitconversion/kunitconversion-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_PYTHON_BINDINGS="off"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE=""
 
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[network]
-	=kde-frameworks/ki18n-${PVCUT}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kuserfeedback/kuserfeedback-6.9.0.ebuild
+++ b/kde-frameworks/kuserfeedback/kuserfeedback-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 

--- a/kde-frameworks/kuserfeedback/kuserfeedback-9999.ebuild
+++ b/kde-frameworks/kuserfeedback/kuserfeedback-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 

--- a/kde-frameworks/kwallet/kwallet-6.9.0.ebuild
+++ b/kde-frameworks/kwallet/kwallet-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature
 
@@ -17,22 +16,22 @@ DEPEND="
 	>=app-crypt/qca-2.3.9:2[qt6(+)]
 	dev-libs/libgcrypt:0=
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[X?]
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
 	gpg? ( app-crypt/gpgme:=[qt6(-)] )
 "
 RDEPEND="${DEPEND}
 	!${CATEGORY}/${PN}:5[-kf6compat(-)]
 "
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kwallet/kwallet-9999.ebuild
+++ b/kde-frameworks/kwallet/kwallet-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature
 
@@ -17,22 +16,22 @@ DEPEND="
 	>=app-crypt/qca-2.3.9:2[qt6(+)]
 	dev-libs/libgcrypt:0=
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kcrash-${PVCUT}*:6
-	=kde-frameworks/kdbusaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
-	=kde-frameworks/kwindowsystem-${PVCUT}*:6[X?]
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
 	gpg? ( app-crypt/gpgme:=[qt6(-)] )
 "
 RDEPEND="${DEPEND}
 	!${CATEGORY}/${PN}:5[-kf6compat(-)]
 "
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${PVCUT}:6 )"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kxmlgui/kxmlgui-6.9.0.ebuild
+++ b/kde-frameworks/kxmlgui/kxmlgui-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
 ECM_PYTHON_BINDINGS="off"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,15 +17,15 @@ IUSE=""
 # slot op: includes QtCore/private/qlocale_p.h
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,network,ssl,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kglobalaccel-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kglobalaccel-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/kxmlgui/kxmlgui-9999.ebuild
+++ b/kde-frameworks/kxmlgui/kxmlgui-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_DESIGNERPLUGIN="true"
 ECM_PYTHON_BINDINGS="off"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -18,15 +17,15 @@ IUSE=""
 # slot op: includes QtCore/private/qlocale_p.h
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,network,ssl,widgets,xml]
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kconfigwidgets-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/kglobalaccel-${PVCUT}*:6
-	=kde-frameworks/kguiaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kitemviews-${PVCUT}*:6
-	=kde-frameworks/kwidgetsaddons-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kconfigwidgets-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kglobalaccel-${KDE_CATV}*:6
+	=kde-frameworks/kguiaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kitemviews-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-frameworks/modemmanager-qt/modemmanager-qt-6.9.0.ebuild
+++ b/kde-frameworks/modemmanager-qt/modemmanager-qt-6.9.0.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 

--- a/kde-frameworks/modemmanager-qt/modemmanager-qt-9999.ebuild
+++ b/kde-frameworks/modemmanager-qt/modemmanager-qt-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 

--- a/kde-frameworks/purpose/purpose-6.9.0.ebuild
+++ b/kde-frameworks/purpose/purpose-6.9.0.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature xdg-utils
 
@@ -21,24 +20,24 @@ RESTRICT="test"
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,network,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/prison-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/prison-${KDE_CATV}*:6
 	webengine? (
 		kde-apps/kaccounts-integration:6
 		>=net-libs/accounts-qt-1.17[qt6(+)]
 	)
 "
 RDEPEND="${DEPEND}
-	>=kde-frameworks/kdeclarative-${PVCUT}:6
-	bluetooth? ( =kde-frameworks/bluez-qt-${PVCUT}*:6 )
+	>=kde-frameworks/kdeclarative-${KDE_CATV}:6
+	bluetooth? ( =kde-frameworks/bluez-qt-${KDE_CATV}*:6 )
 	webengine? (
-		>=kde-frameworks/purpose-kaccounts-services-${PVCUT}
+		>=kde-frameworks/purpose-kaccounts-services-${KDE_CATV}
 		>=net-libs/accounts-qml-0.7_p20231028[qt6(+)]
 	)
 "

--- a/kde-frameworks/purpose/purpose-9999.ebuild
+++ b/kde-frameworks/purpose/purpose-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_QTHELP="false"
 ECM_TEST="forceoptional"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org optfeature xdg-utils
 
@@ -21,24 +20,24 @@ RESTRICT="test"
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,network,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kcoreaddons-${PVCUT}*:6
-	=kde-frameworks/ki18n-${PVCUT}*:6
-	=kde-frameworks/kio-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
-	=kde-frameworks/knotifications-${PVCUT}*:6
-	=kde-frameworks/kservice-${PVCUT}*:6
-	=kde-frameworks/prison-${PVCUT}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/kio-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/prison-${KDE_CATV}*:6
 	webengine? (
 		kde-apps/kaccounts-integration:6
 		>=net-libs/accounts-qt-1.17[qt6(+)]
 	)
 "
 RDEPEND="${DEPEND}
-	>=kde-frameworks/kdeclarative-${PVCUT}:6
-	bluetooth? ( =kde-frameworks/bluez-qt-${PVCUT}*:6 )
+	>=kde-frameworks/kdeclarative-${KDE_CATV}:6
+	bluetooth? ( =kde-frameworks/bluez-qt-${KDE_CATV}*:6 )
 	webengine? (
-		>=kde-frameworks/purpose-kaccounts-services-${PVCUT}
+		>=kde-frameworks/purpose-kaccounts-services-${KDE_CATV}
 		>=net-libs/accounts-qml-0.7_p20231028[qt6(+)]
 	)
 "

--- a/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-6.9.0.ebuild
+++ b/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,11 +18,11 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6=
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6[qml]
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6[qml]
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6

--- a/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-9999.ebuild
+++ b/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_QTHELP="false"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -19,11 +18,11 @@ IUSE=""
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6=
-	=kde-frameworks/kcolorscheme-${PVCUT}*:6
-	=kde-frameworks/kconfig-${PVCUT}*:6
-	=kde-frameworks/kiconthemes-${PVCUT}*:6
-	=kde-frameworks/kirigami-${PVCUT}*:6
-	=kde-frameworks/sonnet-${PVCUT}*:6[qml]
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kiconthemes-${KDE_CATV}*:6
+	=kde-frameworks/kirigami-${KDE_CATV}*:6
+	=kde-frameworks/sonnet-${KDE_CATV}*:6[qml]
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6

--- a/kde-frameworks/syndication/syndication-6.9.0.ebuild
+++ b/kde-frameworks/syndication/syndication-6.9.0.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[xml]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-qt/qtbase-${QTMIN}:6[network] )

--- a/kde-frameworks/syndication/syndication-9999.ebuild
+++ b/kde-frameworks/syndication/syndication-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-2)
 QTMIN=6.7.2
 inherit ecm frameworks.kde.org
 
@@ -16,7 +15,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[xml]
-	=kde-frameworks/kcodecs-${PVCUT}*:6
+	=kde-frameworks/kcodecs-${KDE_CATV}*:6
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-qt/qtbase-${QTMIN}:6[network] )

--- a/kde-misc/kdiff3/kdiff3-9999.ebuild
+++ b/kde-misc/kdiff3/kdiff3-9999.ebuild
@@ -4,8 +4,8 @@
 EAPI=8
 
 ECM_HANDBOOK="optional"
-KFMIN=6.3.0
-QTMIN=6.6.2
+KFMIN=6.6.0
+QTMIN=6.7.2
 inherit ecm kde.org
 
 DESCRIPTION="Frontend to diff3 based on KDE Frameworks"
@@ -17,7 +17,7 @@ KEYWORDS=""
 IUSE=""
 
 COMMON_DEPEND="
-	>=dev-qt/qt5compat-${QTMIN}:6
+	>=dev-libs/icu-70.0:=
 	>=dev-qt/qtbase-${QTMIN}:6[gui,widgets]
 	>=kde-frameworks/kconfig-${KFMIN}:6
 	>=kde-frameworks/kconfigwidgets-${KFMIN}:6

--- a/kde-plasma/bluedevil/bluedevil-6.2.49.9999.ebuild
+++ b/kde-plasma/bluedevil/bluedevil-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,7 +33,7 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6

--- a/kde-plasma/bluedevil/bluedevil-9999.ebuild
+++ b/kde-plasma/bluedevil/bluedevil-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="optional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,7 +33,7 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6

--- a/kde-plasma/breeze-grub/breeze-grub-6.2.49.9999.ebuild
+++ b/kde-plasma/breeze-grub/breeze-grub-6.2.49.9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 inherit plasma.kde.org
 
 DESCRIPTION="Breeze theme for GRUB"

--- a/kde-plasma/breeze-grub/breeze-grub-9999.ebuild
+++ b/kde-plasma/breeze-grub/breeze-grub-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 inherit plasma.kde.org
 
 DESCRIPTION="Breeze theme for GRUB"

--- a/kde-plasma/breeze-gtk/breeze-gtk-6.2.49.9999.ebuild
+++ b/kde-plasma/breeze-gtk/breeze-gtk-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.5.0
-PVCUT=$(ver_cut 1-3)
 PYTHON_COMPAT=( python3_{10..13} )
 inherit ecm plasma.kde.org python-any-r1
 
@@ -19,7 +18,7 @@ IUSE=""
 BDEPEND="${PYTHON_DEPS}
 	dev-lang/sassc
 	$(python_gen_any_dep 'dev-python/pycairo[${PYTHON_USEDEP}]')
-	>=kde-plasma/breeze-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
 "
 
 python_check_deps() {

--- a/kde-plasma/breeze-gtk/breeze-gtk-9999.ebuild
+++ b/kde-plasma/breeze-gtk/breeze-gtk-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.5.0
-PVCUT=$(ver_cut 1-3)
 PYTHON_COMPAT=( python3_{10..13} )
 inherit ecm plasma.kde.org python-any-r1
 
@@ -19,7 +18,7 @@ IUSE=""
 BDEPEND="${PYTHON_DEPS}
 	dev-lang/sassc
 	$(python_gen_any_dep 'dev-python/pycairo[${PYTHON_USEDEP}]')
-	>=kde-plasma/breeze-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
 "
 
 python_check_deps() {

--- a/kde-plasma/breeze-plymouth/breeze-plymouth-6.2.49.9999.ebuild
+++ b/kde-plasma/breeze-plymouth/breeze-plymouth-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 inherit cmake plasma.kde.org
 
 DESCRIPTION="Breeze theme for Plymouth"

--- a/kde-plasma/breeze-plymouth/breeze-plymouth-9999.ebuild
+++ b/kde-plasma/breeze-plymouth/breeze-plymouth-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 inherit cmake plasma.kde.org
 
 DESCRIPTION="Breeze theme for Plymouth"

--- a/kde-plasma/breeze/breeze-6.2.49.9999.ebuild
+++ b/kde-plasma/breeze/breeze-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -33,7 +32,7 @@ RDEPEND="
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	>=kde-plasma/kdecoration-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	qt5? (
 		>=dev-qt/qtdbus-${QT5MIN}:5
 		>=dev-qt/qtdeclarative-${QT5MIN}:5

--- a/kde-plasma/breeze/breeze-9999.ebuild
+++ b/kde-plasma/breeze/breeze-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -33,7 +32,7 @@ RDEPEND="
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	>=kde-plasma/kdecoration-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	qt5? (
 		>=dev-qt/qtdbus-${QT5MIN}:5
 		>=dev-qt/qtdeclarative-${QT5MIN}:5

--- a/kde-plasma/flatpak-kcm/flatpak-kcm-6.2.49.9999.ebuild
+++ b/kde-plasma/flatpak-kcm/flatpak-kcm-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/flatpak-kcm/flatpak-kcm-9999.ebuild
+++ b/kde-plasma/flatpak-kcm/flatpak-kcm-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/kactivitymanagerd/kactivitymanagerd-6.2.49.9999.ebuild
+++ b/kde-plasma/kactivitymanagerd/kactivitymanagerd-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/kactivitymanagerd/kactivitymanagerd-9999.ebuild
+++ b/kde-plasma/kactivitymanagerd/kactivitymanagerd-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-6.2.49.9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -27,7 +26,7 @@ DEPEND="
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/kguiaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	x11-libs/gtk+:3[X]
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -27,7 +26,7 @@ DEPEND="
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/kguiaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	x11-libs/gtk+:3[X]
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kdeplasma-addons/kdeplasma-addons-6.2.49.9999.ebuild
+++ b/kde-plasma/kdeplasma-addons/kdeplasma-addons-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -42,8 +41,8 @@ DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/sonnet-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	alternate-calendar? ( dev-libs/icu:= )
 	share? ( >=kde-frameworks/purpose-${KFMIN}:6 )
 	webengine? ( >=dev-qt/qtwebengine-${QTMIN}:6 )

--- a/kde-plasma/kdeplasma-addons/kdeplasma-addons-9999.ebuild
+++ b/kde-plasma/kdeplasma-addons/kdeplasma-addons-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -42,8 +41,8 @@ DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/sonnet-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	alternate-calendar? ( dev-libs/icu:= )
 	share? ( >=kde-frameworks/purpose-${KFMIN}:6 )
 	webengine? ( >=dev-qt/qtwebengine-${QTMIN}:6 )

--- a/kde-plasma/kinfocenter/kinfocenter-6.2.49.9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -37,7 +36,7 @@ RDEPEND="${DEPEND}
 		dev-qt/qdbus:*
 	)
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/systemsettings-${PVCUT}:6
+	>=kde-plasma/systemsettings-${KDE_CATV}:6
 "
 BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
 

--- a/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -37,7 +36,7 @@ RDEPEND="${DEPEND}
 		dev-qt/qdbus:*
 	)
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/systemsettings-${PVCUT}:6
+	>=kde-plasma/systemsettings-${KDE_CATV}:6
 "
 BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
 

--- a/kde-plasma/kpipewire/kpipewire-6.2.49.9999.ebuild
+++ b/kde-plasma/kpipewire/kpipewire-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-3)
 KFMIN=6.6.0
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -34,7 +33,7 @@ DEPEND="${COMMON_DEPEND}
 		dev-libs/plasma-wayland-protocols
 		dev-libs/wayland
 		>=dev-qt/qtwayland-${QTMIN}:6
-		>=kde-plasma/kwayland-${PVCUT}:6
+		>=kde-plasma/kwayland-${KDE_CATV}:6
 		media-video/pipewire[extra]
 	)
 "

--- a/kde-plasma/kpipewire/kpipewire-9999.ebuild
+++ b/kde-plasma/kpipewire/kpipewire-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 ECM_TEST="true"
-PVCUT=$(ver_cut 1-3)
 KFMIN=9999
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -34,7 +33,7 @@ DEPEND="${COMMON_DEPEND}
 		dev-libs/plasma-wayland-protocols
 		dev-libs/wayland
 		>=dev-qt/qtwayland-${QTMIN}:6
-		>=kde-plasma/kwayland-${PVCUT}:6
+		>=kde-plasma/kwayland-${KDE_CATV}:6
 		media-video/pipewire[extra]
 	)
 "

--- a/kde-plasma/krdp/krdp-6.2.49.9999.ebuild
+++ b/kde-plasma/krdp/krdp-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_EXAMPLES="true"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm flag-o-matic plasma.kde.org toolchain-funcs
 
@@ -30,7 +29,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
-	>=kde-plasma/kpipewire-${PVCUT}:6
+	>=kde-plasma/kpipewire-${KDE_CATV}:6
 	>=net-misc/freerdp-2.10:2[server]
 	x11-libs/libxkbcommon
 "

--- a/kde-plasma/krdp/krdp-9999.ebuild
+++ b/kde-plasma/krdp/krdp-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_EXAMPLES="true"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm flag-o-matic plasma.kde.org toolchain-funcs
 
@@ -30,7 +29,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
-	>=kde-plasma/kpipewire-${PVCUT}:6
+	>=kde-plasma/kpipewire-${KDE_CATV}:6
 	>=net-misc/freerdp-2.10:2[server]
 	x11-libs/libxkbcommon
 "

--- a/kde-plasma/kscreen/kscreen-6.2.49.9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,9 +33,9 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6=
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6=
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	X? (
 		>=dev-qt/qtbase-${QTMIN}:6=[X]
 		x11-libs/libX11

--- a/kde-plasma/kscreen/kscreen-9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,9 +33,9 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6=
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6=
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	X? (
 		>=dev-qt/qtbase-${QTMIN}:6=[X]
 		x11-libs/libX11

--- a/kde-plasma/kscreenlocker/kscreenlocker-6.2.49.9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org pam
 
@@ -36,9 +35,9 @@ COMMON_DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
 	sys-libs/pam
 	x11-libs/libX11
 	x11-libs/libXi
@@ -50,7 +49,7 @@ DEPEND="${COMMON_DEPEND}
 "
 RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 BDEPEND="
 	dev-util/wayland-scanner

--- a/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org pam
 
@@ -36,9 +35,9 @@ COMMON_DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
 	sys-libs/pam
 	x11-libs/libX11
 	x11-libs/libXi
@@ -50,7 +49,7 @@ DEPEND="${COMMON_DEPEND}
 "
 RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 BDEPEND="
 	dev-util/wayland-scanner

--- a/kde-plasma/ksystemstats/ksystemstats-6.2.49.9999.ebuild
+++ b/kde-plasma/ksystemstats/ksystemstats-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -26,7 +25,7 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 	net-libs/libpcap
 	sys-apps/lm-sensors:=
 	sys-libs/libcap

--- a/kde-plasma/ksystemstats/ksystemstats-9999.ebuild
+++ b/kde-plasma/ksystemstats/ksystemstats-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -26,7 +25,7 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 	net-libs/libpcap
 	sys-apps/lm-sensors:=
 	sys-libs/libcap

--- a/kde-plasma/kwin/kwin-6.2.49.9999.ebuild
+++ b/kde-plasma/kwin/kwin-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm fcaps plasma.kde.org
 
@@ -51,10 +50,10 @@ COMMON_DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6=[wayland,X]
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/breeze-${PVCUT}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/lcms:2
@@ -75,9 +74,9 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-wm
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
 	gles2-only? ( >=media-libs/mesa-24.1.0_rc1[opengl] )
-	lock? ( >=kde-plasma/kscreenlocker-${PVCUT}:6 )
+	lock? ( >=kde-plasma/kscreenlocker-${KDE_CATV}:6 )
 	screencast? ( >=media-video/pipewire-0.3.65:= )
-	shortcuts? ( >=kde-plasma/kglobalacceld-${PVCUT}:6 )
+	shortcuts? ( >=kde-plasma/kglobalacceld-${KDE_CATV}:6 )
 "
 RDEPEND="${COMMON_DEPEND}
 	!kde-plasma/kdeplasma-addons:5
@@ -91,7 +90,7 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6[wayland(+)]
+	>=kde-plasma/libplasma-${KDE_CATV}:6[wayland(+)]
 	sys-apps/hwdata
 	x11-base/xwayland[libei]
 "
@@ -103,7 +102,7 @@ DEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtwayland-${QTMIN}:6
 	x11-base/xorg-proto
 	x11-libs/xcb-util-image
-	test? ( screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 ) )
+	test? ( screencast? ( >=kde-plasma/kpipewire-${KDE_CATV}:6 ) )
 "
 BDEPEND="
 	>=dev-qt/qtwayland-${QTMIN}:6

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm fcaps plasma.kde.org
 
@@ -51,10 +50,10 @@ COMMON_DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6=[wayland,X]
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/breeze-${PVCUT}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/lcms:2
@@ -75,9 +74,9 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-wm
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
 	gles2-only? ( >=media-libs/mesa-24.1.0_rc1[opengl] )
-	lock? ( >=kde-plasma/kscreenlocker-${PVCUT}:6 )
+	lock? ( >=kde-plasma/kscreenlocker-${KDE_CATV}:6 )
 	screencast? ( >=media-video/pipewire-1.2.0:= )
-	shortcuts? ( >=kde-plasma/kglobalacceld-${PVCUT}:6 )
+	shortcuts? ( >=kde-plasma/kglobalacceld-${KDE_CATV}:6 )
 "
 RDEPEND="${COMMON_DEPEND}
 	!kde-plasma/kdeplasma-addons:5
@@ -91,7 +90,7 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6[wayland(+)]
+	>=kde-plasma/libplasma-${KDE_CATV}:6[wayland(+)]
 	sys-apps/hwdata
 	>=x11-base/xwayland-23.1.0[libei]
 "
@@ -103,7 +102,7 @@ DEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtwayland-${QTMIN}:6
 	x11-base/xorg-proto
 	x11-libs/xcb-util-image
-	test? ( screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 ) )
+	test? ( screencast? ( >=kde-plasma/kpipewire-${KDE_CATV}:6 ) )
 "
 BDEPEND="
 	>=dev-qt/qtwayland-${QTMIN}:6

--- a/kde-plasma/libplasma/libplasma-6.2.49.9999.ebuild
+++ b/kde-plasma/libplasma/libplasma-6.2.49.9999.ebuild
@@ -7,7 +7,6 @@ ECM_NONGUI="true"
 ECM_QTHELP="true"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -42,7 +41,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	=kde-plasma/plasma-activities-${PVCUT}*:6
+	=kde-plasma/plasma-activities-${KDE_CATV}*:6
 	media-libs/libglvnd
 	x11-libs/libX11
 	x11-libs/libxcb

--- a/kde-plasma/libplasma/libplasma-9999.ebuild
+++ b/kde-plasma/libplasma/libplasma-9999.ebuild
@@ -7,7 +7,6 @@ ECM_NONGUI="true"
 ECM_QTHELP="true"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -42,7 +41,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
-	=kde-plasma/plasma-activities-${PVCUT}*:6
+	=kde-plasma/plasma-activities-${KDE_CATV}*:6
 	media-libs/libglvnd
 	x11-libs/libX11
 	x11-libs/libxcb

--- a/kde-plasma/milou/milou-6.2.49.9999.ebuild
+++ b/kde-plasma/milou/milou-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -24,6 +23,6 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/krunner-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/milou/milou-9999.ebuild
+++ b/kde-plasma/milou/milou-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -24,6 +23,6 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/krunner-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/oxygen/oxygen-6.2.49.9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -32,8 +31,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	qt5? (
 		>=dev-qt/qtdbus-${QT5MIN}:5
 		>=dev-qt/qtdeclarative-${QT5MIN}:5

--- a/kde-plasma/oxygen/oxygen-9999.ebuild
+++ b/kde-plasma/oxygen/oxygen-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -32,8 +31,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kdecoration-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/kdecoration-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	qt5? (
 		>=dev-qt/qtdbus-${QT5MIN}:5
 		>=dev-qt/qtdeclarative-${QT5MIN}:5

--- a/kde-plasma/plasma-bigscreen/plasma-bigscreen-5.27.49.9999.ebuild
+++ b/kde-plasma/plasma-bigscreen/plasma-bigscreen-5.27.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.5.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,11 +29,11 @@ DEPEND="
 	>=kde-frameworks/knotifications-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-activities-stats-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qtsvg-${QTMIN}:6

--- a/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,8 +29,8 @@ RDEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/purpose-${KFMIN}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 "
 DEPEND="${RDEPEND}
 	>=kde-frameworks/krunner-${KFMIN}:6

--- a/kde-plasma/plasma-browser-integration/plasma-browser-integration-9999.ebuild
+++ b/kde-plasma/plasma-browser-integration/plasma-browser-integration-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,8 +29,8 @@ RDEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/purpose-${KFMIN}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 "
 DEPEND="${RDEPEND}
 	>=kde-frameworks/krunner-${KFMIN}:6

--- a/kde-plasma/plasma-desktop/plasma-desktop-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -63,13 +62,13 @@ COMMON_DEPEND="
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
 	>=kde-frameworks/sonnet-${KFMIN}:6
-	>=kde-plasma/kwin-${PVCUT}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-activities-stats-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6[screencast?]
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/kwin-${KDE_CATV}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6[screencast?]
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	media-libs/libcanberra
 	x11-libs/libX11
 	x11-libs/libxcb
@@ -100,7 +99,7 @@ DEPEND="${COMMON_DEPEND}
 	input_devices_wacom? ( >=dev-libs/wayland-protocols-1.25 )
 	test? (
 		>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
-		>=kde-plasma/kactivitymanagerd-${PVCUT}:6
+		>=kde-plasma/kactivitymanagerd-${KDE_CATV}:6
 	)
 "
 RDEPEND="${COMMON_DEPEND}
@@ -110,13 +109,13 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtwayland-${QTMIN}:6
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
-	>=kde-plasma/oxygen-${PVCUT}:6
+	>=kde-plasma/oxygen-${KDE_CATV}:6
 	kde-plasma/plasma-mimeapps-list
 	media-fonts/noto-emoji
 	sys-apps/util-linux
 	x11-apps/setxkbmap
 	x11-misc/xdg-user-dirs
-	screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 )
+	screencast? ( >=kde-plasma/kpipewire-${KDE_CATV}:6 )
 	webengine? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6(+)] )
 "
 BDEPEND="

--- a/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -63,13 +62,13 @@ COMMON_DEPEND="
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
 	>=kde-frameworks/sonnet-${KFMIN}:6
-	>=kde-plasma/kwin-${PVCUT}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-activities-stats-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6[screencast?]
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/kwin-${KDE_CATV}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6[screencast?]
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	media-libs/libcanberra
 	x11-libs/libX11
 	x11-libs/libxcb
@@ -101,7 +100,7 @@ DEPEND="${COMMON_DEPEND}
 	input_devices_wacom? ( >=dev-libs/wayland-protocols-1.25 )
 	test? (
 		>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
-		>=kde-plasma/kactivitymanagerd-${PVCUT}:6
+		>=kde-plasma/kactivitymanagerd-${KDE_CATV}:6
 	)
 "
 RDEPEND="${COMMON_DEPEND}
@@ -111,13 +110,13 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtwayland-${QTMIN}:6
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
-	>=kde-plasma/oxygen-${PVCUT}:6
+	>=kde-plasma/oxygen-${KDE_CATV}:6
 	kde-plasma/plasma-mimeapps-list
 	media-fonts/noto-emoji
 	sys-apps/util-linux
 	x11-apps/setxkbmap
 	x11-misc/xdg-user-dirs
-	screencast? ( >=kde-plasma/kpipewire-${PVCUT}:6 )
+	screencast? ( >=kde-plasma/kpipewire-${KDE_CATV}:6 )
 	webengine? ( >=net-libs/signon-oauth2-0.25_p20210102[qt6(+)] )
 "
 BDEPEND="

--- a/kde-plasma/plasma-integration/plasma-integration-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -72,7 +71,7 @@ RDEPEND="${COMMON_DEPEND}
 	media-fonts/noto-emoji
 "
 PDEPEND="
-	>=kde-plasma/xdg-desktop-portal-kde-${PVCUT}:6
+	>=kde-plasma/xdg-desktop-portal-kde-${KDE_CATV}:6
 "
 BDEPEND="
 	>=dev-qt/qtwayland-${QTMIN}:6

--- a/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KF5MIN=5.115.0
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QT5MIN=5.15.12
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -72,7 +71,7 @@ RDEPEND="${COMMON_DEPEND}
 	media-fonts/noto-emoji
 "
 PDEPEND="
-	>=kde-plasma/xdg-desktop-portal-kde-${PVCUT}:6
+	>=kde-plasma/xdg-desktop-portal-kde-${KDE_CATV}:6
 "
 BDEPEND="
 	>=dev-qt/qtwayland-${QTMIN}:6

--- a/kde-plasma/plasma-nm/plasma-nm-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -39,7 +38,7 @@ DEPEND="
 	>=kde-frameworks/modemmanager-qt-${KFMIN}:6
 	>=kde-frameworks/networkmanager-qt-${KFMIN}:6[teamd=]
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	net-misc/mobile-broadband-provider-info
 	net-misc/networkmanager[teamd=]
 	openconnect? (

--- a/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -39,7 +38,7 @@ DEPEND="
 	>=kde-frameworks/modemmanager-qt-${KFMIN}:6
 	>=kde-frameworks/networkmanager-qt-${KFMIN}:6[teamd=]
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	net-misc/mobile-broadband-provider-info
 	net-misc/networkmanager[teamd=]
 	openconnect? (

--- a/kde-plasma/plasma-pa/plasma-pa-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,7 +29,7 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	media-libs/libcanberra
 	media-libs/libpulse
 	>=media-libs/pulseaudio-qt-1.6.0:=

--- a/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -31,7 +30,7 @@ DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	media-libs/libcanberra
 	media-libs/libpulse
 	>=media-libs/pulseaudio-qt-1.6.0:=

--- a/kde-plasma/plasma-sdk/plasma-sdk-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,8 +33,8 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/ktexteditor-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]

--- a/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
+++ b/kde-plasma/plasma-sdk/plasma-sdk-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,8 +33,8 @@ DEPEND="
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/ktexteditor-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]

--- a/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-6.2.49.9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 KFMIN=6.6.0
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -33,11 +32,11 @@ DEPEND="
 	>=kde-frameworks/kpackage-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kquickcharts-${KFMIN}:6
-	>=kde-plasma/ksystemstats-${PVCUT}:6
+	>=kde-plasma/ksystemstats-${KDE_CATV}:6
 "

--- a/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-9999.ebuild
+++ b/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 KFMIN=9999
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
@@ -33,11 +32,11 @@ DEPEND="
 	>=kde-frameworks/kpackage-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kquickcharts-${KFMIN}:6
-	>=kde-plasma/ksystemstats-${PVCUT}:6
+	>=kde-plasma/ksystemstats-${KDE_CATV}:6
 "

--- a/kde-plasma/plasma-vault/plasma-vault-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-vault/plasma-vault-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm flag-o-matic plasma.kde.org
 
@@ -29,9 +28,9 @@ DEPEND="
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 	networkmanager? ( >=kde-frameworks/networkmanager-qt-${KFMIN}:6 )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/plasma-vault/plasma-vault-9999.ebuild
+++ b/kde-plasma/plasma-vault/plasma-vault-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm flag-o-matic plasma.kde.org
 
@@ -29,9 +28,9 @@ DEPEND="
 	>=kde-frameworks/kitemmodels-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 	networkmanager? ( >=kde-frameworks/networkmanager-qt-${KFMIN}:6 )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/plasma-welcome/plasma-welcome-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-welcome/plasma-welcome-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -32,6 +31,6 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/plasma-welcome/plasma-welcome-9999.ebuild
+++ b/kde-plasma/plasma-welcome/plasma-welcome-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -32,6 +31,6 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"

--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-6.2.49.9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit cmake plasma.kde.org
 

--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-9999.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit cmake plasma.kde.org
 

--- a/kde-plasma/plasma-workspace/plasma-workspace-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="optional"
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -73,17 +72,17 @@ COMMON_DEPEND="
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/prison-${KFMIN}:6[qml]
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/breeze-${PVCUT}:6
-	>=kde-plasma/kscreenlocker-${PVCUT}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/kwin-${PVCUT}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-activities-stats-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
+	>=kde-plasma/kscreenlocker-${KDE_CATV}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/kwin-${KDE_CATV}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	media-libs/libcanberra
 	>=media-libs/phonon-4.12.0[qt6(+)]
 	sci-libs/libqalculate:=
@@ -115,7 +114,7 @@ COMMON_DEPEND="
 	)
 	screencast? (
 		>=dev-qt/qtbase-${QTMIN}:6=[opengl]
-		>=kde-plasma/kpipewire-${PVCUT}:6
+		>=kde-plasma/kpipewire-${KDE_CATV}:6
 		media-libs/libglvnd
 		>=media-video/pipewire-0.3:=
 		x11-libs/libdrm
@@ -143,11 +142,11 @@ RDEPEND="${COMMON_DEPEND}
 	kde-apps/kio-extras:6
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kquickcharts-${KFMIN}:6
-	>=kde-plasma/kactivitymanagerd-${PVCUT}:6
-	>=kde-plasma/kdesu-gui-${PVCUT}:*
-	>=kde-plasma/milou-${PVCUT}:6
-	>=kde-plasma/plasma-integration-${PVCUT}:6
-	>=kde-plasma/plasma-login-sessions-${PVCUT}:6
+	>=kde-plasma/kactivitymanagerd-${KDE_CATV}:6
+	>=kde-plasma/kdesu-gui-${KDE_CATV}:*
+	>=kde-plasma/milou-${KDE_CATV}:6
+	>=kde-plasma/plasma-integration-${KDE_CATV}:6
+	>=kde-plasma/plasma-login-sessions-${KDE_CATV}:6
 	sys-apps/dbus
 	x11-apps/xmessage
 	x11-apps/xprop

--- a/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="optional"
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -73,17 +72,17 @@ COMMON_DEPEND="
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/prison-${KFMIN}:6[qml]
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/breeze-${PVCUT}:6
-	>=kde-plasma/kscreenlocker-${PVCUT}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/kwin-${PVCUT}:6
-	>=kde-plasma/layer-shell-qt-${PVCUT}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-activities-stats-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/breeze-${KDE_CATV}:6
+	>=kde-plasma/kscreenlocker-${KDE_CATV}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/kwin-${KDE_CATV}:6
+	>=kde-plasma/layer-shell-qt-${KDE_CATV}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	media-libs/libcanberra
 	>=media-libs/phonon-4.12.0[qt6(+)]
 	sci-libs/libqalculate:=
@@ -141,11 +140,11 @@ RDEPEND="${COMMON_DEPEND}
 	kde-apps/kio-extras:6
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/kquickcharts-${KFMIN}:6
-	>=kde-plasma/kactivitymanagerd-${PVCUT}:6
-	>=kde-plasma/kdesu-gui-${PVCUT}:*
-	>=kde-plasma/milou-${PVCUT}:6
-	>=kde-plasma/plasma-integration-${PVCUT}:6
-	>=kde-plasma/plasma-login-sessions-${PVCUT}:6
+	>=kde-plasma/kactivitymanagerd-${KDE_CATV}:6
+	>=kde-plasma/kdesu-gui-${KDE_CATV}:*
+	>=kde-plasma/milou-${KDE_CATV}:6
+	>=kde-plasma/plasma-integration-${KDE_CATV}:6
+	>=kde-plasma/plasma-login-sessions-${KDE_CATV}:6
 	sys-apps/dbus
 	x11-apps/xmessage
 	x11-apps/xprop

--- a/kde-plasma/plasma5support/plasma5support-6.2.49.9999.ebuild
+++ b/kde-plasma/plasma5support/plasma5support-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_QTHELP="true"
 ECM_TEST="true"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,7 +29,7 @@ DEPEND="
 	>=kde-frameworks/knotifications-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}
 	!kde-plasma/plasma-workspace:5

--- a/kde-plasma/plasma5support/plasma5support-9999.ebuild
+++ b/kde-plasma/plasma5support/plasma5support-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_QTHELP="true"
 ECM_TEST="true"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -31,7 +30,7 @@ DEPEND="
 	>=kde-frameworks/knotifications-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libksysguard-${PVCUT}:6
+	>=kde-plasma/libksysguard-${KDE_CATV}:6
 	geolocation? ( >=kde-frameworks/networkmanager-qt-${KFMIN}:6 )
 	X? ( x11-libs/libX11 )
 "

--- a/kde-plasma/plymouth-kcm/plymouth-kcm-6.2.49.9999.ebuild
+++ b/kde-plasma/plymouth-kcm/plymouth-kcm-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/plymouth-kcm/plymouth-kcm-9999.ebuild
+++ b/kde-plasma/plymouth-kcm/plymouth-kcm-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/polkit-kde-agent/polkit-kde-agent-6.2.49.9999.ebuild
+++ b/kde-plasma/polkit-kde-agent/polkit-kde-agent-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KDE_ORG_NAME="${PN}-1"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,5 +29,5 @@ DEPEND="
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "

--- a/kde-plasma/polkit-kde-agent/polkit-kde-agent-9999.ebuild
+++ b/kde-plasma/polkit-kde-agent/polkit-kde-agent-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 KDE_ORG_NAME="${PN}-1"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -30,5 +29,5 @@ DEPEND="
 RDEPEND="${DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]
 	>=kde-frameworks/kirigami-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 "

--- a/kde-plasma/powerdevil/powerdevil-6.2.49.9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-6.2.49.9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm fcaps plasma.kde.org
 
@@ -44,10 +43,10 @@ DEPEND="
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	virtual/libudev:=
 	x11-libs/libxcb
 	brightness-control? ( app-misc/ddcutil:= )

--- a/kde-plasma/powerdevil/powerdevil-9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-9999.ebuild
@@ -6,7 +6,6 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm fcaps plasma.kde.org
 
@@ -44,10 +43,10 @@ DEPEND="
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6[X]
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	>=kde-plasma/libkscreen-${PVCUT}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/libkscreen-${KDE_CATV}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	virtual/libudev:=
 	x11-libs/libxcb
 	brightness-control? ( app-misc/ddcutil:= )

--- a/kde-plasma/print-manager/print-manager-6.2.49.9999.ebuild
+++ b/kde-plasma/print-manager/print-manager-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -32,7 +31,7 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	>=net-print/cups-2.4
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/print-manager/print-manager-9999.ebuild
+++ b/kde-plasma/print-manager/print-manager-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -32,7 +31,7 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
 	>=net-print/cups-2.4
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/sddm-kcm/sddm-kcm-6.2.49.9999.ebuild
+++ b/kde-plasma/sddm-kcm/sddm-kcm-6.2.49.9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/sddm-kcm/sddm-kcm-9999.ebuild
+++ b/kde-plasma/sddm-kcm/sddm-kcm-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 

--- a/kde-plasma/systemsettings/systemsettings-6.2.49.9999.ebuild
+++ b/kde-plasma/systemsettings/systemsettings-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="optional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -40,7 +39,7 @@ DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-plasma/systemsettings/systemsettings-9999.ebuild
+++ b/kde-plasma/systemsettings/systemsettings-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="optional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org optfeature
 
@@ -40,7 +39,7 @@ DEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/plasma-activities-${PVCUT}:6
+	>=kde-plasma/plasma-activities-${KDE_CATV}:6
 "
 RDEPEND="${DEPEND}"
 

--- a/kde-plasma/wacomtablet/wacomtablet-6.2.49.9999.ebuild
+++ b/kde-plasma/wacomtablet/wacomtablet-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,8 +33,8 @@ RDEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	>=x11-drivers/xf86-input-wacom-0.20.0
 	x11-libs/libXi
 	x11-libs/libxcb

--- a/kde-plasma/wacomtablet/wacomtablet-9999.ebuild
+++ b/kde-plasma/wacomtablet/wacomtablet-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_HANDBOOK="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -34,8 +33,8 @@ RDEPEND="
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-plasma/libplasma-${PVCUT}:6
-	>=kde-plasma/plasma5support-${PVCUT}:6
+	>=kde-plasma/libplasma-${KDE_CATV}:6
+	>=kde-plasma/plasma5support-${KDE_CATV}:6
 	>=x11-drivers/xf86-input-wacom-0.20.0
 	x11-libs/libXi
 	x11-libs/libxcb

--- a/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-6.2.49.9999.ebuild
+++ b/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-6.2.49.9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=6.6.0
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -42,8 +41,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	x11-libs/libxkbcommon
 "
 DEPEND="${COMMON_DEPEND}

--- a/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-9999.ebuild
+++ b/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 ECM_TEST="forceoptional"
 KFMIN=9999
-PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
 inherit ecm plasma.kde.org
 
@@ -42,8 +41,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kwindowsystem-${KFMIN}:6
-	>=kde-plasma/kwayland-${PVCUT}:6
-	>=kde-plasma/plasma-workspace-${PVCUT}:6
+	>=kde-plasma/kwayland-${KDE_CATV}:6
+	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	x11-libs/libxkbcommon
 "
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
Currently an idea, open to suggestions.

Since meta variables are unlikely to get any less I thought it would make sense to try and reduce where sensical.