### PR TITLE
media-gfx/krita: don't build tests for libs/koplugin when not testing

### DIFF
--- a/media-gfx/krita/files/krita-5.3.0-tests-optional.patch
+++ b/media-gfx/krita/files/krita-5.3.0-tests-optional.patch
@@ -88,3 +88,29 @@ index 88c0516360..01f2383ddb 100644
  
  add_subdirectory(libs)
  add_subdirectory(plugins)
+From e0ba479d6e7a1a34ad9fc984605aef2872d653da Mon Sep 17 00:00:00 2001
+From: Lucio Sauer <watermanpaint@posteo.net>
+Date: Mon, 25 Aug 2025 13:20:34 +0200
+Subject: [PATCH] libs/koplugin: don't build tests when not testing
+
+Signed-off-by: Lucio Sauer <watermanpaint@posteo.net>
+---
+ libs/koplugin/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/libs/koplugin/CMakeLists.txt b/libs/koplugin/CMakeLists.txt
+index c3c6368..720ebe6 100644
+--- a/libs/koplugin/CMakeLists.txt
++++ b/libs/koplugin/CMakeLists.txt
+@@ -28,4 +28,6 @@ set_target_properties(kritaplugin PROPERTIES
+ )
+ install(TARGETS kritaplugin ${INSTALL_TARGETS_DEFAULT_ARGS} )
+ 
+-add_subdirectory(tests)
+\ No newline at end of file
++if (BUILD_TESTING)
++    add_subdirectory(tests)
++endif()
+-- 
+2.49.1
+


### PR DESCRIPTION
Building media-gfx/krita-9999 at commit `522e859ffb001ef37fcb292c3e65e7e713ba73ee` currently fails with:
```
>>> Source unpacked in /var/tmp/portage/media-gfx/krita-9999/work
>>> Preparing source in /var/tmp/portage/media-gfx/krita-9999/work/krita-9999 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/media-gfx/krita-9999/work/krita-9999"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/media-gfx/krita-9999/work/krita-9999_build"
 * Applying krita-5.3.0-tests-optional.patch ...
patching file cmake/modules/KritaAddBrokenUnitTest.cmake
Hunk #1 succeeded at 28 with fuzz 1 (offset 5 lines).
patching file cmake/modules/MacroKritaAddBenchmark.cmake
Hunk #1 succeeded at 25 with fuzz 2 (offset 2 lines).
patching file libs/flake/CMakeLists.txt
Hunk #1 succeeded at 11 with fuzz 2 (offset 2 lines).
patching file libs/image/tiles3/CMakeLists.txt
patching file CMakeLists.txt
Hunk #1 succeeded at 1483 with fuzz 1 (offset 237 lines [ ok ]
 * Applying krita-5.2.2-fftw.patch ...                  [ ok ]
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/media-gfx/krita-9999/work/krita-9999 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/media-gfx/krita-9999/work/krita-9999"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/media-gfx/krita-9999/work/krita-9999_build"
cmake -C /var/tmp/portage/media-gfx/krita-9999/work/krita-9999_build/gentoo_common_config.cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DQT_MAJOR_VERSION=6 -DBUILD_TESTING=OFF -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_INSTALL_DOCBUNDLEDIR=/usr/share/help -DKDE_INSTALL_LIBEXECDIR=/usr/libexec -DBUILD_WITH_QT6=ON -DENABLE_UPDATERS=OFF -DKRITA_ENABLE_PCH=OFF -DCMAKE_DISABLE_FIND_PACKAGE_KSeExpr=ON -DCMAKE_DISABLE_FIND_PACKAGE_OpenColorIO=ON -DCMAKE_DISABLE_FIND_PACKAGE_FFTW3=ON -DCMAKE_DISABLE_FIND_PACKAGE_GIF=ON -DCMAKE_DISABLE_FIND_PACKAGE_GSL=OFF -DCMAKE_DISABLE_FIND_PACKAGE_HEIF=ON -DCMAKE_DISABLE_FIND_PACKAGE_OpenJPEG=ON -DCMAKE_DISABLE_FIND_PACKAGE_JPEGXL=ON -DCMAKE_DISABLE_FIND_PACKAGE_Mlt7=ON -DCMAKE_DISABLE_FIND_PACKAGE_LibMyPaint=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenEXR=ON -DCMAKE_DISABLE_FIND_PACKAGE_Poppler=ON -DCMAKE_DISABLE_FIND_PACKAGE_KDcrawQt6=OFF -DCMAKE_DISABLE_FIND_PACKAGE_WebP=ON -DCMAKE_DISABLE_FIND_PACKAGE_xsimd=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=/var/tmp/portage/media-gfx/krita-9999/work/krita-9999_build/gentoo_toolchain.cmake /var/tmp/portage/media-gfx/krita-9999/work/krita-9999
[...]
-- Found FriBidi: /usr/include/fribidi (found suitable version "1.0.16", minimum required is "1.0.6")
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB - Success
-- Performing Test HAVE_CXX_ATOMICS64_WITHOUT_LIB
-- Performing Test HAVE_CXX_ATOMICS64_WITHOUT_LIB - Success
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Looking for backtrace
-- Looking for backtrace - found
CMake Error at libs/koplugin/tests/CMakeLists.txt:47 (target_compile_definitions):
  Cannot specify compile definitions for target "KoPluginLoaderTest" which is
  not built by this project.


CMake Error at libs/koplugin/tests/CMakeLists.txt:52 (add_dependencies):
  Cannot add target-level dependencies to non-existent target
  "KoPluginLoaderTest".

  The add_dependencies works for top-level logical targets created by the
  add_executable, add_library, or add_custom_target commands.  If you want to
  add file-level dependencies see the DEPENDS option of the add_custom_target
  and add_custom_command commands.
```