### PR TITLE
krdp and krdc freerdp3

### DIFF
--- a/kde-apps/krdc/krdc-9999.ebuild
+++ b/kde-apps/krdc/krdc-9999.ebuild
@@ -41,7 +41,7 @@ DEPEND="
 	activities? ( kde-plasma/plasma-activities:6 )
 	rdp? (
 		>=kde-frameworks/kio-${KFMIN}:6
-		>=net-misc/freerdp-2.1.0:2=
+		>=net-misc/freerdp-2.10:3
 	)
 	vnc? (
 		net-libs/libssh:=

--- a/kde-apps/krdc/metadata.xml
+++ b/kde-apps/krdc/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<remote-id type="kde-invent">network/krdc</remote-id>
 	</upstream>
 	<use>
 		<flag name="activities">Enable Plasma Activities support via <pkg>kde-plasma/plasma-activities</pkg></flag>

--- a/kde-plasma/krdp/krdp-9999.ebuild
+++ b/kde-plasma/krdp/krdp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -30,7 +30,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kstatusnotifieritem-${KFMIN}:6
 	>=kde-plasma/kpipewire-${KDE_CATV}:6
-	>=net-misc/freerdp-2.10:2[server]
+	>=net-misc/freerdp-3.1:3[server]
 	x11-libs/libxkbcommon
 "
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
Upstream krdc still supports freerdp:2 as well, but supporting this in the ebuild makes it harder for portage to resolve. `:*` or `|| ( :3 :2 )` would lead to portage resolving to the older freerdp:2 that is installed blocking updating krdp.