### PR TITLE
Make PlasmaActivities more optional [WIP]

### DIFF
--- a/kde-plasma/kwin/kwin-6.6.91.ebuild
+++ b/kde-plasma/kwin/kwin-6.6.91.ebuild
@@ -16,7 +16,8 @@ DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
 LICENSE="GPL-2+"
 SLOT="6"
 KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
-IUSE="accessibility gamepad gles2-only lock screencast selinux +shortcuts systemd X"
+IUSE="accessibility activities gamepad gles2-only lock screencast selinux
++shortcuts systemd X"
 
 RESTRICT="test"
 
@@ -54,7 +55,6 @@ COMMON_DEPEND="
 	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	>=kde-plasma/knighttime-${KDE_CATV}:6
 	>=kde-plasma/kwayland-${KDE_CATV}:6
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	media-libs/lcms:2
 	media-libs/libcanberra
 	>=media-libs/libdisplay-info-0.2.0:=
@@ -66,6 +66,7 @@ COMMON_DEPEND="
 	>=x11-libs/libxcvt-0.1.1
 	>=x11-libs/libxkbcommon-1.5.0
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	gamepad? ( dev-libs/libevdev )
 	lock? ( >=kde-plasma/kscreenlocker-${KDE_CATV}:6 )
 	screencast? ( >=media-video/pipewire-1.2.0:= )
@@ -154,6 +155,7 @@ src_configure() {
 		# KWIN_BUILD_DECORATIONS exists, drops aurorae, breeze
 		# KWIN_BUILD_NOTIFICATIONS exists, but kdeclarative still hard-depends on it
 		$(cmake_use_find_package accessibility QAccessibilityClient6)
+		$(cmake_use_find_package activities PlasmaActivities)
 		-DKWIN_BUILD_SCREENLOCKER=$(usex lock)
 		-DKWIN_BUILD_GLOBALSHORTCUTS=$(usex shortcuts)
 		-DKWIN_BUILD_X11=$(usex X)

--- a/kde-plasma/kwin/kwin-6.7.49.9999.ebuild
+++ b/kde-plasma/kwin/kwin-6.7.49.9999.ebuild
@@ -16,7 +16,8 @@ DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
 LICENSE="GPL-2+"
 SLOT="6"
 KEYWORDS=""
-IUSE="accessibility gamepad gles2-only lock screencast selinux +shortcuts systemd X"
+IUSE="accessibility activities gamepad gles2-only lock screencast selinux
++shortcuts systemd X"
 
 RESTRICT="test"
 
@@ -54,7 +55,6 @@ COMMON_DEPEND="
 	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	>=kde-plasma/knighttime-${KDE_CATV}:6
 	>=kde-plasma/kwayland-${KDE_CATV}:6
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	media-libs/lcms:2
 	media-libs/libcanberra
 	>=media-libs/libdisplay-info-0.2.0:=
@@ -66,6 +66,7 @@ COMMON_DEPEND="
 	>=x11-libs/libxcvt-0.1.1
 	>=x11-libs/libxkbcommon-1.5.0
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	gamepad? ( dev-libs/libevdev )
 	lock? ( >=kde-plasma/kscreenlocker-${KDE_CATV}:6 )
 	screencast? ( >=media-video/pipewire-1.2.0:= )
@@ -154,6 +155,7 @@ src_configure() {
 		# KWIN_BUILD_DECORATIONS exists, drops aurorae, breeze
 		# KWIN_BUILD_NOTIFICATIONS exists, but kdeclarative still hard-depends on it
 		$(cmake_use_find_package accessibility QAccessibilityClient6)
+		$(cmake_use_find_package activities PlasmaActivities)
 		-DKWIN_BUILD_SCREENLOCKER=$(usex lock)
 		-DKWIN_BUILD_GLOBALSHORTCUTS=$(usex shortcuts)
 		-DKWIN_BUILD_X11=$(usex X)

--- a/kde-plasma/kwin/kwin-9999.ebuild
+++ b/kde-plasma/kwin/kwin-9999.ebuild
@@ -16,7 +16,8 @@ DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
 LICENSE="GPL-2+"
 SLOT="6"
 KEYWORDS=""
-IUSE="accessibility gamepad gles2-only lock screencast selinux +shortcuts systemd X"
+IUSE="accessibility activities gamepad gles2-only lock screencast selinux
++shortcuts systemd X"
 
 RESTRICT="test"
 
@@ -54,7 +55,6 @@ COMMON_DEPEND="
 	>=kde-plasma/kdecoration-${KDE_CATV}:6
 	>=kde-plasma/knighttime-${KDE_CATV}:6
 	>=kde-plasma/kwayland-${KDE_CATV}:6
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	media-libs/lcms:2
 	media-libs/libcanberra
 	>=media-libs/libdisplay-info-0.2.0:=
@@ -66,6 +66,7 @@ COMMON_DEPEND="
 	>=x11-libs/libxcvt-0.1.1
 	>=x11-libs/libxkbcommon-1.5.0
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	gamepad? ( dev-libs/libevdev )
 	lock? ( >=kde-plasma/kscreenlocker-${KDE_CATV}:6 )
 	screencast? ( >=media-video/pipewire-1.2.0:= )
@@ -154,6 +155,7 @@ src_configure() {
 		# KWIN_BUILD_DECORATIONS exists, drops aurorae, breeze
 		# KWIN_BUILD_NOTIFICATIONS exists, but kdeclarative still hard-depends on it
 		$(cmake_use_find_package accessibility QAccessibilityClient6)
+		$(cmake_use_find_package activities PlasmaActivities)
 		-DKWIN_BUILD_SCREENLOCKER=$(usex lock)
 		-DKWIN_BUILD_GLOBALSHORTCUTS=$(usex shortcuts)
 		-DKWIN_BUILD_X11=$(usex X)

--- a/kde-plasma/kwin/metadata.xml
+++ b/kde-plasma/kwin/metadata.xml
@@ -10,6 +10,7 @@
 		<remote-id type="kde-invent">plasma/kwin</remote-id>
 	</upstream>
 	<use>
+		<flag name="activities">Enable support for KDE Activities</flag>
 		<flag name="gamepad">Support using game controllers as input devices</flag>
 		<flag name="lock">Enable screen locking via <pkg>kde-plasma/kscreenlocker</pkg></flag>
 		<flag name="screencast">Enable screencast portal using <pkg>media-video/pipewire</pkg></flag>

--- a/kde-plasma/powerdevil/files/powerdevil-6.6.91-activities-optional.patch
+++ b/kde-plasma/powerdevil/files/powerdevil-6.6.91-activities-optional.patch
@@ -1,0 +1,268 @@
+From 8f4dbf78567ff696cd8590bb9d067439488dfaa5 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 10 Sep 2025 22:41:32 +0200
+Subject: [PATCH] Make PlasmaActivities optional via ENABLE_ACTIVITIES cmake
+ option
+
+See also: https://invent.kde.org/plasma/plasma-workspace/-/issues/35
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+---
+ CMakeLists.txt                         |  7 ++++++-
+ autotests/migrateconfig/CMakeLists.txt |  2 ++
+ daemon/CMakeLists.txt                  | 13 +++++++++++--
+ daemon/config-powerdevil.h.cmake       |  1 +
+ daemon/powerdevilcore.cpp              | 13 ++++++++++---
+ daemon/powerdevilcore.h                |  8 ++++++--
+ daemon/powerdevilmigrateconfig.cpp     |  9 ++++++++-
+ 7 files changed, 44 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8c713345..4d34c4ff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,6 +27,8 @@ include(KDEGitCommitHooks)
+ include(ECMDeprecationSettings)
+ include(ECMQmlModule)
+ 
++option(ENABLE_ACTIVITIES "Enable support for Plasma Activities in daemon" ON)
++
+ find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Widgets DBus)
+ 
+ if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+@@ -53,10 +55,13 @@ find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
+     XmlGui
+ )
+ find_package(Plasma ${PROJECT_DEP_VERSION} REQUIRED)
+-find_package(PlasmaActivities ${PROJECT_DEP_VERSION} REQUIRED)
+ find_package(KF6Screen CONFIG REQUIRED)
+ find_package(LibKWorkspace ${PROJECT_DEP_VERSION} REQUIRED)
+ 
++if(ENABLE_ACTIVITIES)
++    find_package(PlasmaActivities ${PROJECT_DEP_VERSION} REQUIRED)
++endif()
++
+ find_package(UDev REQUIRED)
+ 
+ find_package(XCB REQUIRED COMPONENTS XCB RANDR DPMS)
+diff --git a/autotests/migrateconfig/CMakeLists.txt b/autotests/migrateconfig/CMakeLists.txt
+index 78b2ad66..322d792c 100644
+--- a/autotests/migrateconfig/CMakeLists.txt
++++ b/autotests/migrateconfig/CMakeLists.txt
+@@ -58,6 +58,7 @@ add_migrateconfig_test(
+     ASSERT_NO_POWERDEVILRC_AFTER_MIGRATION
+ )
+ 
++if(ENABLE_ACTIVITIES)
+ add_migrateconfig_test(
+     NAME migrateconfig_test2_activities
+     INPUT_POWERDEVILRC test2_initial_powerdevilrc
+@@ -73,6 +74,7 @@ add_migrateconfig_test(
+     EXPECTED_POWERDEVILRC test2_migrated_powerdevilrc
+     EXPECTED_PROFILESRC test2_migrated_powermanagementprofilesrc
+ )
++endif()
+ 
+ add_migrateconfig_test(
+     NAME migrateconfig_test3_profiles
+diff --git a/daemon/CMakeLists.txt b/daemon/CMakeLists.txt
+index b0dc9397..fbf4b88c 100644
+--- a/daemon/CMakeLists.txt
++++ b/daemon/CMakeLists.txt
+@@ -52,10 +52,16 @@ ecm_qt_declare_logging_category(powerdevil_log_static
+ kconfig_add_kcfg_files(powerdevilcore_SRCS
+     ${CMAKE_SOURCE_DIR}/PowerDevilGlobalSettings.kcfgc
+     ${CMAKE_SOURCE_DIR}/PowerDevilProfileSettings.kcfgc
+-    ${CMAKE_SOURCE_DIR}/PowerDevilActivitySettings.kcfgc
+     GENERATE_MOC
+ )
+ 
++if(ENABLE_ACTIVITIES)
++    kconfig_add_kcfg_files(powerdevilcore_SRCS
++        ${CMAKE_SOURCE_DIR}/PowerDevilActivitySettings.kcfgc
++        GENERATE_MOC
++    )
++endif()
++
+ # DBus Adaptors
+ 
+ set_source_files_properties(
+@@ -88,7 +94,6 @@ generate_export_header(powerdevilcore)
+ 
+ # not exported, so just make the deps public
+ target_link_libraries(powerdevilcore
+-    Plasma::Activities
+     Qt::DBus
+     PW::KWorkspace
+     KF6::CoreAddons
+@@ -111,6 +116,10 @@ target_link_libraries(powerdevilcore
+     Qt::WaylandClient
+ )
+ 
++if(ENABLE_ACTIVITIES)
++    target_link_libraries(powerdevilcore Plasma::Activities)
++endif()
++
+ if (XCB_FOUND) # kwin kscreen helper effect
+     target_link_libraries(powerdevilcore XCB::XCB Qt::GuiPrivate)
+ endif ()
+diff --git a/daemon/config-powerdevil.h.cmake b/daemon/config-powerdevil.h.cmake
+index 444a49cc..2be26ac9 100644
+--- a/daemon/config-powerdevil.h.cmake
++++ b/daemon/config-powerdevil.h.cmake
+@@ -1 +1,2 @@
+ #cmakedefine01 HAVE_XCB
++#cmakedefine01 ENABLE_ACTIVITIES
+diff --git a/daemon/powerdevilcore.cpp b/daemon/powerdevilcore.cpp
+index 98e9c55c..abe33424 100644
+--- a/daemon/powerdevilcore.cpp
++++ b/daemon/powerdevilcore.cpp
+@@ -13,7 +13,9 @@
+ #include "powerdevilpolicyagent.h"
+ #include "powerdevilpowermanagement.h"
+ 
++#if ENABLE_ACTIVITIES
+ #include <PowerDevilActivitySettings.h>
++#endif
+ #include <PowerDevilGlobalSettings.h>
+ #include <PowerDevilProfileSettings.h>
+ 
+@@ -30,9 +32,9 @@
+ #include <KNotification>
+ #include <KPluginFactory>
+ #include <KPluginMetaData>
+-
++#if ENABLE_ACTIVITIES
+ #include <PlasmaActivities/Consumer>
+-
++#endif
+ #include <QDBusConnection>
+ #include <QDBusConnectionInterface>
+ #include <QDBusServiceWatcher>
+@@ -56,7 +58,9 @@ Core::Core(QObject *parent)
+     : QObject(parent)
+     , m_hasDualGpu(false)
+     , m_criticalBatteryTimer(new QTimer(this))
++#if ENABLE_ACTIVITIES
+     , m_activityConsumer(new KActivities::Consumer(this))
++#endif
+     , m_pendingWakeupEvent(true)
+ {
+     KAuth::Action discreteGpuAction(QStringLiteral("org.kde.powerdevil.discretegpuhelper.hasdualgpu"));
+@@ -128,10 +132,11 @@ void Core::onControllersReady()
+     connect(m_suspendController.get(), &SuspendController::aboutToSuspend, this, &Core::onAboutToSuspend);
+     connect(KIdleTime::instance(), &KIdleTime::timeoutReached, this, &Core::onKIdleTimeoutReached);
+     connect(KIdleTime::instance(), &KIdleTime::resumingFromIdle, this, &Core::onResumingFromIdle);
++#if ENABLE_ACTIVITIES
+     connect(m_activityConsumer, &KActivities::Consumer::currentActivityChanged, this, [this]() {
+         loadProfile();
+     });
+-
++#endif
+     // Set up the policy agent
+     PowerDevil::PolicyAgent::instance()->init(m_globalSettings);
+     // When inhibitions change, simulate user activity, see Bug 315438
+@@ -379,6 +384,7 @@ void Core::loadProfile(bool force)
+         Q_EMIT profileChanged(m_currentProfile);
+     }
+ 
++#if ENABLE_ACTIVITIES
+     // Check the activity in which we are in
+     const QString activity = m_activityConsumer->currentActivity();
+     qCDebug(POWERDEVIL) << "Currently using activity" << activity;
+@@ -415,6 +421,7 @@ void Core::loadProfile(bool force)
+             }
+         }
+     }
++#endif
+ 
+     // If the lid is closed, retrigger the lid close signal
+     // so that "switching profile then closing the lid" has the same result as
+diff --git a/daemon/powerdevilcore.h b/daemon/powerdevilcore.h
+index af4c5010..5207e893 100644
+--- a/daemon/powerdevilcore.h
++++ b/daemon/powerdevilcore.h
+@@ -6,6 +6,8 @@
+ 
+ #pragma once
+ 
++#include <config-powerdevil.h>
++
+ #include <QPointer>
+ #include <QSet>
+ #include <QStringList>
+@@ -26,10 +28,12 @@
+ #include "controllers/suspendcontroller.h"
+ #include "powerdevilcore_export.h"
+ 
++#if ENABLE_ACTIVITIES
+ namespace KActivities
+ {
+ class Consumer;
+ } // namespace KActivities
++#endif
+ 
+ class QDBusServiceWatcher;
+ class QTimer;
+@@ -179,9 +183,9 @@ private:
+     QPointer<KNotification> m_criticalBatteryNotification;
+     QPointer<KNotification> m_powerCordPluggedInNotification;
+     QPointer<KNotification> m_powerCordUnpluggedNotification;
+-
++#if ENABLE_ACTIVITIES
+     KActivities::Consumer *const m_activityConsumer;
+-
++#endif
+     // Idle time management
+     QHash<Action *, QList<int>> m_registeredActionTimeouts;
+     QSet<Action *> m_pendingResumeFromIdleActions;
+diff --git a/daemon/powerdevilmigrateconfig.cpp b/daemon/powerdevilmigrateconfig.cpp
+index c2b599f6..7e7e38a2 100644
+--- a/daemon/powerdevilmigrateconfig.cpp
++++ b/daemon/powerdevilmigrateconfig.cpp
+@@ -4,11 +4,15 @@
+  *  SPDX-License-Identifier: GPL-2.0-or-later
+  */
+ 
++#include <config-powerdevil.h>
++
+ #include "powerdevilmigrateconfig.h"
+ 
+ #include "powerdevilenums.h"
+ 
++#if ENABLE_ACTIVITIES
+ #include <PowerDevilActivitySettings.h>
++#endif
+ #include <PowerDevilProfileSettings.h>
+ #include <powerdevil_version.h>
+ 
+@@ -37,6 +41,7 @@ struct IdentityTransformer {
+ namespace PowerDevil
+ {
+ 
++#if ENABLE_ACTIVITIES
+ void migrateActivitiesConfig(KSharedConfig::Ptr profilesConfig)
+ {
+     KConfigGroup migrationGroup = profilesConfig->group(QStringLiteral("Migration"));
+@@ -67,7 +72,7 @@ void migrateActivitiesConfig(KSharedConfig::Ptr profilesConfig)
+     migrationGroup.writeEntry("MigratedActivitiesToPlasma6", "powerdevilrc");
+     profilesConfig->sync();
+ }
+-
++#endif
+ void ensureLockScreenIdleTimeoutInKScreenLockerKCM(int seconds)
+ {
+     KSharedConfig::Ptr lockerConfig = KSharedConfig::openConfig(QStringLiteral("kscreenlockerrc"));
+@@ -244,7 +249,9 @@ void migrateConfig(bool isMobile, bool isVM, bool canSuspend)
+     KSharedConfig::Ptr profilesConfig = KSharedConfig::openConfig(QStringLiteral("powermanagementprofilesrc"));
+     // TODO KF7 (or perhaps earlier): Remove Plasma 5->6 migration code and delete powermanagementprofilesrc
+ 
++#if ENABLE_ACTIVITIES
+     migrateActivitiesConfig(profilesConfig);
++#endif
+     migrateProfilesConfig(profilesConfig, isMobile, isVM, canSuspend);
+ }
+ 
+-- 
+2.51.0
+

--- a/kde-plasma/powerdevil/metadata.xml
+++ b/kde-plasma/powerdevil/metadata.xml
@@ -10,6 +10,7 @@
 		<remote-id type="kde-invent">plasma/powerdevil</remote-id>
 	</upstream>
 	<use>
+		<flag name="activities">Enable support for KDE Activities</flag>
 		<flag name="brightness-control">Enable screen brightness control using <pkg>app-misc/ddcutil</pkg></flag>
 	</use>
 </pkgmetadata>

--- a/kde-plasma/powerdevil/powerdevil-6.6.91.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-6.6.91.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://invent.kde.org/plasma/powerdevil"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
-IUSE="brightness-control"
+IUSE="activities brightness-control"
 
 RESTRICT="test" # bug 926513
 
@@ -44,10 +44,10 @@ COMMON_DEPEND="
 	>=kde-frameworks/solid-${KFMIN}:6
 	>=kde-plasma/libkscreen-${KDE_CATV}:6
 	>=kde-plasma/libplasma-${KDE_CATV}:6=
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	virtual/libudev:=
 	x11-libs/libxcb
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	brightness-control? ( app-misc/ddcutil:= )
 "
 DEPEND="${COMMON_DEPEND}
@@ -73,8 +73,11 @@ BDEPEND="
 # -m 0755 to avoid suid with USE="-filecaps"
 FILECAPS=( -m 0755 cap_wake_alarm=ep usr/libexec/org_kde_powerdevil )
 
+PATCHES=( "${FILESDIR}/${P}-activities-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
+		-DENABLE_ACTIVITIES=$(usex activities)
 		$(cmake_use_find_package brightness-control DDCUtil)
 	)
 	use test && mycmakeargs+=(

--- a/kde-plasma/powerdevil/powerdevil-6.7.49.9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-6.7.49.9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://invent.kde.org/plasma/powerdevil"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS=""
-IUSE="brightness-control"
+IUSE="activities brightness-control"
 
 RESTRICT="test" # bug 926513
 
@@ -44,10 +44,10 @@ COMMON_DEPEND="
 	>=kde-frameworks/solid-${KFMIN}:6
 	>=kde-plasma/libkscreen-${KDE_CATV}:6
 	>=kde-plasma/libplasma-${KDE_CATV}:6=
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	virtual/libudev:=
 	x11-libs/libxcb
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	brightness-control? ( app-misc/ddcutil:= )
 "
 DEPEND="${COMMON_DEPEND}
@@ -73,8 +73,11 @@ BDEPEND="
 # -m 0755 to avoid suid with USE="-filecaps"
 FILECAPS=( -m 0755 cap_wake_alarm=ep usr/libexec/org_kde_powerdevil )
 
+PATCHES=( "${FILESDIR}/${PN}-6.6.91-activities-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
+		-DENABLE_ACTIVITIES=$(usex activities)
 		$(cmake_use_find_package brightness-control DDCUtil)
 	)
 	use test && mycmakeargs+=(

--- a/kde-plasma/powerdevil/powerdevil-9999.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://invent.kde.org/plasma/powerdevil"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="6"
 KEYWORDS=""
-IUSE="brightness-control"
+IUSE="activities brightness-control"
 
 RESTRICT="test" # bug 926513
 
@@ -44,10 +44,10 @@ COMMON_DEPEND="
 	>=kde-frameworks/solid-${KFMIN}:6
 	>=kde-plasma/libkscreen-${KDE_CATV}:6
 	>=kde-plasma/libplasma-${KDE_CATV}:6=
-	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
 	virtual/libudev:=
 	x11-libs/libxcb
+	activities? ( >=kde-plasma/plasma-activities-${KDE_CATV}:6= )
 	brightness-control? ( app-misc/ddcutil:= )
 "
 DEPEND="${COMMON_DEPEND}
@@ -73,8 +73,11 @@ BDEPEND="
 # -m 0755 to avoid suid with USE="-filecaps"
 FILECAPS=( -m 0755 cap_wake_alarm=ep usr/libexec/org_kde_powerdevil )
 
+PATCHES=( "${FILESDIR}/${PN}-6.6.91-activities-optional.patch" )
+
 src_configure() {
 	local mycmakeargs=(
+		-DENABLE_ACTIVITIES=$(usex activities)
 		$(cmake_use_find_package brightness-control DDCUtil)
 	)
 	use test && mycmakeargs+=(


### PR DESCRIPTION
- [x] kde-plasma/libplasma (see also: https://invent.kde.org/plasma/libplasma/-/merge_requests/1364)
- [x] kde-plasma/kwin and kde-plasma/kwin-x11
- [x] kde-plasma/powerdevil (needs small-ish patch)
- [ ] kde-plasma/plasma-browser-integration (needs patching)
- [ ] kde-plasma/plasma-desktop (huge): imports/activitymanager, desktoppackage/contents/activitymanager, kcms/activities; patching in many other places
- [ ] kde-plasma/plasma-workspace (huge): containmentactions/switchactivity; patching in many other places, however there is https://invent.kde.org/plasma/plasma-workspace/-/issues/35
- [x] kde-apps/okular ~~(see also: https://invent.kde.org/graphics/okular/-/merge_requests/1233)~~ dependency dropped upstream in https://invent.kde.org/graphics/okular/-/merge_requests/1234