### PR TITLE
net-p2p/ktorrent: metadata: use global USE=upnp description

### DIFF
--- a/net-p2p/ktorrent/metadata.xml
+++ b/net-p2p/ktorrent/metadata.xml
@@ -22,7 +22,6 @@
 		<flag name="scanfolder">Scan folders for torrent files and load them</flag>
 		<flag name="shutdown">Shutdown when done</flag>
 		<flag name="stats">Shows statistics about torrents in several graphs</flag>
-		<flag name="upnp">Forward ports using UPnP</flag>
 		<flag name="webengine">Embedded search for torrents using <pkg>dev-qt/qtwebengine</pkg></flag>
 		<flag name="zeroconf">Discover peers on the local network using the Zeroconf protocol</flag>
 	</use>


### PR DESCRIPTION
https://packages.gentoo.org/useflags/upnp

That will do just fine