### PR TITLE
kde-frameworks/kwallet split to kde-frameworks/kwallet-runtime

### DIFF
--- a/kde-frameworks/kwallet-runtime/files/kwallet-runtime-6.14.0-stdalone.patch
+++ b/kde-frameworks/kwallet-runtime/files/kwallet-runtime-6.14.0-stdalone.patch
@@ -1,0 +1,189 @@
+From 8e59e6a833dc8cec95d25fe7a1c00ba52b045060 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 30 Apr 2025 18:12:08 +0200
+Subject: [PATCH 1/2] In src/runtime, try to find system KF6Wallet if target
+ not yet exists
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ src/runtime/CMakeLists.txt                    | 4 ++++
+ src/runtime/ksecretd/CMakeLists.txt           | 2 +-
+ src/runtime/ksecretd/autotests/CMakeLists.txt | 2 +-
+ src/runtime/kwallet-query/src/CMakeLists.txt  | 2 +-
+ src/runtime/kwalletbackend/CMakeLists.txt     | 3 +--
+ 5 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
+index b38948d1..4e833b3f 100644
+--- a/src/runtime/CMakeLists.txt
++++ b/src/runtime/CMakeLists.txt
+@@ -1,3 +1,7 @@
++if(NOT TARGET KF6::Wallet)
++    find_package(KF6Wallet ${KF_DEP_VERSION} REQUIRED)
++endif()
++
+ if(BUILD_KSECRETD OR BUILD_KWALLETD)
+     find_package(Gpgmepp 1.7.0) # provided by GpgME
+ 
+diff --git a/src/runtime/ksecretd/CMakeLists.txt b/src/runtime/ksecretd/CMakeLists.txt
+index 016ee52c..439254f1 100644
+--- a/src/runtime/ksecretd/CMakeLists.txt
++++ b/src/runtime/ksecretd/CMakeLists.txt
+@@ -128,7 +128,7 @@ endif ()
+ 
+ target_link_libraries(ksecretd
+     KF6WalletBackend
+-    KF6Wallet
++    KF6::Wallet
+     Qt6::Widgets
+     KF6::I18n
+     KF6::ColorScheme
+diff --git a/src/runtime/ksecretd/autotests/CMakeLists.txt b/src/runtime/ksecretd/autotests/CMakeLists.txt
+index 2499edc6..728a34bf 100644
+--- a/src/runtime/ksecretd/autotests/CMakeLists.txt
++++ b/src/runtime/ksecretd/autotests/CMakeLists.txt
+@@ -66,7 +66,7 @@ ecm_add_test(
+     kwalletfreedesktoppromptadaptor.cpp
+     TEST_NAME fdo_secrets_test
+     LINK_LIBRARIES
+-        KF6Wallet
++        KF6::Wallet
+         KF6WalletBackend
+         Qt6::Widgets
+         Qt6::Test
+diff --git a/src/runtime/kwallet-query/src/CMakeLists.txt b/src/runtime/kwallet-query/src/CMakeLists.txt
+index b809048f..dc785494 100644
+--- a/src/runtime/kwallet-query/src/CMakeLists.txt
++++ b/src/runtime/kwallet-query/src/CMakeLists.txt
+@@ -9,7 +9,7 @@ target_sources(kwallet-query PRIVATE
+ 
+ 
+ TARGET_LINK_LIBRARIES(kwallet-query
+-    KF6Wallet
++    KF6::Wallet
+     KF6::CoreAddons
+     KF6::I18n
+     Qt6::Widgets
+diff --git a/src/runtime/kwalletbackend/CMakeLists.txt b/src/runtime/kwalletbackend/CMakeLists.txt
+index b7849dc7..e883b77a 100644
+--- a/src/runtime/kwalletbackend/CMakeLists.txt
++++ b/src/runtime/kwalletbackend/CMakeLists.txt
+@@ -36,8 +36,6 @@ set_target_properties(KF6WalletBackend PROPERTIES
+     SOVERSION ${KWALLETBACKEND_SOVERSION}
+ )
+ 
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../api/KWallet)
+-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../../api/KWallet)
+ include_directories(${LIBGCRYPT_INCLUDE_DIRS})
+ 
+ remove_definitions(-DQT_NO_CAST_FROM_ASCII)
+@@ -71,6 +69,7 @@ target_link_libraries(KF6WalletBackend
+     KF6::CoreAddons
+     KF6::Notifications
+     KF6::I18n
++    KF6::Wallet
+     ${LIBGCRYPT_LIBRARIES}
+     ${Qca_LIBRARY}
+ )
+-- 
+2.49.0
+
+
+From ff4bbd29e92570836f0a2dab2ef7e714b5cfa42a Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 30 Apr 2025 18:02:08 +0200
+Subject: [PATCH 2/2] Split runtime logging categories into separate file
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ src/CMakeLists.txt                        | 6 ------
+ src/api/CMakeLists.txt                    | 6 ++++++
+ src/runtime/CMakeLists.txt                | 6 ++++++
+ src/runtime/ksecretd/CMakeLists.txt       | 2 +-
+ src/runtime/kwalletbackend/CMakeLists.txt | 2 +-
+ src/runtime/kwalletd/CMakeLists.txt       | 2 +-
+ 6 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4ec4ca79..3c0163d7 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,9 +1,3 @@
+ 
+ add_subdirectory(api)
+ add_subdirectory(runtime)
+-
+-ecm_qt_install_logging_categories(
+-    EXPORT KWALLET
+-    FILE kwallet.categories
+-    DESTINATION ${KDE_INSTALL_LOGGINGCATEGORIESDIR}
+-)
+diff --git a/src/api/CMakeLists.txt b/src/api/CMakeLists.txt
+index ef921ee4..b4810d80 100644
+--- a/src/api/CMakeLists.txt
++++ b/src/api/CMakeLists.txt
+@@ -1,2 +1,8 @@
+ 
+ add_subdirectory(KWallet)
++
++ecm_qt_install_logging_categories(
++    EXPORT KWALLET
++    FILE kwallet.categories
++    DESTINATION ${KDE_INSTALL_LOGGINGCATEGORIESDIR}
++)
+diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
+index 4e833b3f..3705c45d 100644
+--- a/src/runtime/CMakeLists.txt
++++ b/src/runtime/CMakeLists.txt
+@@ -25,3 +25,9 @@ endif()
+ if(BUILD_KWALLET_QUERY)
+   add_subdirectory(kwallet-query)
+ endif()
++
++ecm_qt_install_logging_categories(
++    EXPORT KWALLET_RUNTIME
++    FILE kwallet-runtime.categories
++    DESTINATION ${KDE_INSTALL_LOGGINGCATEGORIESDIR}
++)
+diff --git a/src/runtime/ksecretd/CMakeLists.txt b/src/runtime/ksecretd/CMakeLists.txt
+index 439254f1..75ccd198 100644
+--- a/src/runtime/ksecretd/CMakeLists.txt
++++ b/src/runtime/ksecretd/CMakeLists.txt
+@@ -66,7 +66,7 @@ ecm_qt_declare_logging_category(ksecretd
+     CATEGORY_NAME kf.wallet.ksecretd
+     OLD_CATEGORY_NAMES kf5.kwallet.ksecretd
+     DESCRIPTION "ksecretd"
+-    EXPORT KWALLET
++    EXPORT KWALLET_RUNTIME
+ )
+ 
+ ki18n_wrap_ui(ksecretd
+diff --git a/src/runtime/kwalletbackend/CMakeLists.txt b/src/runtime/kwalletbackend/CMakeLists.txt
+index e883b77a..95ea54c1 100644
+--- a/src/runtime/kwalletbackend/CMakeLists.txt
++++ b/src/runtime/kwalletbackend/CMakeLists.txt
+@@ -55,7 +55,7 @@ ecm_qt_declare_logging_category(KF6WalletBackend
+     CATEGORY_NAME kf.wallet.backend
+     OLD_CATEGORY_NAMES kf5.kwallet.kwalletbackend
+     DESCRIPTION "kwalletbackend"
+-    EXPORT KWALLET
++    EXPORT KWALLET_RUNTIME
+ )
+ 
+ 
+diff --git a/src/runtime/kwalletd/CMakeLists.txt b/src/runtime/kwalletd/CMakeLists.txt
+index 627fb69c..4a5f6135 100644
+--- a/src/runtime/kwalletd/CMakeLists.txt
++++ b/src/runtime/kwalletd/CMakeLists.txt
+@@ -54,7 +54,7 @@ ecm_qt_declare_logging_category(kwalletd6
+     IDENTIFIER KWALLETD_LOG
+     CATEGORY_NAME kf.wallet.kwalletd
+     DESCRIPTION "kwalletd"
+-    EXPORT KWALLET
++    EXPORT KWALLET_RUNTIME
+ )
+ 
+ target_link_libraries(kwalletd6
+-- 
+2.49.0
+

--- a/kde-frameworks/kwallet-runtime/kwallet-runtime-9999.ebuild
+++ b/kde-frameworks/kwallet-runtime/kwallet-runtime-9999.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+KDE_ORG_NAME="kwallet"
+QTMIN=6.7.2
+inherit ecm frameworks.kde.org optfeature
+
+DESCRIPTION="Framework providing desktop-wide storage for passwords"
+
+LICENSE="LGPL-2+"
+KEYWORDS=""
+IUSE="gpg +man +keyring +legacy-kwallet X"
+
+DEPEND="
+	>=app-crypt/qca-2.3.9:2[qt6(+)]
+	dev-libs/libgcrypt:0=
+	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
+	=kde-frameworks/kconfig-${KDE_CATV}*:6
+	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
+	=kde-frameworks/kcrash-${KDE_CATV}*:6
+	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
+	=kde-frameworks/ki18n-${KDE_CATV}*:6
+	=kde-frameworks/knotifications-${KDE_CATV}*:6
+	=kde-frameworks/kservice-${KDE_CATV}*:6
+	=kde-frameworks/kwallet-${KDE_CATV}*:6
+	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
+	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
+	gpg? ( app-crypt/gpgme:=[qt6(-)] )
+	legacy-kwallet? ( app-crypt/libsecret )
+"
+RDEPEND="${DEPEND}
+	!<kde-frameworks/kwallet-5.116.0-r2:5[-kf6compat(-)]
+	!<kde-frameworks/kwallet-6.14.0:6
+"
+BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
+
+PATCHES=( "${FILESDIR}/${PN}-6.14.0-stdalone.patch" )
+
+src_prepare() {
+	ecm_src_prepare
+	cmake_run_in src cmake_comment_add_subdirectory api
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_KWALLET_QUERY=ON # could be split easily together w/ docs
+		$(cmake_use_find_package gpg Gpgmepp)
+		-DBUILD_KSECRETD=$(usex keyring)
+		-DBUILD_KWALLETD=$(usex legacy-kwallet)
+		$(cmake_use_find_package man KF6DocTools)
+		-DWITH_X11=$(usex X)
+	)
+
+	ecm_src_configure
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		optfeature "Auto-unlocking after Plasma login" "kde-plasma/kwallet-pam"
+		optfeature "KWallet management" "kde-apps/kwalletmanager"
+		elog "For more information, read https://wiki.gentoo.org/wiki/KDE#KWallet"
+	fi
+}

--- a/kde-frameworks/kwallet-runtime/metadata.xml
+++ b/kde-frameworks/kwallet-runtime/metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<upstream>
+		<bugs-to>https://bugs.kde.org/enter_bug.cgi?product=frameworks-kwallet</bugs-to>
+		<remote-id type="kde-invent">frameworks/kwallet</remote-id>
+	</upstream>
+	<use>
+		<flag name="gpg">Support wallets with GnuPG encryption in addition to the default blowfish-encrypted file</flag>
+		<flag name="legacy-kwallet">Support KWallet D-Bus API for applications still using it</flag>
+	</use>
+	<slots>
+		<subslots>
+			Must only be used by packages that are known to use private parts of the Frameworks API.
+		</subslots>
+	</slots>
+</pkgmetadata>

--- a/kde-frameworks/kwallet/files/kwallet-6.14.0-deps.patch
+++ b/kde-frameworks/kwallet/files/kwallet-6.14.0-deps.patch
@@ -1,0 +1,75 @@
+https://invent.kde.org/frameworks/kwallet/-/merge_requests/112
+
+From 0993bb19ae8d8f99f6b646ef99b2a8a40149efcc Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 30 Apr 2025 17:11:55 +0200
+Subject: [PATCH] Depend on what/when we use it
+
+If KWallet library can be built w/o the runtimes, then let's define
+the deps like that as well.
+
+Only runtime has translations.
+
+Only kwallet-query has docs.
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ CMakeLists.txt | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 199685e4..8b2f91d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@ include(KDEGitCommitHooks)
+ include(ECMDeprecationSettings)
+ 
+ set(REQUIRED_QT_VERSION 6.7.0)
+-find_package(Qt6 ${REQUIRED_QT_VERSION} CONFIG REQUIRED Widgets DBus)
++find_package(Qt6 ${REQUIRED_QT_VERSION} CONFIG REQUIRED Core DBus Gui Widgets)
+ 
+ include(ECMAddQch)
+ include(ECMGenerateExportHeader)
+@@ -47,11 +47,11 @@ endif()
+ # Therefore we must not exclude those by default
+ set(EXCLUDE_DEPRECATED_BEFORE_AND_AT 0 CACHE STRING "Control the range of deprecated API excluded from the build [default=0].")
+ 
+-find_package(KF6CoreAddons ${KF_DEP_VERSION} REQUIRED)
+ find_package(KF6Config ${KF_DEP_VERSION} REQUIRED)
+-find_package(KF6WindowSystem ${KF_DEP_VERSION} REQUIRED)
+-find_package(KF6I18n ${KF_DEP_VERSION} REQUIRED)
+-find_package(KF6DocTools ${KF_DEP_VERSION})
++
++if(BUILD_KSECRETD OR BUILD_KWALLETD)
++    find_package(KF6 ${KF_DEP_VERSION} REQUIRED COMPONENTS CoreAddons I18n WindowSystem)
++endif()
+ 
+ ecm_set_disabled_deprecation_versions(
+     QT 6.9.0
+@@ -65,15 +65,20 @@ else()
+ endif()
+ 
+ add_definitions(-DTRANSLATION_DOMAIN=\"ksecretd6\")
+-ki18n_install(po)
++if(BUILD_KSECRETD OR BUILD_KWALLETD OR BUILD_KWALLET_QUERY)
++    ki18n_install(po)
++endif()
+ add_subdirectory(src)
+ if (BUILD_TESTING)
+     add_subdirectory(autotests)
+     add_subdirectory(tests)
+     add_subdirectory(examples)
+ endif()
+-if (KF6DocTools_FOUND)
+-    add_subdirectory(docs)
++if(BUILD_KWALLET_QUERY)
++    find_package(KF6DocTools ${KF_DEP_VERSION})
++    if(KF6DocTools_FOUND)
++        add_subdirectory(docs)
++    endif()
+ endif()
+ 
+ include(ECMFeatureSummary)
+-- 
+2.49.0
+

--- a/kde-frameworks/kwallet/kwallet-9999.ebuild
+++ b/kde-frameworks/kwallet/kwallet-9999.ebuild
@@ -3,50 +3,30 @@
 
 EAPI=8
 
+ECM_QTHELP="true"
 QTMIN=6.7.2
-inherit ecm frameworks.kde.org optfeature
+inherit ecm frameworks.kde.org
 
-DESCRIPTION="Framework providing desktop-wide storage for passwords"
+DESCRIPTION="Interface to KWallet Framework providing desktop-wide storage for passwords"
 
 LICENSE="LGPL-2+"
 KEYWORDS=""
-IUSE="gpg +man X"
+IUSE="minimal"
 
 DEPEND="
-	>=app-crypt/qca-2.3.9:2[qt6(+)]
-	dev-libs/libgcrypt:0=
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
-	=kde-frameworks/kcolorscheme-${KDE_CATV}*:6
 	=kde-frameworks/kconfig-${KDE_CATV}*:6
-	=kde-frameworks/kcoreaddons-${KDE_CATV}*:6
-	=kde-frameworks/kcrash-${KDE_CATV}*:6
-	=kde-frameworks/kdbusaddons-${KDE_CATV}*:6
-	=kde-frameworks/ki18n-${KDE_CATV}*:6
-	=kde-frameworks/knotifications-${KDE_CATV}*:6
-	=kde-frameworks/kservice-${KDE_CATV}*:6
-	=kde-frameworks/kwidgetsaddons-${KDE_CATV}*:6
-	=kde-frameworks/kwindowsystem-${KDE_CATV}*:6[X?]
-	gpg? ( app-crypt/gpgme:=[qt6(-)] )
 "
-RDEPEND="${DEPEND}
-	!<kde-frameworks/kwallet-5.116.0-r2:5[-kf6compat(-)]
-"
-BDEPEND="man? ( >=kde-frameworks/kdoctools-${KDE_CATV}:6 )"
+RDEPEND="${DEPEND}"
+PDEPEND="!minimal? ( =kde-frameworks/kwallet-runtime-${KDE_CATV}* )"
+
+PATCHES=( "${FILESDIR}/${PN}-6.14.0-deps.patch" )
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package gpg Gpgmepp)
-		$(cmake_use_find_package man KF6DocTools)
-		-DWITH_X11=$(usex X)
+		-DBUILD_KSECRETD=OFF
+		-DBUILD_KWALLETD=OFF
+		-DBUILD_KWALLET_QUERY=OFF
 	)
-
 	ecm_src_configure
-}
-
-pkg_postinst() {
-	if [[ -z "${REPLACING_VERSIONS}" ]]; then
-		optfeature "Auto-unlocking after Plasma login" "kde-plasma/kwallet-pam"
-		optfeature "KWallet management" "kde-apps/kwalletmanager"
-		elog "For more information, read https://wiki.gentoo.org/wiki/KDE#KWallet"
-	fi
 }

--- a/kde-frameworks/kwallet/metadata.xml
+++ b/kde-frameworks/kwallet/metadata.xml
@@ -6,7 +6,8 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<upstream>
-		<bugs-to>https://bugs.kde.org/</bugs-to>
+		<bugs-to>https://bugs.kde.org/enter_bug.cgi?product=frameworks-kwallet</bugs-to>
+		<remote-id type="kde-invent">frameworks/kwallet</remote-id>
 	</upstream>
 	<use>
 		<flag name="gpg">Support wallets with GnuPG encryption in addition to the default blowfish-encrypted file</flag>

--- a/kde-frameworks/kwallet/metadata.xml
+++ b/kde-frameworks/kwallet/metadata.xml
@@ -9,9 +9,6 @@
 		<bugs-to>https://bugs.kde.org/enter_bug.cgi?product=frameworks-kwallet</bugs-to>
 		<remote-id type="kde-invent">frameworks/kwallet</remote-id>
 	</upstream>
-	<use>
-		<flag name="gpg">Support wallets with GnuPG encryption in addition to the default blowfish-encrypted file</flag>
-	</use>
 	<slots>
 		<subslots>
 			Must only be used by packages that are known to use private parts of the Frameworks API.


### PR DESCRIPTION
- 1/3 patches is pending upstream so far, the other two are not sure if upstreamable
- `kde-frameworks/kwallet-runtime[legacy-kwallet]` should be forced for the time being
- next step would be adding `kde-frameworks/kwallet-runtime[keyring]` to `virtual/secret-service`