### PR TITLE
Leftovers from "Mass update ebuilds for ecm eclass noops"

### DIFF
--- a/kde-frameworks/kcoreaddons/kcoreaddons-9999.ebuild
+++ b/kde-frameworks/kcoreaddons/kcoreaddons-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 ECM_PYTHON_BINDINGS="off"
 QTMIN=6.7.2
-inherit ecm frameworks.kde.org xdg-utils
+inherit ecm frameworks.kde.org xdg
 
 DESCRIPTION="Framework for solving common problems such as caching, randomisation, and more"
 
@@ -47,14 +47,4 @@ src_test() {
 	)
 	# bug 619656
 	ecm_src_test -j1
-}
-
-pkg_postinst() {
-	ecm_pkg_postinst
-	xdg_mimeinfo_database_update
-}
-
-pkg_postrm() {
-	ecm_pkg_postrm
-	xdg_mimeinfo_database_update
 }

--- a/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -40,7 +40,6 @@ CMAKE_SKIP_TESTS=(
 
 pkg_setup() {
 	use test && python-any-r1_pkg_setup
-	ecm_pkg_setup
 }
 
 src_configure() {

--- a/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
+++ b/kde-frameworks/kfilemetadata/kfilemetadata-9999.ebuild
@@ -60,5 +60,4 @@ pkg_postinst() {
 		optfeature "Microsoft Word/Powerpoint file indexing" app-text/catdoc
 		optfeature "Microsoft Excel file indexing" dev-libs/libxls
 	fi
-	ecm_pkg_postinst
 }

--- a/kde-frameworks/ki18n/ki18n-9999.ebuild
+++ b/kde-frameworks/ki18n/ki18n-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,11 +35,6 @@ CMAKE_SKIP_TESTS=(
 	kcountrytest
 	kcountrysubdivisiontest
 )
-
-pkg_setup() {
-	ecm_pkg_setup
-	python-single-r1_pkg_setup
-}
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-frameworks/kio/kio-9999.ebuild
+++ b/kde-frameworks/kio/kio-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ ECM_HANDBOOK="optional"
 ECM_HANDBOOK_DIR="docs"
 ECM_TEST="forceoptional"
 QTMIN=6.7.2
-inherit ecm frameworks.kde.org xdg-utils
+inherit ecm frameworks.kde.org xdg
 
 DESCRIPTION="Framework providing transparent file and data management"
 
@@ -82,14 +82,4 @@ src_configure() {
 	)
 
 	ecm_src_configure
-}
-
-pkg_postinst() {
-	ecm_pkg_postinst
-	xdg_desktop_database_update
-}
-
-pkg_postrm() {
-	ecm_pkg_postrm
-	xdg_desktop_database_update
 }

--- a/kde-frameworks/kwallet/kwallet-9999.ebuild
+++ b/kde-frameworks/kwallet/kwallet-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -49,5 +49,4 @@ pkg_postinst() {
 		optfeature "KWallet management" "kde-apps/kwalletmanager"
 		elog "For more information, read https://wiki.gentoo.org/wiki/KDE#KWallet"
 	fi
-	ecm_pkg_postinst
 }

--- a/kde-frameworks/purpose/purpose-9999.ebuild
+++ b/kde-frameworks/purpose/purpose-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 ECM_QTHELP="false"
 ECM_TEST="forceoptional"
 QTMIN=6.7.2
-inherit ecm frameworks.kde.org optfeature xdg-utils
+inherit ecm frameworks.kde.org optfeature xdg
 
 DESCRIPTION="Library for providing abstractions to get the developer's purposes fulfilled"
 
@@ -70,10 +70,5 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "Send through KDE Connect" kde-misc/kdeconnect
 	fi
-	ecm_pkg_postinst
-	xdg_icon_cache_update
-}
-
-pkg_postrm() {
-	xdg_icon_cache_update
+	xdg_pkg_postinst
 }

--- a/kde-frameworks/solid/solid-9999.ebuild
+++ b/kde-frameworks/solid/solid-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -44,5 +44,4 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "media player devices support" app-misc/media-player-info
 	fi
-	ecm_pkg_postinst
 }

--- a/kde-plasma/drkonqi/drkonqi-6.2.91.ebuild
+++ b/kde-plasma/drkonqi/drkonqi-6.2.91.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,11 +58,6 @@ RDEPEND="${COMMON_DEPEND}
 		llvm-core/lldb
 	)
 "
-
-pkg_setup() {
-	ecm_pkg_setup
-	python-single-r1_pkg_setup
-}
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/drkonqi/drkonqi-6.3.49.9999.ebuild
+++ b/kde-plasma/drkonqi/drkonqi-6.3.49.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,11 +58,6 @@ RDEPEND="${COMMON_DEPEND}
 		llvm-core/lldb
 	)
 "
-
-pkg_setup() {
-	ecm_pkg_setup
-	python-single-r1_pkg_setup
-}
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/drkonqi/drkonqi-9999.ebuild
+++ b/kde-plasma/drkonqi/drkonqi-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,11 +58,6 @@ RDEPEND="${COMMON_DEPEND}
 		llvm-core/lldb
 	)
 "
-
-pkg_setup() {
-	ecm_pkg_setup
-	python-single-r1_pkg_setup
-}
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Continuation from https://github.com/gentoo/kde/pull/1016

Cases that I looked were ones where KFMIN was more than 6.9 (drkonqi) and where KFMIN was unset (the rest).