### PR TITLE
kde-apps/ark: 7zip[symlink] as an alternative 

### DIFF
--- a/kde-apps/ark/ark-25.04.49.9999.ebuild
+++ b/kde-apps/ark/ark-25.04.49.9999.ebuild
@@ -72,7 +72,7 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "rar archive creation/extraction" "app-arch/rar"
 		optfeature "rar archive extraction only" "app-arch/unar" "app-arch/unrar"
-		optfeature "7-Zip archive support" "app-arch/p7zip"
+		optfeature "7-Zip archive support" ">=app-arch/7zip-24.09[symlink(+)]" "app-arch/p7zip"
 		optfeature "lrz archive support" "app-arch/lrzip"
 		optfeature "Markdown support in text previews" "kde-misc/markdownpart:${SLOT}"
 	fi

--- a/kde-apps/ark/ark-9999.ebuild
+++ b/kde-apps/ark/ark-9999.ebuild
@@ -72,7 +72,7 @@ pkg_postinst() {
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		optfeature "rar archive creation/extraction" "app-arch/rar"
 		optfeature "rar archive extraction only" "app-arch/unar" "app-arch/unrar"
-		optfeature "7-Zip archive support" "app-arch/p7zip"
+		optfeature "7-Zip archive support" ">=app-arch/7zip-24.09[symlink(+)]" "app-arch/p7zip"
 		optfeature "lrz archive support" "app-arch/lrzip"
 		optfeature "Markdown support in text previews" "kde-misc/markdownpart:${SLOT}"
 	fi

--- a/kde-apps/kdeutils-meta/kdeutils-meta-25.04.49.9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-25.04.49.9999.ebuild
@@ -43,7 +43,10 @@ RDEPEND="
 "
 # Optional runtime deps: kde-apps/ark
 RDEPEND="${RDEPEND}
-	7zip? ( app-arch/p7zip )
+	7zip? ( || (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	) )
 	lrz? ( app-arch/lrzip )
 	rar? ( || (
 		app-arch/rar

--- a/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-9999.ebuild
@@ -43,7 +43,10 @@ RDEPEND="
 "
 # Optional runtime deps: kde-apps/ark
 RDEPEND="${RDEPEND}
-	7zip? ( app-arch/p7zip )
+	7zip? ( || (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	) )
 	lrz? ( app-arch/lrzip )
 	rar? ( || (
 		app-arch/rar

--- a/kde-apps/kdeutils-meta/metadata.xml
+++ b/kde-apps/kdeutils-meta/metadata.xml
@@ -9,7 +9,7 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
 	<use>
-		<flag name="7zip">Install <pkg>app-arch/p7zip</pkg> for 7zip archive support in <pkg>kde-apps/ark</pkg></flag>
+		<flag name="7zip">Install <pkg>app-arch/p7zip</pkg> or <pkg>app-arch/7zip</pkg>[symlink] for 7zip archive support in <pkg>kde-apps/ark</pkg></flag>
 		<flag name="gpg">Install <pkg>kde-apps/kgpg</pkg> which depends on <pkg>kde-apps/akonadi</pkg></flag>
 		<flag name="lrz">Install <pkg>app-arch/lrzip</pkg> for LRZ archive support in <pkg>kde-apps/ark</pkg></flag>
 		<flag name="rar">Install one of <pkg>app-arch/rar</pkg>, <pkg>app-arch/unrar</pkg> or <pkg>app-arch/unar</pkg> for RAR archive support in <pkg>kde-apps/ark</pkg></flag>


### PR DESCRIPTION
In the future its planned to use libarchive for 7z archives. In my tests ark (ark 24.12.3) worked correctly (opening and creating 7z archive with or without passwords) when I had 7zip[symlink] installed and p7zip in package.provided.

https://invent.kde.org/utilities/ark/-/merge_requests/238
https://bugs.kde.org/show_bug.cgi?id=458334
https://bugs.kde.org/show_bug.cgi?id=468240