### PR TITLE
kde-frameworks/extra-cmake-modules: include implicit include

### DIFF
--- a/kde-frameworks/extra-cmake-modules/extra-cmake-modules-9999.ebuild
+++ b/kde-frameworks/extra-cmake-modules/extra-cmake-modules-9999.ebuild
@@ -38,7 +38,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-5.49.0-no-fatal-warnings.patch"
 	"${FILESDIR}/${PN}-5.93.0-skip-ecm_add_test-early.patch"
-	"${FILESDIR}/${PN}-5.245.0-disable-qmlplugindump.patch"
+	"${FILESDIR}/${PN}-6.15.0-disable-qmlplugindump.patch"
 	"${FILESDIR}/${PN}-6.5.0-disable-appstreamtest.patch"
 	"${FILESDIR}/${PN}-6.5.0-disable-git-commit-hooks.patch"
 )

--- a/kde-frameworks/extra-cmake-modules/files/extra-cmake-modules-6.15.0-disable-qmlplugindump.patch
+++ b/kde-frameworks/extra-cmake-modules/files/extra-cmake-modules-6.15.0-disable-qmlplugindump.patch
@@ -1,0 +1,41 @@
+From 67ec9d9f6a8b97bee36ad4272354dec07be05d12 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Sun, 8 Dec 2019 15:01:33 +0100
+Subject: [PATCH] ECMFindQMLModule.cmake.in: Add ECM_DISABLE_QMLPLUGINDUMP to
+ avoid sandbox violations
+
+See also: https://phabricator.kde.org/D25812
+
+Backstory: https://bugzilla.gnome.org/show_bug.cgi?id=744135
+BUG: 387753
+--- a/modules/ECMFindQmlModule.cmake.in
++++ b/modules/ECMFindQmlModule.cmake.in
+@@ -9,6 +9,17 @@ include(FindPackageHandleStandardArgs)
+ include("${ECM_MODULE_DIR}/QtVersionOption.cmake")
+ include("${ECM_MODULE_DIR}/ECMQueryQt.cmake")
+ 
++option (ECM_DISABLE_QMLPLUGINDUMP "Do not use qmlplugindump which may segfault in some sandboxed environments" OFF)
++
++if(ECM_DISABLE_QMLPLUGINDUMP)
++    message(NOTICE "@GENMODULE@: qmlplugindump disabled - assuming dependency is available as >= @VERSION@.")
++    set(@GENMODULE@_FOUND TRUE)
++    set(@GENMODULE@_VERSION @VERSION@)
++    if (QT_MAJOR_VERSION EQUAL "6")
++        # implicit include
++        include(${ECM_MODULE_DIR}/ECMQmlModule.cmake)
++    endif()
++else()
+ if (QT_MAJOR_VERSION EQUAL "6")
+     include(${ECM_MODULE_DIR}/ECMQmlModule.cmake)
+     # Get the qmldir file
+@@ -68,6 +79,7 @@ if (NOT CMAKE_CROSSCOMPILING AND NOT MODULE_NOTFOUND AND NOT @GENMODULE@_FOUND A
+         set(@GENMODULE@_FOUND FALSE)
+     endif()
+ endif()
++endif()
+ 
+ set(@GENMODULE@_FOUND ${@GENMODULE@_FOUND} PARENT_SCOPE)
+ set(@GENMODULE@_VERSION ${@GENMODULE@_VERSION} PARENT_SCOPE)
+-- 
+2.49.0
+


### PR DESCRIPTION
kinfocenter notably relies on this implicit include that this patch would otherwise remove.

Depending on the release order, this may have to be backported so that kinfocenter's next release works.
