### PR TITLE
kde-plasma/powerdevil: missing dependency kcmutils

### DIFF
--- a/kde-plasma/powerdevil/powerdevil-6.4.49.9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-6.4.49.9999.ebuild
@@ -25,6 +25,7 @@ COMMON_DEPEND="
 	dev-libs/wayland
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
 	>=kde-frameworks/kauth-${KFMIN}:6[policykit]
+	>=kde-frameworks/kcmutils-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
 	>=kde-frameworks/kconfigwidgets-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6

--- a/kde-plasma/powerdevil/powerdevil-9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-9999.ebuild
@@ -25,6 +25,7 @@ COMMON_DEPEND="
 	dev-libs/wayland
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
 	>=kde-frameworks/kauth-${KFMIN}:6[policykit]
+	>=kde-frameworks/kcmutils-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
 	>=kde-frameworks/kconfigwidgets-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6


### PR DESCRIPTION
Upstream commit: 096cf6fd5c7139c11e16c4f9bfc882963c5d17fb

According to qa-vdb it links against kcmutils, so its correct to also have it in RDEPEND/DEPEND in addition to BDEPEND.