### PR TITLE
kde-apps/mbox-importer: update dependencies

### DIFF
--- a/kde-apps/mbox-importer/mbox-importer-9999.ebuild
+++ b/kde-apps/mbox-importer/mbox-importer-9999.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	>=kde-frameworks/kcrash-${KFMIN}:6
 	>=kde-frameworks/kdbusaddons-${KFMIN}:6
 	>=kde-frameworks/ki18n-${KFMIN}:6
+	>=kde-frameworks/kiconthemes-${KFMIN}:6
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 "


### PR DESCRIPTION
Upstream commit: 79406a87f21eb87f39710f75aa39a63896232c23

Looked at kio as well, but that appears to be genuinely unused despite being in the CMakeLists.txt
https://invent.kde.org/pim/mbox-importer/-/commit/f91cc7c5ea77f7e0d7d1bae366190a6a3c012fc9