### PR TITLE
kde-apps/audiocd-kio: patch redundant

### DIFF
--- a/kde-apps/audiocd-kio/audiocd-kio-25.08.49.9999.ebuild
+++ b/kde-apps/audiocd-kio/audiocd-kio-25.08.49.9999.ebuild
@@ -37,7 +37,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}-19.04.0-handbook.patch" )
+PATCHES=( "${FILESDIR}/${PN}-23.03.80-handbook.patch" )
 
 src_configure() {
 	local mycmakeargs=(

--- a/kde-apps/audiocd-kio/audiocd-kio-9999.ebuild
+++ b/kde-apps/audiocd-kio/audiocd-kio-9999.ebuild
@@ -37,8 +37,6 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}-19.04.0-handbook.patch" )
-
 src_configure() {
 	local mycmakeargs=(
 		$(cmake_use_find_package flac FLAC)

--- a/kde-apps/audiocd-kio/files/audiocd-kio-23.03.80-handbook.patch
+++ b/kde-apps/audiocd-kio/files/audiocd-kio-23.03.80-handbook.patch
@@ -1,7 +1,7 @@
 From 205f9336485b161bedb0f4fc4292247040166111 Mon Sep 17 00:00:00 2001
 From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
 Date: Sat, 20 Apr 2019 23:18:17 +0200
-Subject: [PATCH] Add kcmaudiocd doc subdir only if KF5DocTools_FOUND
+Subject: [PATCH] Add kcmaudiocd doc subdir only if KF6DocTools_FOUND
 
 ---
  kcmaudiocd/CMakeLists.txt | 4 +++-
@@ -16,7 +16,7 @@ index 2e0ce60..7b94b46 100644
  ########### add handbook ################
  
 -add_subdirectory(doc)
-+if(KF5DocTools_FOUND)
++if(KF6DocTools_FOUND)
 +    add_subdirectory(doc)
 +endif()
 -- 


### PR DESCRIPTION
Upstream commit: 7e6c8e08c919216b8d456a8c2fb0b4c9484f5d4c

The patch was broken either way as it wasn't updated for kf6.