### PR TITLE
net-libs/libktorrent: allow to use gcrypt instead of openssl 3

### DIFF
--- a/net-libs/libktorrent/libktorrent-25.08.49.9999.ebuild
+++ b/net-libs/libktorrent/libktorrent-25.08.49.9999.ebuild
@@ -15,12 +15,11 @@ HOMEPAGE="https://apps.kde.org/ktorrent/ https://userbase.kde.org/KTorrent"
 LICENSE="GPL-2+"
 SLOT="6"
 KEYWORDS=""
-IUSE="xfs"
+IUSE="gcrypt xfs"
 
 COMMON_DEPEND="
 	>=app-crypt/qca-2.3.7:2[qt6(+)]
 	>=dev-libs/gmp-6.0.0a:0=
-	>=dev-libs/openssl-3:0=
 	>=dev-qt/qtbase-${QTMIN}:6[network,xml]
 	>=kde-frameworks/karchive-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
@@ -29,6 +28,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
+	!gcrypt? ( >=dev-libs/openssl-3:0= )
+	gcrypt? ( dev-libs/libgcrypt:0= )
 	xfs? ( sys-fs/xfsprogs )
 "
 DEPEND="${COMMON_DEPEND}
@@ -51,7 +52,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DUSE_CRYPTO_BACKEND=OpenSSL
+		-DUSE_CRYPTO_BACKEND=$(usex gcrypt LibGcrypt OpenSSL)
 		-DWITH_XFS=$(usex xfs)
 	)
 	ecm_src_configure

--- a/net-libs/libktorrent/libktorrent-9999.ebuild
+++ b/net-libs/libktorrent/libktorrent-9999.ebuild
@@ -15,12 +15,11 @@ HOMEPAGE="https://apps.kde.org/ktorrent/ https://userbase.kde.org/KTorrent"
 LICENSE="GPL-2+"
 SLOT="6"
 KEYWORDS=""
-IUSE="xfs"
+IUSE="gcrypt xfs"
 
 COMMON_DEPEND="
 	>=app-crypt/qca-2.3.7:2[qt6(+)]
 	>=dev-libs/gmp-6.0.0a:0=
-	>=dev-libs/openssl-3:0=
 	>=dev-qt/qtbase-${QTMIN}:6[network,xml]
 	>=kde-frameworks/karchive-${KFMIN}:6
 	>=kde-frameworks/kconfig-${KFMIN}:6
@@ -29,6 +28,8 @@ COMMON_DEPEND="
 	>=kde-frameworks/ki18n-${KFMIN}:6
 	>=kde-frameworks/kio-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
+	!gcrypt? ( >=dev-libs/openssl-3:0= )
+	gcrypt? ( dev-libs/libgcrypt:0= )
 	xfs? ( sys-fs/xfsprogs )
 "
 DEPEND="${COMMON_DEPEND}
@@ -51,7 +52,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DUSE_CRYPTO_BACKEND=OpenSSL
+		-DUSE_CRYPTO_BACKEND=$(usex gcrypt LibGcrypt OpenSSL)
 		-DWITH_XFS=$(usex xfs)
 	)
 	ecm_src_configure

--- a/net-libs/libktorrent/metadata.xml
+++ b/net-libs/libktorrent/metadata.xml
@@ -9,6 +9,7 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
 	<use>
+		<flag name="gcrypt">Use libgcrypt instead of openssl</flag>
 		<flag name="xfs">Enable XFS specific disk preallocation support via <pkg>sys-fs/xfsprogs</pkg></flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://github.com/gentoo/libressl/pull/601