### PR TITLE
Mass update ebuilds for ecm eclass noops after KFMIN-6.9

### DIFF
--- a/app-accessibility/kontrast/kontrast-9999.ebuild
+++ b/app-accessibility/kontrast/kontrast-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Tool to check contrast for colors to verify they are correctly accessible"
 HOMEPAGE="https://apps.kde.org/kontrast/"

--- a/app-cdr/isoimagewriter/isoimagewriter-9999.ebuild
+++ b/app-cdr/isoimagewriter/isoimagewriter-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Write hybrid ISO files onto a USB disk"
 HOMEPAGE="https://community.kde.org/ISOImageWriter"

--- a/app-crypt/keysmith/keysmith-9999.ebuild
+++ b/app-crypt/keysmith/keysmith-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KDE_ORG_CATEGORY="utilities"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="OTP client for Plasma Mobile and Desktop"
 HOMEPAGE="https://apps.kde.org/keysmith/"

--- a/app-editors/ghostwriter/ghostwriter-9999.ebuild
+++ b/app-editors/ghostwriter/ghostwriter-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KDE_ORG_CATEGORY="office"
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Cross-platform, aesthetic, distraction-free markdown editor"
 HOMEPAGE="https://ghostwriter.kde.org/"

--- a/app-misc/francis/francis-9999.ebuild
+++ b/app-misc/francis/francis-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2024 Gentoo Authors
+# Copyright 2024-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 KDE_ORG_CATEGORY="utilities"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Productivity application using the well-known pomodoro technique"
 HOMEPAGE="https://apps.kde.org/francis/"

--- a/app-office/merkuro/merkuro-9999.ebuild
+++ b/app-office/merkuro/merkuro-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Calendar application using Akonadi"
 HOMEPAGE="https://apps.kde.org/merkuro.calendar/"

--- a/app-text/arianna/arianna-9999.ebuild
+++ b/app-text/arianna/arianna-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_ORG_CATEGORY="graphics"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="EPub Reader for mobile devices"
 HOMEPAGE="https://apps.kde.org/arianna/"

--- a/dev-libs/kopeninghours/kopeninghours-9999.ebuild
+++ b/dev-libs/kopeninghours/kopeninghours-9999.ebuild
@@ -42,11 +42,6 @@ BDEPEND="
 	app-alternatives/yacc
 "
 
-pkg_setup() {
-	ecm_pkg_setup
-	python_setup
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DPython_LIBRARY=$(python_get_library_path)

--- a/dev-libs/kopeninghours/kopeninghours-9999.ebuild
+++ b/dev-libs/kopeninghours/kopeninghours-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,8 +42,6 @@ BDEPEND="
 	app-alternatives/yacc
 "
 
-PATCHES=( "${FILESDIR}"/${PN}-22.04.0-boostpython.patch )
-
 pkg_setup() {
 	ecm_pkg_setup
 	python_setup
@@ -51,7 +49,8 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBOOSTPYTHON_VERSION_MAJOR_MINOR=${EPYTHON}
+		-DPython_LIBRARY=$(python_get_library_path)
+		-DPython_INCLUDE_DIR=$(python_get_includedir)
 		$(cmake_use_find_package python Boost)
 	)
 	ecm_src_configure

--- a/dev-util/kdevelop-python/kdevelop-python-9999.ebuild
+++ b/dev-util/kdevelop-python/kdevelop-python-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -41,8 +41,3 @@ RDEPEND="${DEPEND}
 		dev-python/pycodestyle[${PYTHON_USEDEP}]
 	')
 "
-
-pkg_setup() {
-	python-single-r1_pkg_setup
-	ecm_pkg_setup
-}

--- a/dev-util/kdevelop/kdevelop-9999.ebuild
+++ b/dev-util/kdevelop/kdevelop-9999.ebuild
@@ -88,11 +88,6 @@ RDEPEND="${COMMON_DEPEND}
 	kde-apps/kio-extras:6
 "
 
-pkg_setup() {
-	ecm_pkg_setup
-	llvm-r1_pkg_setup
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DLLVM_ROOT="$(get_llvm_prefix)"

--- a/dev-util/kdevelop/kdevelop-9999.ebuild
+++ b/dev-util/kdevelop/kdevelop-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ KDE_ORG_CATEGORY="kdevelop"
 KFMIN=6.9.0
 LLVM_COMPAT=( 15 16 17 18 )
 QTMIN=6.7.2
-inherit ecm gear.kde.org llvm-r1 optfeature
+inherit ecm gear.kde.org llvm-r1 optfeature xdg
 
 DESCRIPTION="Integrated Development Environment, supporting KF6/Qt, C/C++ and much more"
 HOMEPAGE="https://kdevelop.org/"
@@ -118,5 +118,5 @@ pkg_postinst() {
 		optfeature "formatting configurations via customscript plugin" dev-util/indent
 		optfeature "formatting configurations via customscript plugin" dev-util/uncrustify
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/dev-util/massif-visualizer/massif-visualizer-9999.ebuild
+++ b/dev-util/massif-visualizer/massif-visualizer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Tool visualising massif data"
 HOMEPAGE="https://apps.kde.org/massif_visualizer/"

--- a/games-puzzle/skladnik/skladnik-9999.ebuild
+++ b/games-puzzle/skladnik/skladnik-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="The Japanese warehouse keeper sokoban game"
 HOMEPAGE="https://apps.kde.org/skladnik/ https://invent.kde.org/games/skladnik"

--- a/kde-apps/akonadi-import-wizard/akonadi-import-wizard-9999.ebuild
+++ b/kde-apps/akonadi-import-wizard/akonadi-import-wizard-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Assistant to import PIM data from other applications into Akonadi"
 HOMEPAGE+=" https://userbase.kde.org/KMail/Import_Options"

--- a/kde-apps/akonadi-mime/akonadi-mime-9999.ebuild
+++ b/kde-apps/akonadi-mime/akonadi-mime-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Library for akonadi mime types"
 

--- a/kde-apps/akonadi/akonadi-9999.ebuild
+++ b/kde-apps/akonadi/akonadi-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
 VIRTUALDBUS_TEST="true"
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Storage service for PIM data and libraries for PIM apps"
 HOMEPAGE="https://community.kde.org/KDE_PIM/akonadi"

--- a/kde-apps/akonadiconsole/akonadiconsole-9999.ebuild
+++ b/kde-apps/akonadiconsole/akonadiconsole-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional" # FIXME: Check back for doc in release
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Application for debugging Akonadi Resources"
 HOMEPAGE="https://techbase.kde.org/KDE_PIM/Akonadi/Development_Tools"

--- a/kde-apps/akregator/akregator-9999.ebuild
+++ b/kde-apps/akregator/akregator-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="News feed aggregator"
 HOMEPAGE="https://apps.kde.org/akregator/"

--- a/kde-apps/ark/ark-9999.ebuild
+++ b/kde-apps/ark/ark-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="File archiver by KDE"
 HOMEPAGE="https://apps.kde.org/ark/"
@@ -76,5 +76,5 @@ pkg_postinst() {
 		optfeature "lrz archive support" "app-arch/lrzip"
 		optfeature "Markdown support in text previews" "kde-misc/markdownpart:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/blinken/blinken-9999.ebuild
+++ b/kde-apps/blinken/blinken-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Memory enhancement game based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/blinken/"

--- a/kde-apps/bomber/bomber-9999.ebuild
+++ b/kde-apps/bomber/bomber-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Single player arcade bombing game"
 HOMEPAGE="https://apps.kde.org/bomber/"

--- a/kde-apps/bovo/bovo-9999.ebuild
+++ b/kde-apps/bovo/bovo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Five-in-a-row Board Game"
 HOMEPAGE="https://apps.kde.org/bovo/"

--- a/kde-apps/cantor/cantor-9999.ebuild
+++ b/kde-apps/cantor/cantor-9999.ebuild
@@ -79,7 +79,6 @@ BDEPEND="x11-misc/shared-mime-info"
 pkg_setup() {
 	use lua && lua-single_pkg_setup
 	use python && python-single-r1_pkg_setup
-	ecm_pkg_setup
 }
 
 src_configure() {

--- a/kde-apps/cantor/cantor-9999.ebuild
+++ b/kde-apps/cantor/cantor-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ PYTHON_COMPAT=( python3_{10..12} )
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org lua-single optfeature python-single-r1
+inherit ecm gear.kde.org lua-single optfeature python-single-r1 xdg
 
 DESCRIPTION="Interface for doing mathematics and scientific computing"
 HOMEPAGE="https://apps.kde.org/cantor/"
@@ -113,5 +113,5 @@ pkg_postinst() {
 		optfeature "Octave backend" sci-mathematics/octave
 		optfeature "LaTeX support" virtual/latex-base
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/dolphin/dolphin-9999.ebuild
+++ b/kde-apps/dolphin/dolphin-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Plasma filemanager focusing on usability"
 HOMEPAGE="https://apps.kde.org/dolphin/ https://userbase.kde.org/Dolphin"
@@ -87,5 +87,5 @@ pkg_postinst() {
 		optfeature "crypto actions" "kde-apps/kleopatra:${SLOT}"
 		optfeature "'Share' context menu actions" "kde-frameworks/purpose:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/dragon/dragon-9999.ebuild
+++ b/kde-apps/dragon/dragon-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Simple video player"
 HOMEPAGE="https://apps.kde.org/dragonplayer/"

--- a/kde-apps/filelight/filelight-9999.ebuild
+++ b/kde-apps/filelight/filelight-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Visualise disk usage with interactive map of concentric, segmented rings"
 HOMEPAGE="https://apps.kde.org/filelight/"

--- a/kde-apps/granatier/granatier-9999.ebuild
+++ b/kde-apps/granatier/granatier-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Bomberman game"
 HOMEPAGE="https://apps.kde.org/granatier/"

--- a/kde-apps/gwenview/gwenview-9999.ebuild
+++ b/kde-apps/gwenview/gwenview-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Image viewer by KDE"
 HOMEPAGE="https://apps.kde.org/gwenview/ https://userbase.kde.org/Gwenview"
@@ -106,5 +106,5 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "SVG support" "kde-apps/svgpart:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/juk/juk-9999.ebuild
+++ b/kde-apps/juk/juk-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Jukebox and music manager by KDE"
 HOMEPAGE="https://apps.kde.org/juk/"

--- a/kde-apps/k3b/k3b-9999.ebuild
+++ b/kde-apps/k3b/k3b-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm flag-o-matic gear.kde.org
+inherit ecm flag-o-matic gear.kde.org xdg
 
 DESCRIPTION="Full-featured burning and ripping application based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/k3b/ https://userbase.kde.org/K3b"
@@ -98,7 +98,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 
 	elog "If you get warnings on start-up, uncheck the \"Check system"
 	elog "configuration\" option in the \"Misc\" settings window."

--- a/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE accounts providers"
 HOMEPAGE="https://community.kde.org/KTp"

--- a/kde-apps/kaddressbook/kaddressbook-9999.ebuild
+++ b/kde-apps/kaddressbook/kaddressbook-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Address book application based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/kaddressbook/"
@@ -66,5 +66,5 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "Postal addresses" "kde-apps/kdepim-addons:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/kajongg/kajongg-9999.ebuild
+++ b/kde-apps/kajongg/kajongg-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{10..12} )
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit python-single-r1 ecm gear.kde.org
+inherit python-single-r1 ecm gear.kde.org xdg
 
 DESCRIPTION="Classical Mah Jongg for four players"
 HOMEPAGE="https://apps.kde.org/kajongg/"

--- a/kde-apps/kajongg/kajongg-9999.ebuild
+++ b/kde-apps/kajongg/kajongg-9999.ebuild
@@ -36,11 +36,6 @@ RDEPEND="${DEPEND}
 	>=kde-apps/libkmahjongg-${PVCUT}:6
 "
 
-pkg_setup() {
-	python-single-r1_pkg_setup
-	ecm_pkg_setup
-}
-
 src_prepare() {
 	python_fix_shebang src
 	ecm_src_prepare

--- a/kde-apps/kalarm/kalarm-9999.ebuild
+++ b/kde-apps/kalarm/kalarm-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Application to manage alarms and other timer based alerts for the desktop"
 HOMEPAGE="https://apps.kde.org/kalarm/ https://userbase.kde.org/KAlarm"

--- a/kde-apps/kalgebra/kalgebra-9999.ebuild
+++ b/kde-apps/kalgebra/kalgebra-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm flag-o-matic gear.kde.org
+inherit ecm flag-o-matic gear.kde.org xdg
 
 DESCRIPTION="MathML-based 2D and 3D graph calculator by KDE"
 HOMEPAGE="https://apps.kde.org/kalgebra/"

--- a/kde-apps/kalzium/kalzium-9999.ebuild
+++ b/kde-apps/kalzium/kalzium-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org flag-o-matic
+inherit ecm gear.kde.org flag-o-matic xdg
 
 DESCRIPTION="Periodic table of the elements"
 HOMEPAGE="https://apps.kde.org/kalzium/"

--- a/kde-apps/kanagram/kanagram-9999.ebuild
+++ b/kde-apps/kanagram/kanagram-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Game based on anagrams of words"
 HOMEPAGE="https://apps.kde.org/kanagram/"

--- a/kde-apps/kapman/kapman-9999.ebuild
+++ b/kde-apps/kapman/kapman-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Pac-Man clone by KDE"
 HOMEPAGE="https://apps.kde.org/kapman/"

--- a/kde-apps/kapptemplate/kapptemplate-9999.ebuild
+++ b/kde-apps/kapptemplate/kapptemplate-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Shell script to create the necessary framework to develop KDE applications"
 HOMEPAGE="https://apps.kde.org/kapptemplate/"

--- a/kde-apps/kate-addons/kate-addons-9999.ebuild
+++ b/kde-apps/kate-addons/kate-addons-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -96,5 +96,4 @@ pkg_postinst() {
 		optfeature "Markdown text previews" "kde-misc/markdownpart:${SLOT}"
 		optfeature "DOT graph file previews" "media-gfx/kgraphviewer"
 	fi
-	ecm_pkg_postinst
 }

--- a/kde-apps/kate/kate-9999.ebuild
+++ b/kde-apps/kate/kate-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoff"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm flag-o-matic gear.kde.org
+inherit ecm flag-o-matic gear.kde.org xdg
 
 DESCRIPTION="Multi-document editor with network transparency, Plasma integration and more"
 HOMEPAGE="https://kate-editor.org/ https://apps.kde.org/kate/"

--- a/kde-apps/katomic/katomic-9999.ebuild
+++ b/kde-apps/katomic/katomic-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Atomic Entertainment Game"
 HOMEPAGE="https://apps.kde.org/katomic/"

--- a/kde-apps/kbackup/kbackup-9999.ebuild
+++ b/kde-apps/kbackup/kbackup-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Program that lets you back up any directories or files"
 HOMEPAGE="https://apps.kde.org/kbackup/"

--- a/kde-apps/kblackbox/kblackbox-9999.ebuild
+++ b/kde-apps/kblackbox/kblackbox-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Game of hide and seek played on a grid of boxes"
 HOMEPAGE="https://apps.kde.org/kblackbox/"

--- a/kde-apps/kblocks/kblocks-9999.ebuild
+++ b/kde-apps/kblocks/kblocks-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Single-player Tetris-like KDE game"
 HOMEPAGE="https://apps.kde.org/kblocks/"

--- a/kde-apps/kbounce/kbounce-9999.ebuild
+++ b/kde-apps/kbounce/kbounce-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Bounce Ball Game"
 HOMEPAGE="https://apps.kde.org/kbounce/"

--- a/kde-apps/kbreakout/kbreakout-9999.ebuild
+++ b/kde-apps/kbreakout/kbreakout-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Breakout-like game by KDE"
 HOMEPAGE="https://apps.kde.org/kbreakout/"

--- a/kde-apps/kbruch/kbruch-9999.ebuild
+++ b/kde-apps/kbruch/kbruch-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Educational application to learn calculating with fractions"
 HOMEPAGE="https://apps.kde.org/kbruch/"

--- a/kde-apps/kcachegrind/kcachegrind-9999.ebuild
+++ b/kde-apps/kcachegrind/kcachegrind-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Frontend for Cachegrind by KDE"
 HOMEPAGE="https://apps.kde.org/kcachegrind/

--- a/kde-apps/kcolorchooser/kcolorchooser-9999.ebuild
+++ b/kde-apps/kcolorchooser/kcolorchooser-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE color selector/editor"
 HOMEPAGE="https://apps.kde.org/kcolorchooser/"

--- a/kde-apps/kde-dev-utils/kde-dev-utils-9999.ebuild
+++ b/kde-apps/kde-dev-utils/kde-dev-utils-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Development Utilities"
 

--- a/kde-apps/kdeedu-data/kdeedu-data-9999.ebuild
+++ b/kde-apps/kdeedu-data/kdeedu-data-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake gear.kde.org
+inherit cmake gear.kde.org xdg
 
 DESCRIPTION="Shared icons, artwork and data files for educational applications"
 

--- a/kde-apps/kdenlive/kdenlive-9999.ebuild
+++ b/kde-apps/kdenlive/kdenlive-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ ECM_QTHELP="true"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Non-linear video editing suite by KDE"
 HOMEPAGE="https://kdenlive.org/en/"
@@ -71,6 +71,6 @@ src_configure() {
 }
 
 pkg_postinst() {
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 	optfeature "VP8 and VP9 codec support" "media-video/ffmpeg[vpx]"
 }

--- a/kde-apps/kdepim-addons/kdepim-addons-9999.ebuild
+++ b/kde-apps/kdepim-addons/kdepim-addons-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -83,5 +83,4 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "regex support for Sieve editor plugin" kde-misc/kregexpeditor
 	fi
-	ecm_pkg_postinst
 }

--- a/kde-apps/kdepim-runtime/kdepim-runtime-9999.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Runtime plugin collection to extend the functionality of KDE PIM"
 HOMEPAGE="https://apps.kde.org/kontact/"

--- a/kde-apps/kdf/kdf-9999.ebuild
+++ b/kde-apps/kdf/kdf-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE free disk space utility"
 HOMEPAGE="https://apps.kde.org/kdf/"

--- a/kde-apps/kdiamond/kdiamond-9999.ebuild
+++ b/kde-apps/kdiamond/kdiamond-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Single player three-in-a-row game"
 HOMEPAGE="https://apps.kde.org/kdiamond/"

--- a/kde-apps/kfind/kfind-9999.ebuild
+++ b/kde-apps/kfind/kfind-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="File finder utility based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/kfind/"

--- a/kde-apps/kfourinline/kfourinline-9999.ebuild
+++ b/kde-apps/kfourinline/kfourinline-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE four-in-a-row game"
 HOMEPAGE="https://apps.kde.org/kfourinline/"

--- a/kde-apps/kgeography/kgeography-9999.ebuild
+++ b/kde-apps/kgeography/kgeography-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Geography learning tool"
 HOMEPAGE="https://apps.kde.org/kgeography/"

--- a/kde-apps/kget/kget-9999.ebuild
+++ b/kde-apps/kget/kget-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Advanced download manager by KDE"
 HOMEPAGE="https://apps.kde.org/kget/"

--- a/kde-apps/kgoldrunner/kgoldrunner-9999.ebuild
+++ b/kde-apps/kgoldrunner/kgoldrunner-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Game of action and puzzle solving by KDE"
 HOMEPAGE="https://apps.kde.org/kgoldrunner/"

--- a/kde-apps/kgpg/kgpg-9999.ebuild
+++ b/kde-apps/kgpg/kgpg-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="gpg"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Frontend for GnuPG, a powerful encryption utility by KDE"
 HOMEPAGE="https://apps.kde.org/kgpg/"

--- a/kde-apps/khangman/khangman-9999.ebuild
+++ b/kde-apps/khangman/khangman-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Classical hangman game by KDE"
 HOMEPAGE="https://apps.kde.org/khangman/"

--- a/kde-apps/khelpcenter/khelpcenter-9999.ebuild
+++ b/kde-apps/khelpcenter/khelpcenter-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Application to read documentation for KDE Plasma, Applications, Utilities"
 HOMEPAGE="https://apps.kde.org/khelpcenter/ https://userbase.kde.org/KHelpCenter"

--- a/kde-apps/kigo/kigo-9999.ebuild
+++ b/kde-apps/kigo/kigo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Go game by KDE"
 HOMEPAGE="https://apps.kde.org/kigo/"

--- a/kde-apps/killbots/killbots-9999.ebuild
+++ b/kde-apps/killbots/killbots-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Kill the bots or they kill you!"
 HOMEPAGE="https://apps.kde.org/killbots/"

--- a/kde-apps/kimagemapeditor/kimagemapeditor-9999.ebuild
+++ b/kde-apps/kimagemapeditor/kimagemapeditor-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Generator of HTML image maps"
 HOMEPAGE="https://apps.kde.org/kimagemapeditor/"

--- a/kde-apps/kio-extras/kio-extras-9999.ebuild
+++ b/kde-apps/kio-extras/kio-extras-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -102,5 +102,4 @@ src_configure() {
 
 pkg_postinst() {
 	optfeature "alternative filename search backend" sys-apps/ripgrep
-	ecm_pkg_postinst
 }

--- a/kde-apps/kiriki/kiriki-9999.ebuild
+++ b/kde-apps/kiriki/kiriki-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="An addictive and fun dice game"
 HOMEPAGE="https://apps.kde.org/kiriki/"

--- a/kde-apps/kiten/kiten-9999.ebuild
+++ b/kde-apps/kiten/kiten-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Japanese dictionary and reference"
 HOMEPAGE="https://apps.kde.org/kiten/"

--- a/kde-apps/kitinerary/kitinerary-9999.ebuild
+++ b/kde-apps/kitinerary/kitinerary-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Data Model and Extraction System for Travel Reservation information"
 HOMEPAGE="https://apps.kde.org/kontact/"

--- a/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
+++ b/kde-apps/kjumpingcube/kjumpingcube-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Tactical one or two player game"
 HOMEPAGE="https://apps.kde.org/kjumpingcube/"

--- a/kde-apps/kleopatra/kleopatra-9999.ebuild
+++ b/kde-apps/kleopatra/kleopatra-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Certificate manager and GUI for OpenPGP and CMS cryptography"
 HOMEPAGE="https://apps.kde.org/kleopatra/"

--- a/kde-apps/klettres/klettres-9999.ebuild
+++ b/kde-apps/klettres/klettres-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Alphabet learning application"
 HOMEPAGE="https://apps.kde.org/klettres/"

--- a/kde-apps/klickety/klickety-9999.ebuild
+++ b/kde-apps/klickety/klickety-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="An adaptation of the Clickomania game"
 HOMEPAGE="https://apps.kde.org/klickety/"

--- a/kde-apps/klines/klines-9999.ebuild
+++ b/kde-apps/klines/klines-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="A little KDE game about balls and how to get rid of them"
 HOMEPAGE="https://apps.kde.org/klines/"

--- a/kde-apps/kmag/kmag-9999.ebuild
+++ b/kde-apps/kmag/kmag-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE screen magnifier"
 HOMEPAGE="https://apps.kde.org/kmag/"

--- a/kde-apps/kmahjongg/kmahjongg-9999.ebuild
+++ b/kde-apps/kmahjongg/kmahjongg-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="A tile matching game for one or two players"
 HOMEPAGE="https://apps.kde.org/kmahjongg/"

--- a/kde-apps/kmail/kmail-9999.ebuild
+++ b/kde-apps/kmail/kmail-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Email client, supporting POP3 and IMAP mailboxes"
 HOMEPAGE="https://apps.kde.org/kmail2/
@@ -115,5 +115,5 @@ pkg_postinst() {
 		optfeature "crypto config and certificate details GUI" "kde-apps/kleopatra:${SLOT}"
 		optfeature "import PIM data from other applications" "kde-apps/akonadi-import-wizard:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/kmines/kmines-9999.ebuild
+++ b/kde-apps/kmines/kmines-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Classic mine sweeper game"
 HOMEPAGE="https://apps.kde.org/kmines/"

--- a/kde-apps/kmix/kmix-9999.ebuild
+++ b/kde-apps/kmix/kmix-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 ECM_TEST="false"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Volume control gui based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/kmix/"
@@ -66,5 +66,5 @@ pkg_postinst() {
 	fi
 	elog "KMix will be shown as [Volume Control] after manually starting it once"
 	elog "and will be autostarted after configuring such in KMix startup settings."
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/kmousetool/kmousetool-9999.ebuild
+++ b/kde-apps/kmousetool/kmousetool-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE program that clicks the mouse for you"
 HOMEPAGE="https://apps.kde.org/kmousetool/"

--- a/kde-apps/kmouth/kmouth-9999.ebuild
+++ b/kde-apps/kmouth/kmouth-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Text-to-speech synthesizer front end"
 HOMEPAGE="https://apps.kde.org/kmouth/"

--- a/kde-apps/kmplot/kmplot-9999.ebuild
+++ b/kde-apps/kmplot/kmplot-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Mathematical function plotter"
 HOMEPAGE="https://apps.kde.org/kmplot/"

--- a/kde-apps/knavalbattle/knavalbattle-9999.ebuild
+++ b/kde-apps/knavalbattle/knavalbattle-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Battleship clone by KDE"
 HOMEPAGE="https://apps.kde.org/knavalbattle/"

--- a/kde-apps/knetwalk/knetwalk-9999.ebuild
+++ b/kde-apps/knetwalk/knetwalk-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE version of the popular NetWalk game for system administrators"
 HOMEPAGE="https://apps.kde.org/knetwalk/"

--- a/kde-apps/knights/knights-9999.ebuild
+++ b/kde-apps/knights/knights-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Simple chess board based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/knights/"

--- a/kde-apps/kolf/kolf-9999.ebuild
+++ b/kde-apps/kolf/kolf-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Minigolf game by KDE"
 HOMEPAGE="https://apps.kde.org/kolf/"

--- a/kde-apps/kollision/kollision-9999.ebuild
+++ b/kde-apps/kollision/kollision-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Simple ball dodging game"
 HOMEPAGE="https://apps.kde.org/kollision/"

--- a/kde-apps/kolourpaint/kolourpaint-9999.ebuild
+++ b/kde-apps/kolourpaint/kolourpaint-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Paint Program by KDE"
 HOMEPAGE="https://apps.kde.org/kolourpaint/"

--- a/kde-apps/kompare/kompare-9999.ebuild
+++ b/kde-apps/kompare/kompare-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Graphical File Differences Tool"
 HOMEPAGE="https://apps.kde.org/kompare/"

--- a/kde-apps/konqueror/konqueror-9999.ebuild
+++ b/kde-apps/konqueror/konqueror-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit flag-o-matic ecm gear.kde.org optfeature
+inherit flag-o-matic ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Web browser and file manager based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/konqueror/"
@@ -81,5 +81,5 @@ pkg_postinst() {
 		optfeature "filemanager component" "kde-apps/dolphin:${SLOT}"
 		optfeature "SVG support" "kde-apps/svg:${SLOT}"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/konquest/konquest-9999.ebuild
+++ b/kde-apps/konquest/konquest-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Galactic Strategy KDE Game"
 HOMEPAGE="https://apps.kde.org/konquest/"

--- a/kde-apps/konsolekalendar/konsolekalendar-9999.ebuild
+++ b/kde-apps/konsolekalendar/konsolekalendar-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoff"
 KDE_ORG_NAME="akonadi-calendar-tools"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Command line interface to KDE calendars"
 HOMEPAGE+=" https://userbase.kde.org/KonsoleKalendar"

--- a/kde-apps/kontact/kontact-9999.ebuild
+++ b/kde-apps/kontact/kontact-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Container application to unify several major PIM applications within one"
 HOMEPAGE="https://kontact.kde.org/ https://apps.kde.org/kontact/"

--- a/kde-apps/korganizer/korganizer-9999.ebuild
+++ b/kde-apps/korganizer/korganizer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Organizational assistant, providing calendars and other similar functionality"
 HOMEPAGE="https://apps.kde.org/korganizer/"

--- a/kde-apps/kpat/kpat-9999.ebuild
+++ b/kde-apps/kpat/kpat-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE patience game"
 HOMEPAGE="https://apps.kde.org/kpat/"

--- a/kde-apps/krdc/krdc-9999.ebuild
+++ b/kde-apps/krdc/krdc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Remote desktop connection (RDP and VNC) client"
 HOMEPAGE="https://apps.kde.org/krdc/"

--- a/kde-apps/kreversi/kreversi-9999.ebuild
+++ b/kde-apps/kreversi/kreversi-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Board game by KDE"
 HOMEPAGE="https://apps.kde.org/kreversi/"

--- a/kde-apps/krfb/krfb-9999.ebuild
+++ b/kde-apps/krfb/krfb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="VNC-compatible server to share Plasma desktops"
 HOMEPAGE="https://apps.kde.org/krfb/"

--- a/kde-apps/kruler/kruler-9999.ebuild
+++ b/kde-apps/kruler/kruler-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Screen ruler for Plasma"
 HOMEPAGE="https://apps.kde.org/kruler/"

--- a/kde-apps/kshisen/kshisen-9999.ebuild
+++ b/kde-apps/kshisen/kshisen-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Solitaire-like game played using the standard set of Mahjong tiles"
 HOMEPAGE="https://apps.kde.org/kshisen/"

--- a/kde-apps/ksirk/ksirk-9999.ebuild
+++ b/kde-apps/ksirk/ksirk-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Port of the board game Risk"
 HOMEPAGE="https://apps.kde.org/ksirk/"

--- a/kde-apps/ksnakeduel/ksnakeduel-9999.ebuild
+++ b/kde-apps/ksnakeduel/ksnakeduel-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE Tron game"
 HOMEPAGE="https://apps.kde.org/ksnakeduel/"

--- a/kde-apps/kspaceduel/kspaceduel-9999.ebuild
+++ b/kde-apps/kspaceduel/kspaceduel-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Space Game by KDE"
 HOMEPAGE="https://apps.kde.org/kspaceduel/"

--- a/kde-apps/ksquares/ksquares-9999.ebuild
+++ b/kde-apps/ksquares/ksquares-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE clone of the game squares"
 HOMEPAGE="https://apps.kde.org/ksquares/"

--- a/kde-apps/ksudoku/ksudoku-9999.ebuild
+++ b/kde-apps/ksudoku/ksudoku-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Logic-based symbol placement puzzle by KDE"
 HOMEPAGE="https://apps.kde.org/ksudoku/"

--- a/kde-apps/ksystemlog/ksystemlog-9999.ebuild
+++ b/kde-apps/ksystemlog/ksystemlog-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -56,7 +56,6 @@ src_configure() {
 }
 
 pkg_postinst() {
-	ecm_pkg_postinst
 	use kdesu || elog "Will show only user readable logs without USE=kdesu (only in X)."
 	use kdesu && elog "Cannot be launched from application menu in Wayland with USE=kdesu."
 }

--- a/kde-apps/kteatime/kteatime-9999.ebuild
+++ b/kde-apps/kteatime/kteatime-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="KDE timer for making a fine cup of tea"
 HOMEPAGE="https://apps.kde.org/kteatime/"

--- a/kde-apps/ktimer/ktimer-9999.ebuild
+++ b/kde-apps/ktimer/ktimer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Little tool to execute programs after some time"
 HOMEPAGE="https://apps.kde.org/ktimer/"

--- a/kde-apps/ktuberling/ktuberling-9999.ebuild
+++ b/kde-apps/ktuberling/ktuberling-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Potato game for kids by KDE"
 HOMEPAGE="https://apps.kde.org/ktuberling/"

--- a/kde-apps/kturtle/kturtle-9999.ebuild
+++ b/kde-apps/kturtle/kturtle-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Educational programming environment using the Logo programming language"
 HOMEPAGE="https://apps.kde.org/kturtle/"

--- a/kde-apps/kubrick/kubrick-9999.ebuild
+++ b/kde-apps/kubrick/kubrick-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Game based on the \"Rubik's Cube\" puzzle by KDE"
 HOMEPAGE="https://apps.kde.org/kubrick/"

--- a/kde-apps/kwalletmanager/kwalletmanager-9999.ebuild
+++ b/kde-apps/kwalletmanager/kwalletmanager-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Tool to manage the passwords on your system using KDE Wallet"
 HOMEPAGE="https://apps.kde.org/kwalletmanager5/"

--- a/kde-apps/kwave/kwave-9999.ebuild
+++ b/kde-apps/kwave/kwave-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Sound editor built on KDE Frameworks that can edit many types of audio files"
 HOMEPAGE="https://apps.kde.org/kwave/"

--- a/kde-apps/kwordquiz/kwordquiz-9999.ebuild
+++ b/kde-apps/kwordquiz/kwordquiz-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Powerful flashcard and vocabulary learning program"
 HOMEPAGE="https://apps.kde.org/kwordquiz/"

--- a/kde-apps/kwrite/kwrite-9999.ebuild
+++ b/kde-apps/kwrite/kwrite-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KDE_ORG_NAME="kate"
 ECM_HANDBOOK="forceoff"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm flag-o-matic gear.kde.org
+inherit ecm flag-o-matic gear.kde.org xdg
 
 DESCRIPTION="Simple text editor based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/kwrite/"

--- a/kde-apps/libksane-common/libksane-common-9999.ebuild
+++ b/kde-apps/libksane-common/libksane-common-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KDE_ORG_NAME="${PN/-common/}"
 KFMIN=6.9.0
-inherit ecm-common gear.kde.org
+inherit ecm-common gear.kde.org xdg
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/kde-apps/libksane/libksane-9999.ebuild
+++ b/kde-apps/libksane/libksane-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 KFMIN=6.9.0
 PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="SANE Library interface based on KDE Frameworks"
 

--- a/kde-apps/lokalize/lokalize-9999.ebuild
+++ b/kde-apps/lokalize/lokalize-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PYTHON_COMPAT=( python3_{10..12} )
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit python-single-r1 ecm gear.kde.org optfeature
+inherit python-single-r1 ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Localization tool for KDE software and other free and open source software"
 HOMEPAGE="https://apps.kde.org/lokalize/ https://l10n.kde.org/tools/"
@@ -62,5 +62,5 @@ pkg_postinst() {
 		optfeature "autofetch kde.org translations in new project wizard" dev-vcs/subversion
 		optfeature "spell and grammar checking" app-text/languagetool
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/lokalize/lokalize-9999.ebuild
+++ b/kde-apps/lokalize/lokalize-9999.ebuild
@@ -46,11 +46,6 @@ RDEPEND="${DEPEND}
 	')
 "
 
-pkg_setup() {
-	python-single-r1_pkg_setup
-	ecm_pkg_setup
-}
-
 src_install() {
 	ecm_src_install
 	rm "${ED}"/usr/share/lokalize/scripts/msgmerge.{py,rc} || die

--- a/kde-apps/lskat/lskat-9999.ebuild
+++ b/kde-apps/lskat/lskat-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_SELINUX_MODULE="games"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Skat game by KDE"
 HOMEPAGE="https://apps.kde.org/lskat/"

--- a/kde-apps/marble/marble-9999.ebuild
+++ b/kde-apps/marble/marble-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional" # see src/apps/marble-kde/CMakeLists.txt
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Virtual Globe and World Atlas to learn more about Earth"
 HOMEPAGE="https://marble.kde.org/"

--- a/kde-apps/mbox-importer/mbox-importer-9999.ebuild
+++ b/kde-apps/mbox-importer/mbox-importer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional" # FIXME: Check back for doc in release
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Import mbox email archives from various sources into Akonadi"
 

--- a/kde-apps/minuet/minuet-9999.ebuild
+++ b/kde-apps/minuet/minuet-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Music Education software by KDE"
 HOMEPAGE="https://minuet.kde.org/"

--- a/kde-apps/okular/okular-9999.ebuild
+++ b/kde-apps/okular/okular-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Universal document viewer based on KDE Frameworks"
 HOMEPAGE="https://okular.kde.org https://apps.kde.org/okular/"

--- a/kde-apps/palapeli/palapeli-9999.ebuild
+++ b/kde-apps/palapeli/palapeli-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Jigsaw puzzle game by KDE"
 HOMEPAGE="https://apps.kde.org/palapeli/"

--- a/kde-apps/parley/parley-9999.ebuild
+++ b/kde-apps/parley/parley-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_HANDBOOK_DIR="docs"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Vocabulary trainer to help you memorize things"
 HOMEPAGE="https://apps.kde.org/parley/"
@@ -61,5 +61,5 @@ src_configure() {
 
 pkg_postinst() {
 	optfeature "online access to translations" app-i18n/translate-shell
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-apps/picmi/picmi-9999.ebuild
+++ b/kde-apps/picmi/picmi-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Nonogram logic game by KDE"
 HOMEPAGE="https://apps.kde.org/picmi/"

--- a/kde-apps/pim-sieve-editor/pim-sieve-editor-9999.ebuild
+++ b/kde-apps/pim-sieve-editor/pim-sieve-editor-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Assistant for editing IMAP Sieve filters"
 

--- a/kde-apps/spectacle/spectacle-9999.ebuild
+++ b/kde-apps/spectacle/spectacle-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="forceoptional"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Screenshot capture utility"
 HOMEPAGE="https://apps.kde.org/spectacle/"

--- a/kde-apps/step/step-9999.ebuild
+++ b/kde-apps/step/step-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Interactive physics simulator"
 HOMEPAGE="https://apps.kde.org/step/"

--- a/kde-apps/sweeper/sweeper-9999.ebuild
+++ b/kde-apps/sweeper/sweeper-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Privacy settings widget to clean unwanted traces on the system"
 HOMEPAGE="https://apps.kde.org/sweeper/"

--- a/kde-apps/yakuake/yakuake-9999.ebuild
+++ b/kde-apps/yakuake/yakuake-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Quake-style terminal emulator based on konsole"
 HOMEPAGE="https://apps.kde.org/yakuake/"

--- a/kde-misc/colord-kde/colord-kde-9999.ebuild
+++ b/kde-misc/colord-kde/colord-kde-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 KDE_ORG_CATEGORY=graphics
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Provides interfaces and session daemon to colord"
 HOMEPAGE="https://invent.kde.org/graphics/colord-kde"
@@ -50,7 +50,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 	if ! has_version "gnome-extra/gnome-color-manager"; then
 		elog "You may want to install gnome-extra/gnome-color-manager to add support for"
 		elog "colorhug calibration devices."

--- a/kde-misc/itinerary/itinerary-9999.ebuild
+++ b/kde-misc/itinerary/itinerary-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_ORG_CATEGORY="pim"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org optfeature
+inherit ecm gear.kde.org optfeature xdg
 
 DESCRIPTION="Digital travel assistant with a priority on protecting your privacy"
 HOMEPAGE="https://apps.kde.org/itinerary/
@@ -64,5 +64,5 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "screen brightness control to aid barcode scanning" "kde-frameworks/solid:6"
 	fi
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 }

--- a/kde-misc/kclock/kclock-9999.ebuild
+++ b/kde-misc/kclock/kclock-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 KDE_ORG_CATEGORY="utilities"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Convergent clock application for Plasma"
 HOMEPAGE="https://apps.kde.org/kclock/"

--- a/kde-misc/kdeconnect/kdeconnect-9999.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ KDE_ORG_NAME="${PN}-kde"
 KDE_SELINUX_MODULE="${PN}"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm flag-o-matic gear.kde.org
+inherit ecm flag-o-matic gear.kde.org xdg
 
 DESCRIPTION="Adds communication between KDE Plasma and your smartphone"
 HOMEPAGE="https://kdeconnect.kde.org/ https://apps.kde.org/kdeconnect/"
@@ -99,7 +99,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	ecm_pkg_postinst
+	xdg_pkg_postinst
 
 	elog "The Android .apk file is available via"
 	elog "https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"

--- a/kde-misc/kweather/kweather-9999.ebuild
+++ b/kde-misc/kweather/kweather-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KDE_ORG_CATEGORY="utilities"
 ECM_TEST="false"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Weather forecast application for Plasma with flat and dynamic/animated views"
 HOMEPAGE="https://apps.kde.org/kweather/"

--- a/kde-misc/skanlite/skanlite-9999.ebuild
+++ b/kde-misc/skanlite/skanlite-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ KDE_ORG_CATEGORY="graphics"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Simple image scanning application based on libksane and KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/skanlite/"

--- a/kde-misc/zanshin/zanshin-9999.ebuild
+++ b/kde-misc/zanshin/zanshin-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ KDE_ORG_CATEGORY="pim"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Getting things done application by KDE"
 HOMEPAGE="https://zanshin.kde.org/ https://apps.kde.org/zanshin/

--- a/kde-plasma/breeze/breeze-9999.ebuild
+++ b/kde-plasma/breeze/breeze-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KF5MIN=5.115.0
 KFMIN=9999
 QT5MIN=5.15.12
 QTMIN=6.8.1
-inherit ecm plasma.kde.org
+inherit ecm plasma.kde.org xdg
 
 DESCRIPTION="Breeze visual style for the Plasma desktop"
 HOMEPAGE="https://invent.kde.org/plasma/breeze"

--- a/media-gfx/kgraphviewer/kgraphviewer-9999.ebuild
+++ b/media-gfx/kgraphviewer/kgraphviewer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Graphviz dot graph file viewer"
 HOMEPAGE="https://apps.kde.org/kgraphviewer/"

--- a/media-gfx/skanpage/skanpage-9999.ebuild
+++ b/media-gfx/skanpage/skanpage-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ KDE_ORG_CATEGORY="utilities"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Multi-page scanning application supporting image and pdf files"
 HOMEPAGE="https://apps.kde.org/skanpage/"

--- a/media-sound/audex/audex-9999.ebuild
+++ b/media-sound/audex/audex-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Tool for ripping compact discs"
 HOMEPAGE="https://apps.kde.org/audex/ https://userbase.kde.org/Audex"

--- a/media-sound/elisa/elisa-9999.ebuild
+++ b/media-sound/elisa/elisa-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Simple music player by KDE"
 HOMEPAGE="https://apps.kde.org/elisa/"

--- a/media-sound/kasts/kasts-9999.ebuild
+++ b/media-sound/kasts/kasts-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Convergent podcast application for desktop and mobile"
 HOMEPAGE="https://apps.kde.org/kasts/"

--- a/media-sound/krecorder/krecorder-9999.ebuild
+++ b/media-sound/krecorder/krecorder-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 KDE_ORG_CATEGORY="utilities"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Convergent audio recording application for Plasma"
 HOMEPAGE="https://apps.kde.org/krecorder/"

--- a/media-video/plasmatube/plasmatube-9999.ebuild
+++ b/media-video/plasmatube/plasmatube-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="YouTube video player based on mpv, yt-dlp, and Invidious"
 HOMEPAGE="https://apps.kde.org/plasmatube/"

--- a/net-im/neochat/neochat-9999.ebuild
+++ b/net-im/neochat/neochat-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Client for Matrix, the decentralized communication protocol"
 HOMEPAGE="https://apps.kde.org/neochat/"

--- a/net-im/tokodon/tokodon-9999.ebuild
+++ b/net-im/tokodon/tokodon-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Mastodon client for Plasma and Plasma Mobile"
 HOMEPAGE="https://apps.kde.org/tokodon/"

--- a/net-irc/konversation/konversation-9999.ebuild
+++ b/net-irc/konversation/konversation-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_HANDBOOK="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="User friendly IRC Client"
 HOMEPAGE="https://konversation.kde.org https://apps.kde.org/konversation/"

--- a/net-news/alligator/alligator-9999.ebuild
+++ b/net-news/alligator/alligator-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_TEST="forceoptional"
 KFMIN=6.9.0
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Convergent RSS/Atom feed reader for Plasma"
 HOMEPAGE="https://apps.kde.org/alligator/"

--- a/net-p2p/ktorrent/ktorrent-9999.ebuild
+++ b/net-p2p/ktorrent/ktorrent-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_TEST="true"
 KFMIN=6.9.0
 PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Powerful BitTorrent client based on KDE Frameworks"
 HOMEPAGE="https://apps.kde.org/ktorrent/"

--- a/sys-block/partitionmanager/partitionmanager-9999.ebuild
+++ b/sys-block/partitionmanager/partitionmanager-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ ECM_HANDBOOK="optional"
 KFMIN=6.9.0
 PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.2
-inherit ecm gear.kde.org
+inherit ecm gear.kde.org xdg
 
 DESCRIPTION="Utility for management of disks, partitions and file systems"
 HOMEPAGE="https://apps.kde.org/partitionmanager/"

--- a/www-client/falkon/falkon-9999.ebuild
+++ b/www-client/falkon/falkon-9999.ebuild
@@ -62,7 +62,6 @@ BDEPEND=">=dev-qt/qttools-${QTMIN}:6[linguist]"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
-	ecm_pkg_setup
 }
 
 src_configure() {

--- a/www-client/falkon/falkon-9999.ebuild
+++ b/www-client/falkon/falkon-9999.ebuild
@@ -7,7 +7,7 @@ ECM_TEST="true"
 KFMIN=6.9.0
 QTMIN=6.7.2
 PYTHON_COMPAT=( python3_{10..12} )
-inherit ecm gear.kde.org python-single-r1
+inherit ecm gear.kde.org python-single-r1 xdg
 
 DESCRIPTION="Cross-platform web browser using QtWebEngine"
 HOMEPAGE="https://www.falkon.org/ https://apps.kde.org/falkon/"


### PR DESCRIPTION
Depends on https://github.com/gentoo/kde/pull/1015 as some changes are done on top of this.

Need for xdg was figured out in a dumb way where I just rebuilt everything with KFMIN=6.9 and seeing what generated QA messages about missing xdg calls.