### PR TITLE
kde-plasma/kscreen: new and missing dependencies. re-enable tests

### DIFF
--- a/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
@@ -27,6 +27,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kcmutils-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
+	>=kde-frameworks/kcrash-${KFMIN}:6
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6

--- a/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
@@ -16,9 +16,6 @@ SLOT="6"
 KEYWORDS=""
 IUSE="X"
 
-# bug #580440, last checked 5.6.3
-RESTRICT="test"
-
 # slot op: Uses Qt6GuiPrivate and Qt6WaylandClientPrivate
 COMMON_DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
@@ -58,6 +55,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 BDEPEND+=" || ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
+
+CMAKE_SKIP_TESTS=(
+	# last checked 2025-07-17, also fails upstream
+	# FAIL!  : TestConfig::testDisabledScreenConfig() Compared values are not the same
+	kscreen-kded-configtest
+)
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-6.4.49.9999.ebuild
@@ -19,8 +19,9 @@ IUSE="X"
 # bug #580440, last checked 5.6.3
 RESTRICT="test"
 
-DEPEND="
-	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+# slot op: Uses Qt6GuiPrivate and Qt6WaylandClientPrivate
+COMMON_DEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
 	>=dev-qt/qtsensors-${QTMIN}:6
 	>=kde-frameworks/kcmutils-${KFMIN}:6
@@ -41,11 +42,21 @@ DEPEND="
 		x11-libs/libXi
 	)
 "
-RDEPEND="${DEPEND}
+RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]
 	>=kde-plasma/kglobalacceld-${KDE_CATV}:6
 "
-BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
+RDEPEND+=" || ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
+DEPEND="${COMMON_DEPEND}
+	>=dev-libs/wayland-protocols-1.41
+"
+BDEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6[wayland]
+	dev-util/wayland-scanner
+	>=kde-frameworks/kcmutils-${KFMIN}:6
+	virtual/pkgconfig
+"
+BDEPEND+=" || ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/kscreen/kscreen-9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-9999.ebuild
@@ -27,6 +27,7 @@ COMMON_DEPEND="
 	>=kde-frameworks/kcmutils-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
 	>=kde-frameworks/kcoreaddons-${KFMIN}:6
+	>=kde-frameworks/kcrash-${KFMIN}:6
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/ksvg-${KFMIN}:6

--- a/kde-plasma/kscreen/kscreen-9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-9999.ebuild
@@ -19,8 +19,9 @@ IUSE="X"
 # bug #580440, last checked 5.6.3
 RESTRICT="test"
 
-DEPEND="
-	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,widgets]
+# slot op: Uses Qt6GuiPrivate and Qt6WaylandClientPrivate
+COMMON_DEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
 	>=dev-qt/qtdeclarative-${QTMIN}:6[widgets]
 	>=dev-qt/qtsensors-${QTMIN}:6
 	>=kde-frameworks/kcmutils-${KFMIN}:6
@@ -41,11 +42,21 @@ DEPEND="
 		x11-libs/libXi
 	)
 "
-RDEPEND="${DEPEND}
+RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]
 	>=kde-plasma/kglobalacceld-${KDE_CATV}:6
 "
-BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
+RDEPEND+=" || ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
+DEPEND="${COMMON_DEPEND}
+	>=dev-libs/wayland-protocols-1.41
+"
+BDEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6[wayland]
+	dev-util/wayland-scanner
+	>=kde-frameworks/kcmutils-${KFMIN}:6
+	virtual/pkgconfig
+"
+BDEPEND+="|| ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-plasma/kscreen/kscreen-9999.ebuild
+++ b/kde-plasma/kscreen/kscreen-9999.ebuild
@@ -16,9 +16,6 @@ SLOT="6"
 KEYWORDS=""
 IUSE="X"
 
-# bug #580440, last checked 5.6.3
-RESTRICT="test"
-
 # slot op: Uses Qt6GuiPrivate and Qt6WaylandClientPrivate
 COMMON_DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6=[dbus,gui,wayland,widgets]
@@ -58,6 +55,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 BDEPEND+="|| ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )"
+
+CMAKE_SKIP_TESTS=(
+	# last checked 2025-07-17, also fails upstream
+	# FAIL!  : TestConfig::testDisabledScreenConfig() Compared values are not the same
+	kscreen-kded-configtest
+)
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
https://invent.kde.org/plasma/kscreen/-/commit/7b8ba62fed07826014234f901e6d97e77f219e54
https://invent.kde.org/plasma/kscreen/-/commit/e90e26ebb8bd5bd59975f61c5b6b4ee2074a6c52

pkgconfig and the wayland scanner BDEPEND's come from the cmake modules that are used from qtwayland and wayland protocols.