### PR TITLE
media-gfx/qrca: add IUSE=networkmanager

### DIFF
--- a/media-gfx/qrca/qrca-25.04.49.9999.ebuild
+++ b/media-gfx/qrca/qrca-25.04.49.9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/qrca/"
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="networkmanager"
 
 DOCS=( README.md )
 
@@ -35,7 +35,14 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-frameworks/networkmanager-qt-${KFMIN}:6
 	>=kde-frameworks/prison-${KFMIN}:6
+	networkmanager? ( >=kde-frameworks/networkmanager-qt-${KFMIN}:6 )
 "
 RDEPEND="${DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake_use_find_package networkmanager KF6NetworkManagerQt)
+	)
+	ecm_src_configure
+}

--- a/media-gfx/qrca/qrca-9999.ebuild
+++ b/media-gfx/qrca/qrca-9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/qrca/"
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="networkmanager"
 
 DOCS=( README.md )
 
@@ -35,7 +35,14 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/kxmlgui-${KFMIN}:6
-	>=kde-frameworks/networkmanager-qt-${KFMIN}:6
 	>=kde-frameworks/prison-${KFMIN}:6
+	networkmanager? ( >=kde-frameworks/networkmanager-qt-${KFMIN}:6 )
 "
 RDEPEND="${DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake_use_find_package networkmanager KF6NetworkManagerQt)
+	)
+	ecm_src_configure
+}


### PR DESCRIPTION
Make networkmanager optional. This disables the wifi configuration features.

Moved from https://github.com/gentoo/gentoo/pull/41737