### PR TITLE
dev-util/elf-dissector: new package, add 9999

### DIFF
--- a/dev-util/elf-dissector/elf-dissector-9999.ebuild
+++ b/dev-util/elf-dissector/elf-dissector-9999.ebuild
@@ -1,0 +1,38 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ECM_TEST=true
+KFMIN=6.9.0
+QTMIN=6.7
+inherit ecm kde.org xdg
+
+DESCRIPTION="Static analysis tool for ELF libraries and executables"
+HOMEPAGE="https://invent.kde.org/sdk/elf-dissector"
+
+LICENSE="BSD-2 GPL-2 LGPL-2+"
+SLOT="0"
+KEYWORDS=""
+
+IUSE="capstone"
+
+# libdwarf supports appears to have issues with >=2.0.0
+#dwarf? ( >=dev-libs/libdwarf-0.10:= )
+DEPEND="
+	>=dev-qt/qtbase-${QTMIN}:6[widgets]
+	sys-libs/binutils-libs:=
+	capstone? ( dev-libs/capstone:= )
+"
+RDEPEND="${DEPEND}
+	sci-visualization/gnuplot
+"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake_use_find_package capstone Capstone)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Dwarf=ON
+		#$(cmake_use_find_package dwarf Dwarf)
+	)
+	ecm_src_configure
+}

--- a/dev-util/elf-dissector/metadata.xml
+++ b/dev-util/elf-dissector/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="kde-invent">sdk/elf-dissector</remote-id>
+	</upstream>
+	<use>
+		<flag name="capstone">Enable disassembly support with <pkg>dev-libs/capstone</pkg></flag>
+	</use>
+</pkgmetadata>


### PR DESCRIPTION
@thesamesam I looked at my worktrees and noticed I had a very unfinished ebuild and apparently got confused at libiberty and stopped (its just a static library in binutils-libs that gets installed even with USE="-static-libs"). Decided to finish and it was quite straightforward :D

Edit: I think the test failures are maybe from libdwarf. Upstream tests against 0.11.1 while gentoo packages 2.1.0
Edit: Edit: its not libwarf, downgraded to 0.11.1 and the same test failures persist.