### PR TITLE
kde-plasma/plasma-bigscreen: new dependencies

### DIFF
--- a/kde-plasma/plasma-bigscreen/plasma-bigscreen-9999.ebuild
+++ b/kde-plasma/plasma-bigscreen/plasma-bigscreen-9999.ebuild
@@ -15,8 +15,11 @@ SLOT="6"
 KEYWORDS=""
 IUSE=""
 
-DEPEND="
+# TODO: libcec automagic
+COMMON_DEPEND="
 	>=dev-libs/qcoro-0.7.0[qml]
+	>=dev-libs/libcec-6:=
+	dev-libs/wayland
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui,network]
 	>=dev-qt/qtdeclarative-${QTMIN}:6
 	>=dev-qt/qtmultimedia-${QTMIN}:6
@@ -42,8 +45,12 @@ DEPEND="
 	>=kde-plasma/plasma-activities-${KDE_CATV}:6=
 	>=kde-plasma/plasma-activities-stats-${KDE_CATV}:6
 	>=kde-plasma/plasma-workspace-${KDE_CATV}:6
+	media-libs/libsdl3
 "
-RDEPEND="${DEPEND}
+DEPEND="${COMMON_DEPEND}
+	dev-libs/plasma-wayland-protocols
+"
+RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qtsvg-${QTMIN}:6
 	>=dev-qt/qtvirtualkeyboard-${QTMIN}:6
 "


### PR DESCRIPTION
Upstream commit: fa335afa7169a49c8590550ec4faa48ee81ffe9a

Whilst libcec is intended as optional upstream, it cannot be made non automagic with usual cmake methods due to using pkg_check_modules.