### PR TITLE
media-gfx/skanpage: make ocr unconditinal

### DIFF
--- a/media-gfx/skanpage/skanpage-9999.ebuild
+++ b/media-gfx/skanpage/skanpage-9999.ebuild
@@ -15,9 +15,10 @@ HOMEPAGE="https://apps.kde.org/skanpage/"
 LICENSE="|| ( GPL-2 GPL-3 ) CC0-1.0"
 SLOT="6"
 KEYWORDS=""
-IUSE="ocr"
+IUSE=""
 
 DEPEND="
+	>=app-text/tesseract-5:=
 	>=dev-qt/qtbase-${QTMIN}:6[concurrent,gui,network,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtwebengine-${QTMIN}:6[pdfium]
@@ -33,17 +34,6 @@ DEPEND="
 	>=kde-frameworks/purpose-${KFMIN}:6
 	media-libs/kquickimageeditor:6
 	>=media-libs/ksanecore-${PVCUT}:6
-	ocr? (
-		>=app-text/tesseract-5:=
-		media-libs/leptonica:=
-	)
+	media-libs/leptonica:=
 "
 RDEPEND="${DEPEND}"
-
-src_configure() {
-	local mycmakeargs=(
-		$(cmake_use_find_package ocr Tesseract)
-		$(cmake_use_find_package ocr Leptonica)
-	)
-	ecm_src_configure
-}


### PR DESCRIPTION
Upstream has made it unconditional.

https://invent.kde.org/utilities/skanpage/-/commit/a11e0b8c2730800f010e7fda25ba6d7cd32f2028

https://invent.kde.org/utilities/skanpage/-/merge_requests/89
> It caused more harm than good IMHO due to packaging issues.