### PR TITLE
net-im/tokodon: set KFMIN=6.11.0

### DIFF
--- a/net-im/tokodon/tokodon-25.04.49.9999.ebuild
+++ b/net-im/tokodon/tokodon-25.04.49.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_TEST="forceoptional"
-KFMIN=6.9.0
+KFMIN=6.11.0
 QTMIN=6.7.2
 inherit ecm gear.kde.org xdg
 


### PR DESCRIPTION
Tokodon 25.04 fails to configure if an older version of frameworks is
installed.