### PR TITLE
kde-plasma/plasma-meta: depend on plasma-desktop[input_devices_wacom] for wacom USE

### DIFF
--- a/kde-plasma/plasma-meta/plasma-meta-6.3.49.9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-6.3.49.9999.ebuild
@@ -117,7 +117,10 @@ RDEPEND="
 	!unsupported? (
 		!gui-apps/qt6ct
 	)
-	wacom? ( >=kde-plasma/wacomtablet-${PV}:${SLOT} )
+	wacom? (
+		>=kde-plasma/plasma-desktop-${PV}:${SLOT}[input_devices_wacom]
+		>=kde-plasma/wacomtablet-${PV}:${SLOT}
+	)
 	wallpapers? ( >=kde-plasma/plasma-workspace-wallpapers-${PV}:${SLOT} )
 	webengine? ( kde-apps/khelpcenter:6 )
 	xwayland? ( >=gui-apps/xwaylandvideobridge-0.4.0 )

--- a/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
+++ b/kde-plasma/plasma-meta/plasma-meta-9999.ebuild
@@ -117,7 +117,10 @@ RDEPEND="
 	!unsupported? (
 		!gui-apps/qt6ct
 	)
-	wacom? ( >=kde-plasma/wacomtablet-${PV}:${SLOT} )
+	wacom? (
+		>=kde-plasma/plasma-desktop-${PV}:${SLOT}[input_devices_wacom]
+		>=kde-plasma/wacomtablet-${PV}:${SLOT}
+	)
 	wallpapers? ( >=kde-plasma/plasma-workspace-wallpapers-${PV}:${SLOT} )
 	webengine? ( kde-apps/khelpcenter:6 )
 	xwayland? ( >=gui-apps/xwaylandvideobridge-0.4.0 )


### PR DESCRIPTION
This USE flag is required to install the Drawing Tablet KCM, which is very useful for someone with a drawing tablet.